### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 The enhavo CMS is a open source PHP project on top of the fullstack Symfony framework and uses awesome Sylius components
 to serve a very flexible software, that can handle most of complex data structure with a clean and usability interface.
 
-Enhavo is still under heavy development and we can't gurantee for backward compatibility or security issues nor is our documentation up to date. 
+Enhavo is still under heavy development and we can't guarantee for backward compatibility or security issues nor is our documentation up to date. 
 So we advice you to not use the software for production until we reach a stable release. 
 
 

--- a/docs/source/book/architecture/type-pattern.rst
+++ b/docs/source/book/architecture/type-pattern.rst
@@ -69,7 +69,7 @@ The assembly of the view data is delegated to the type. After you get the action
         }
 
 Thanks to the symfony dependency injection container we can add this type to the central repository by tagging,
-and it will only be instanciated if it is really used.
+and it will only be instantiated if it is really used.
 
 .. note::
 

--- a/docs/source/contributing/conventions.rst
+++ b/docs/source/contributing/conventions.rst
@@ -12,7 +12,7 @@ Route name
 
 For example you have a bundle called ``enhavoAppBundle``, and a action
 called ``index`` then you have to name your route like this ``enhavo_app_index``.
-A route should contain the following information devide by an underscore:
+A route should contain the following information divide by an underscore:
 
 1) Company name
 

--- a/docs/source/get-started/create-entity.rst
+++ b/docs/source/get-started/create-entity.rst
@@ -190,7 +190,7 @@ The common path for the Repository-classes are ``src/Repository``.
 
     }
 
-An empty Repository is very unspectacular, but we will learn how usefull they can be later.
+An empty Repository is very unspectacular, but we will learn how useful they can be later.
 
 
 Update Database

--- a/docs/source/guides/media/add-media-file-to-resource.rst
+++ b/docs/source/guides/media/add-media-file-to-resource.rst
@@ -198,7 +198,7 @@ To allow the user to edit this information, we define the fields in our resource
                 'label' => 'media.form.label.alt_tag',
                 'translationDomain' => 'EnhavoMediaBundle'
             ),
-            'my_paramater' => array(
+            'my_parameter' => array(
                 'label' => 'myresource.form.label.my_parameter',
                 'translationDomain' => 'AcmeMyResourceBundle'
             )

--- a/docs/source/guides/routing/dynamic-routing.rst
+++ b/docs/source/guides/routing/dynamic-routing.rst
@@ -96,7 +96,7 @@ Form
 
 To add an url field in our form we just use this simple snippet.
 There is already a form type ``enhavo_route``, which handle
-all we need. Also the contraints, so we use a clean and unique url.
+all we need. Also the constraints, so we use a clean and unique url.
 
 .. code-block:: php
 

--- a/docs/source/guides/search/add-search-for-entity.rst
+++ b/docs/source/guides/search/add-search-for-entity.rst
@@ -56,7 +56,7 @@ If there is a HTML text which contains HTML-tags, you should choose the ``Html``
               h2: 10
               p: 7
 
-With the `type` you can set the type as which the field gets stored in the database and whith the `weight` you choose the weight of the field compared to all the other fields.
+With the `type` you can set the type as which the field gets stored in the database and with the `weight` you choose the weight of the field compared to all the other fields.
 If you have the `Html` field you can give weights to each HTML-tag (if you just skip the `weights` there are default weights for the HTML-tags).
 
 Attention: If you use elastic-search you can not define the weight for each HTML-tag. Just use the weight like explained for the `Plain` type.

--- a/docs/source/reference/action/open-action.rst
+++ b/docs/source/reference/action/open-action.rst
@@ -1,7 +1,7 @@
 Open Action
 ===========
 
-Opens the specified route in a seperate tab in your browser. Can be used, for example, to view self-created newsletters, products, etc.
+Opens the specified route in a separate tab in your browser. Can be used, for example, to view self-created newsletters, products, etc.
 
 .. csv-table::
     :widths: 50 150

--- a/docs/source/reference/action/update-action.rst
+++ b/docs/source/reference/action/update-action.rst
@@ -29,7 +29,7 @@ route
 **type**: `string`
 **default**: `null`
 
-Defines which update route should be used to edit the selected ressource.
+Defines which update route should be used to edit the selected resource.
 
 .. code-block:: yaml
 

--- a/docs/source/reference/form/list.rst
+++ b/docs/source/reference/form/list.rst
@@ -61,7 +61,7 @@ Add properties
 --------------
 
 There are two more properties you can add to the formType. Add these like you have done it with the ``allow_delete`` property.
-If you want to seperate the items from eachother with a border, set the ``border`` property to true. If not you can just skip this step.
+If you want to separate the items from eachother with a border, set the ``border`` property to true. If not you can just skip this step.
 
 .. code-block:: php
 


### PR DESCRIPTION
Hi,

This PR will fix : 

- 1 typo in `README.md`
- 1 typo in `docs/source/book/architecture/type-pattern.rst`
- 1 typo in `docs/source/contributing/conventions.rst`
- 1 typo in `docs/source/get-started/create-entity.rst`
- 1 typo in `docs/source/guides/media/add-media-file-to-resource.rst`
- 1 typo in `docs/source/guides/routing/dynamic-routing.rst`
- 1 typo in `docs/source/guides/search/add-search-for-entity.rst`
- 1 typo in `docs/source/reference/action/open-action.rst`
- 1 typo in `docs/source/reference/action/update-action.rst`
- 1 typo in `docs/source/reference/form/list.rst`



Ciao! :robot: