### PR TITLE
[AppBundle/MultiTenancyBundle] Updated all filters to allow dot property path notation

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Filter/Type/BooleanType.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/Type/BooleanType.php
@@ -58,13 +58,14 @@ class BooleanType extends AbstractFilterType
         if($value === null) {
             return;
         }
-        $property = $options['property'];
+        $propertyPath = explode('.', $options['property']);
+        $property = array_pop($propertyPath);
 
         if ($options['checkbox']) {
             $boolValue = (boolean)$value;
             if($boolValue) {
                 $equals = $options['equals'];
-                $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $equals);
+                $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $equals, $propertyPath);
             }
         } else {
             if ($value == self::VALUE_TRUE) {
@@ -75,8 +76,7 @@ class BooleanType extends AbstractFilterType
                 throw new FilterException('Value invalid, must be one of ' . implode(',', [self::VALUE_TRUE, self::VALUE_FALSE]));
             }
 
-            $property = $options['property'];
-            $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $boolValue);
+            $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $boolValue, $propertyPath);
         }
     }
 

--- a/src/Enhavo/Bundle/AppBundle/Filter/Type/OptionType.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/Type/OptionType.php
@@ -62,8 +62,9 @@ class OptionType extends AbstractFilterType
             throw new FilterException('Value does not exists in options');
         }
 
-        $property = $options['property'];
-        $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $value);
+        $propertyPath = explode('.', $options['property']);
+        $property = array_pop($propertyPath);
+        $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $value, $propertyPath);
     }
 
     public function configureOptions(OptionsResolver $optionsResolver)

--- a/src/Enhavo/Bundle/AppBundle/Filter/Type/TextType.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/Type/TextType.php
@@ -30,22 +30,12 @@ class TextType extends AbstractFilterType
 
     public function buildQuery(FilterQuery $query, $options, $value)
     {
-        $property = $options['property'];
-        $joinProperty = [];
-        if(substr_count($property, '.') >= 1){
-            $exploded = explode('.', $property);
-            foreach ($exploded as $piece) {
-                if(count($exploded) > 1){
-                    $joinProperty[] = array_shift($exploded);
-                } elseif (count($exploded) === 1) {
-                    $property = array_shift($exploded);
-                }
-            }
-        }
+        $propertyPath = explode('.', $options['property']);
+        $property = array_pop($propertyPath);
 
         $operator = $options['operator'];
         if($value !== null && trim($value) !== '') {
-            $query->addWhere($property, $operator, $value, $joinProperty ? $joinProperty : null);
+            $query->addWhere($property, $operator, $value, $propertyPath);
         }
     }
 

--- a/src/Enhavo/Bundle/MultiTenancyBundle/Filter/TenancyFilterType.php
+++ b/src/Enhavo/Bundle/MultiTenancyBundle/Filter/TenancyFilterType.php
@@ -67,8 +67,9 @@ class TenancyFilterType extends AbstractFilterType
             throw new FilterException('Value submitted for TenancyFilter is not a valid tenant');
         }
 
-        $property = $options['property'];
-        $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $value);
+        $propertyPath = explode('.', $options['property']);
+        $property = array_pop($propertyPath);
+        $query->addWhere($property, FilterQuery::OPERATOR_EQUALS, $value, $propertyPath);
     }
 
     public function configureOptions(OptionsResolver $optionsResolver)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

Some filter types (Boolean, Option and Tenancy) still didn't support dot notation on the property parameter to create join queries. I updated all of these, and also simplified the code in TextType to match the other filters.