### PR TITLE
Grid Item Generator: changed names

### DIFF
--- a/src/Enhavo/Bundle/GeneratorBundle/Command/GenerateGridItemCommand.php
+++ b/src/Enhavo/Bundle/GeneratorBundle/Command/GenerateGridItemCommand.php
@@ -12,7 +12,7 @@ class GenerateGridItemCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('enhavo:generate:grid:item')
+            ->setName('enhavo:generate:grid-item')
             ->setDescription('Generate templates for new grid item')
             ->addArgument(
                 'bundleName',

--- a/src/Enhavo/Bundle/GeneratorBundle/Generator/GridItemGenerator.php
+++ b/src/Enhavo/Bundle/GeneratorBundle/Generator/GridItemGenerator.php
@@ -68,7 +68,7 @@ class GridItemGenerator extends Generator
             array(
                 'bundle_namespace' => $bundle->getNamespace(),
                 'item_name' => $itemName,
-                'table_name' => 'grid_item_' . $bundleNameSnakeCase . '_' . $itemNameSnakeCase
+                'table_name' => $bundleNameSnakeCase . '_' . $itemNameSnakeCase
             )))
         {
             throw new \RuntimeException('Error writing file "' . $filePath . '".');
@@ -183,8 +183,7 @@ class GridItemGenerator extends Generator
     {
         return
             $this->camelCaseToSnakeCase($this->removeBundlePostFix($bundle->getName()))
-            . '_grid_item_'
-            . $this->camelCaseToSnakeCase($itemName);
+            . '_' . $this->camelCaseToSnakeCase($itemName);
     }
 
     protected function camelCaseToSnakeCase($camelCaseName, $minusSeparator = false)


### PR DESCRIPTION
Changed command name from "enhavo:generate:grid:item" to "enhavo:generate:grid-item"
Removed "grid_item" from default database table name and form type alias