### PR TITLE
[FormBundle] HeadLineType: Render attributes in enclosing div; this i…

### DIFF
--- a/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
+++ b/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
@@ -218,7 +218,7 @@
 {%- endblock form_errors -%}
 
 {% block head_line_widget %}
-    <div class="head-line-widget">
+    <div class="head-line-widget" {{ block('attributes') }}>
         {% spaceless %}
             <div class="head-line-widget-text">
                 {{ form_widget(form.text) }}


### PR DESCRIPTION
…s not ideal because attributes are usually rendered on the form item itself, but still better than not rendering them at all like before