### PR TITLE
[DoctrineExtensionBundle] Added priority to ExtendSubscriber; it was …

### DIFF
--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/Resources/config/services/listener.yaml
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/Resources/config/services/listener.yaml
@@ -10,4 +10,4 @@ services:
         arguments:
             - '@Enhavo\Component\Metadata\MetadataRepository[DoctrineExtension]'
         tags:
-            - { name: doctrine.event_subscriber }
+            - { name: doctrine.event_subscriber, priority: 1000 }


### PR DESCRIPTION
…missing some entities (Format, File) because their dependencies caused an early build of Metadata when the subscriber wasn't registered yet