### PR TITLE
[MediaBundle] Prevent quick succession requests on media format route…

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Entity/Format.php
+++ b/src/Enhavo/Bundle/MediaBundle/Entity/Format.php
@@ -53,6 +53,12 @@ class Format implements FormatInterface
     private $content;
 
     /**
+     * @var \DateTime|null
+     */
+    private $filterOperationsLock;
+
+
+    /**
      * @inheritdoc
      */
     public function getId()
@@ -170,5 +176,21 @@ class Format implements FormatInterface
     public function setContent(ContentInterface $content)
     {
         $this->content = $content;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getFilterOperationsLock()
+    {
+        return $this->filterOperationsLock;
+    }
+
+    /**
+     * @param \DateTime|null $filterOperationsLock
+     */
+    public function setFilterOperationsLock($filterOperationsLock)
+    {
+        $this->filterOperationsLock = $filterOperationsLock;
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Entity/Format.php
+++ b/src/Enhavo/Bundle/MediaBundle/Entity/Format.php
@@ -55,7 +55,7 @@ class Format implements FormatInterface
     /**
      * @var \DateTime|null
      */
-    private $filterOperationsLock;
+    private $lockAt;
 
 
     /**
@@ -181,16 +181,16 @@ class Format implements FormatInterface
     /**
      * @return \DateTime|null
      */
-    public function getFilterOperationsLock()
+    public function getLockAt()
     {
-        return $this->filterOperationsLock;
+        return $this->lockAt;
     }
 
     /**
-     * @param \DateTime|null $filterOperationsLock
+     * @param \DateTime|null $lockAt
      */
-    public function setFilterOperationsLock($filterOperationsLock)
+    public function setLockAt($lockAt)
     {
-        $this->filterOperationsLock = $filterOperationsLock;
+        $this->lockAt = $lockAt;
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Media/FormatManager.php
+++ b/src/Enhavo/Bundle/MediaBundle/Media/FormatManager.php
@@ -281,11 +281,9 @@ class FormatManager
     {
         $timedOutFormats = $this->formatRepository->findByTimedOutFilterOperationsLock(self::LOCK_FILTER_OPERATIONS_TIMEOUT);
         foreach($timedOutFormats as $format) {
-            try {
-                $this->deleteFormat($format);
-            } catch (\Exception $exception) {
-                // Timed out filter operations might not have files, which might lead to Exceptions when trying to delete those files
-            }
+            $this->em->remove($format);
+            $this->em->flush();
+            // Associated files are NOT deleted, since they might be part of a later format creation that did not timeout
         }
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Model/FormatInterface.php
+++ b/src/Enhavo/Bundle/MediaBundle/Model/FormatInterface.php
@@ -98,4 +98,14 @@ interface FormatInterface extends ResourceInterface
      * @return string
      */
     public function getFilename();
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getFilterOperationsLock();
+
+    /**
+     * @param \DateTime|null $filterOperationsLock
+     */
+    public function setFilterOperationsLock($filterOperationsLock);
 }

--- a/src/Enhavo/Bundle/MediaBundle/Model/FormatInterface.php
+++ b/src/Enhavo/Bundle/MediaBundle/Model/FormatInterface.php
@@ -102,10 +102,10 @@ interface FormatInterface extends ResourceInterface
     /**
      * @return \DateTime|null
      */
-    public function getFilterOperationsLock();
+    public function getLockAt();
 
     /**
-     * @param \DateTime|null $filterOperationsLock
+     * @param \DateTime|null $lockAt
      */
-    public function setFilterOperationsLock($filterOperationsLock);
+    public function setLockAt($lockAt);
 }

--- a/src/Enhavo/Bundle/MediaBundle/Repository/FormatRepository.php
+++ b/src/Enhavo/Bundle/MediaBundle/Repository/FormatRepository.php
@@ -8,9 +8,37 @@
 
 namespace Enhavo\Bundle\MediaBundle\Repository;
 
+use Enhavo\Bundle\MediaBundle\Media\FormatManager;
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 class FormatRepository extends EntityRepository
 {
+    public function findByFormatNameAndFile($formatName, FileInterface $file, $filterOperationsLockTimeout = FormatManager::LOCK_FILTER_OPERATIONS_TIMEOUT)
+    {
+        $queryBuilder = $this->createQueryBuilder('format');
+        $queryBuilder
+            ->andWhere('format.name = :formatName')
+            ->andWhere('format.file = :file')
+            ->andWhere('format.filterOperationsLock >= :lockTimeout')
+            ->setParameter('formatName', $formatName)
+            ->setParameter('file', $file)
+            ->setParameter('lockTimeout', new \DateTime($filterOperationsLockTimeout . ' seconds ago'));
 
+        $allResults = $queryBuilder->getQuery()->getResult();
+        if (count($allResults) > 0) {
+            return $allResults[0];
+        }
+        return null;
+    }
+
+    public function findByTimedOutFilterOperationsLock($filterOperationsLockTimeout = FormatManager::LOCK_FILTER_OPERATIONS_TIMEOUT)
+    {
+        $queryBuilder = $this->createQueryBuilder('format');
+        $queryBuilder
+            ->andWhere('format.filterOperationsLock < :lockTimeout')
+            ->setParameter('lockTimeout', new \DateTime($filterOperationsLockTimeout . ' seconds ago'));
+
+        return $queryBuilder->getQuery()->getResult();
+    }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Repository/FormatRepository.php
+++ b/src/Enhavo/Bundle/MediaBundle/Repository/FormatRepository.php
@@ -14,16 +14,16 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 class FormatRepository extends EntityRepository
 {
-    public function findByFormatNameAndFile($formatName, FileInterface $file, $filterOperationsLockTimeout = FormatManager::LOCK_FILTER_OPERATIONS_TIMEOUT)
+    public function findByFormatNameAndFile($formatName, FileInterface $file, $lockTimeout = FormatManager::LOCK_TIMEOUT)
     {
         $queryBuilder = $this->createQueryBuilder('format');
         $queryBuilder
             ->andWhere('format.name = :formatName')
             ->andWhere('format.file = :file')
-            ->andWhere('format.filterOperationsLock >= :lockTimeout')
+            ->andWhere('format.lockAt >= :lockTimeout')
             ->setParameter('formatName', $formatName)
             ->setParameter('file', $file)
-            ->setParameter('lockTimeout', new \DateTime($filterOperationsLockTimeout . ' seconds ago'));
+            ->setParameter('lockTimeout', new \DateTime($lockTimeout . ' seconds ago'));
 
         $allResults = $queryBuilder->getQuery()->getResult();
         if (count($allResults) > 0) {
@@ -32,12 +32,12 @@ class FormatRepository extends EntityRepository
         return null;
     }
 
-    public function findByTimedOutFilterOperationsLock($filterOperationsLockTimeout = FormatManager::LOCK_FILTER_OPERATIONS_TIMEOUT)
+    public function findByTimedOutLock($lockTimeout = FormatManager::LOCK_TIMEOUT)
     {
         $queryBuilder = $this->createQueryBuilder('format');
         $queryBuilder
-            ->andWhere('format.filterOperationsLock < :lockTimeout')
-            ->setParameter('lockTimeout', new \DateTime($filterOperationsLockTimeout . ' seconds ago'));
+            ->andWhere('format.lockAt < :lockTimeout')
+            ->setParameter('lockTimeout', new \DateTime($lockTimeout . ' seconds ago'));
 
         return $queryBuilder->getQuery()->getResult();
     }

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/doctrine/Format.orm.yml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/doctrine/Format.orm.yml
@@ -24,8 +24,12 @@ Enhavo\Bundle\MediaBundle\Entity\Format:
             nullable: true
 
         parameters:
-              type: json_array
-              nullable: true
+            type: json_array
+            nullable: true
+
+        filterOperationsLock:
+            type: datetime
+            nullable: true
 
     manyToOne:
         file:

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/doctrine/Format.orm.yml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/doctrine/Format.orm.yml
@@ -27,7 +27,7 @@ Enhavo\Bundle\MediaBundle\Entity\Format:
             type: json_array
             nullable: true
 
-        filterOperationsLock:
+        lockAt:
             type: datetime
             nullable: true
 


### PR DESCRIPTION
… to trigger multiple creations of the same format file.

Before this change, quick succession requests on long running formats (e.g. ImageCompression Filter on png) could lead to a high number of concurrent file operation processes, slowing down the server, running into timeouts and potentially never finishing. This is now prevented via a locking mechanic, and later requests will wait for the running operation to finish instead of triggering one themselves.

There is still a small time frame between looking for a locked format and creating a new one. So requests in very fast succession will still be able to trigger the format creation multiple times this way. But since this can only happen with a small number of processes at once, it won't lead to any problems.