### PR TITLE
[AppBundle] Changed ResourceResolver for the case that a table route …

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Controller/ResourcesResolver.php
+++ b/src/Enhavo/Bundle/AppBundle/Controller/ResourcesResolver.php
@@ -50,7 +50,7 @@ class ResourcesResolver implements ResourcesResolverInterface
                 $query = $this->filterQueryBuilder->buildQueryFromRequestConfiguration($requestConfiguration);
                 if (null !== $repositoryMethod = $requestConfiguration->getRepositoryMethod()) {
                     $callable = [$repository, $repositoryMethod];
-                    $resources = call_user_func_array($callable, array_merge([$query], $requestConfiguration->getRepositoryArguments()));
+                    $resources = call_user_func_array($callable, array_merge($requestConfiguration->getRepositoryArguments(), [$query]));
 
                 } else {
                     $resources = $repository->filter($query);


### PR DESCRIPTION
…uses both filters and a repository function to add the query parameter as last repository function parameter instead if as first. This allows for reuse of repository functions by declaring the query parameter as optional.