### PR TITLE
Fix empty navigation model

### DIFF
--- a/src/Enhavo/Bundle/NavigationBundle/Form/Type/NodeCollectionType.php
+++ b/src/Enhavo/Bundle/NavigationBundle/Form/Type/NodeCollectionType.php
@@ -87,7 +87,9 @@ class NodeCollectionType extends AbstractType
             /** @var NodeInterface $node */
             $node = new $this->class;
             $modelClass = $item->getModel();
-            $node->setSubject(new $modelClass);
+            if ($modelClass !== null) {
+                $node->setSubject(new $modelClass);
+            }
             $data[$key] = $node;
         }
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

The model class on `NavItemType` can be `null` for valid reasons. E.g. empty nav item as placeholder. This PR allowed to set model as `null` 
