### PR TITLE
Add typescript support for mocha tests

### DIFF
--- a/assets/node_modules/@enhavo/vue-form/form/FormFactory.ts
+++ b/assets/node_modules/@enhavo/vue-form/form/FormFactory.ts
@@ -28,7 +28,7 @@ export class FormFactory implements FormFactoryInterface
         this.entries.push(new Entry(component, factory));
     }
 
-    private getEntry(name: string): Entry
+    private getEntry(name: string): Entry|null
     {
         for (let entry of this.entries) {
             if (entry.name === name) {

--- a/assets/node_modules/@enhavo/vue-form/tests/form/FormFactory.mocha.ts
+++ b/assets/node_modules/@enhavo/vue-form/tests/form/FormFactory.mocha.ts
@@ -1,0 +1,22 @@
+import {FormFactory} from "@enhavo/vue-form/form/FormFactory"
+import {TestFactory} from "@enhavo/vue-form/tests/mock/TestFactory"
+import {TestForm} from "@enhavo/vue-form/tests/mock/TestForm";
+const chai = require("chai");
+
+describe('vue-form/form/FormFactory', () => {
+    describe('After register a form factory', () => {
+        let factory = new FormFactory();
+        let testFactory = new TestFactory();
+        factory.registerFactory('test', testFactory);
+
+        it('it should be used if component matches', () => {
+            let createForm = <TestForm>factory.createForm({component: 'test'});
+            chai.assert(createForm.foo === 'bar')
+        });
+
+        it('it should not be used if component not matches', () => {
+            let otherForm = <TestForm>factory.createForm({component: 'something'});
+            chai.assert(typeof otherForm.foo === 'undefined')
+        });
+    });
+});

--- a/assets/node_modules/@enhavo/vue-form/tests/mock/TestFactory.ts
+++ b/assets/node_modules/@enhavo/vue-form/tests/mock/TestFactory.ts
@@ -1,0 +1,11 @@
+import {FormFactoryInterface} from "@enhavo/vue-form/form/FormFactoryInterface";
+import {Form} from "@enhavo/vue-form/form/Form";
+import {TestForm} from "@enhavo/vue-form/tests/mock/TestForm";
+
+export class TestFactory implements FormFactoryInterface
+{
+    createForm(data: object): Form
+    {
+        return new TestForm();
+    }
+}

--- a/assets/node_modules/@enhavo/vue-form/tests/mock/TestForm.ts
+++ b/assets/node_modules/@enhavo/vue-form/tests/mock/TestForm.ts
@@ -1,0 +1,6 @@
+import {Form} from "@enhavo/vue-form/form/Form";
+
+export class TestForm extends Form
+{
+    public foo = "bar";
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "routes:dump": "bin/console fos:js-routing:dump --format=json --target=public/js/fos_js_routes.json",
     "karma": "TESTBUILD=true encore dev --config webpack.test.config.js && karma start --single-run --browsers ChromeHeadless karma.conf.js && rm -rf public/build/test/*",
-    "mocha": "mocha assets/node_modules/**/tests/**/*.mocha.js",
+    "mocha": "TS_NODE_SKIP_IGNORE=true TS_NODE_PROJECT=./tsconfig.test.json mocha --require ts-node/register assets/node_modules/**/tests/**/*.mocha.{ts,js}",
+    "mocha:file": "TS_NODE_SKIP_IGNORE=true TS_NODE_PROJECT=./tsconfig.test.json mocha --require ts-node/register",
     "di": "node ./assets/node_modules/@enhavo/dependency-injection/bin/dependency-injection.js \"./assets/services/enhavo/*\"",
     "webfonts:generate": "node ./assets/node_modules/@enhavo/app/bin/webfont-generate.js",
     "dev": "encore dev",
@@ -47,6 +48,7 @@
     "source-sans-pro": "^2.45.0",
     "tinymce": "^5.6.0",
     "ts-loader": "^5.3",
+    "ts-node": "^9.1.1",
     "typeface-cormorant-garamond": "^0.0.72",
     "typescript": "^3.1.1",
     "urijs": "^1.19.1",

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "lib": [ "es2015", "dom" ],
+    "module": "amd",
+    "target": "es5",
+    "allowJs": true,
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "./assets/**/*"
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": [ "es2015", "dom" ],
+    "module": "commonjs",
+    "target": "es5",
+    "allowJs": true,
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true
+  }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| License       | MIT

Use `ts-node` to transpile mocha tests written in typescript. `TS_NODE_SKIP_IGNORE` must be `true` in order to use tests inside `node_modules`
