### PR TITLE
[AppBundle] Added possibility to add OR blocks to FilterQuery

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Filter/FilterQueryOr.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/FilterQueryOr.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Filter;
+
+class FilterQueryOr
+{
+    /**
+     * @var array
+     */
+    private $where = [];
+
+    public function addWhere($property, $operator, $value, $joinProperty = null)
+    {
+        $this->where[] = [
+            'property' => $property,
+            'operator' => $operator,
+            'value' => $value,
+            'joinProperty' => $joinProperty
+        ];
+
+        return $this;
+    }
+
+    public function removeWhere($property, $operator, $value, $joinProperty = null)
+    {
+        if(!$property && !$operator && !$value && !$joinProperty){
+            return $this;
+        }
+        foreach ($this->where as $index => $where){
+            if($property && $where['property'] !== $property){
+                continue;
+            }
+            if($operator && $where['operator'] !== $operator){
+                continue;
+            }
+            if($value && $where['value'] !== $value){
+                continue;
+            }
+            if($joinProperty && $where['joinProperty'] !== $joinProperty){
+                continue;
+            }
+            unset($this->where[$index]);
+        }
+
+        return $this;
+    }
+
+    public function getWhere()
+    {
+        return $this->where;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc PR?       | no
| License       | MIT

Expanded FilterQuery to allow adding OR blocks.

`$filterQuery->or()->addWhere('property1', '=', 'value1')->addWhere('property2', '=', 'value2');`

These blocks will be added as an AND statement in parenthesis, like this:

`AND (property1 = "value1" OR property2 = "value2")`
