### PR TITLE
Form headline type attributes

### DIFF
--- a/src/Enhavo/Bundle/ArticleBundle/Controller/ArticleController.php
+++ b/src/Enhavo/Bundle/ArticleBundle/Controller/ArticleController.php
@@ -44,7 +44,7 @@ class ArticleController extends AbstractController
         ]);
 
         if($article === null) {
-            $this->createNotFoundException();
+            throw $this->createNotFoundException();
         }
 
         return $this->showResourceAction($article, $request);

--- a/src/Enhavo/Bundle/CalendarBundle/Controller/AppointmentController.php
+++ b/src/Enhavo/Bundle/CalendarBundle/Controller/AppointmentController.php
@@ -19,14 +19,14 @@ class AppointmentController extends AbstractController
 
     public function showAction(Request $request)
     {
-        $article = $this->get('enhavo_calendar.repository.appointment')->findOneBy([
+        $appointment = $this->get('enhavo_calendar.repository.appointment')->findOneBy([
             'slug' => $request->get('slug')
         ]);
 
-        if($article === null) {
-            $this->createNotFoundException();
+        if($appointment === null) {
+            throw $this->createNotFoundException();
         }
 
-        return $this->showResourceAction($article);
+        return $this->showResourceAction($appointment);
     }
 }

--- a/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
+++ b/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
@@ -218,7 +218,7 @@
 {%- endblock form_errors -%}
 
 {% block head_line_widget %}
-    <div class="head-line-widget">
+    <div class="head-line-widget" {{ block('attributes') }}>
         {% spaceless %}
             <div class="head-line-widget-text">
                 {{ form_widget(form.text) }}


### PR DESCRIPTION
[FormBundle] HeadLineType: Render attributes in enclosing div; this is not ideal because attributes are usually rendered on the form item itself, but still better than not rendering them at all like before