### PR TITLE
[FormBundle] BooleanType readonly/disabled

### DIFF
--- a/assets/node_modules/@enhavo/form/assets/styles/module/_icheck.scss
+++ b/assets/node_modules/@enhavo/form/assets/styles/module/_icheck.scss
@@ -6,7 +6,7 @@
   &:after { background:$color1b;position:absolute; top:calc(50% - 5px); left:calc(50% - 5px); width:10px; height:10px;border-radius:50%; content:'';transform:scale(0); opacity:0;}
   + label {display: inline-block;vertical-align: middle; margin-left:5px;cursor:pointer;font-size:0.85rem;}
   input {top:0;left:0;width:100%;height:100%;margin:0;padding:0;}
-  &.readonly { pointer-events: none; background: $grey2; border-color: $grey3;
+  &.readonly, &.disabled { pointer-events: none; background: $grey2; border-color: $grey3;
     &:after { background: $grey3; }
     + label { pointer-events: none; }
   }

--- a/assets/node_modules/@enhavo/form/assets/styles/module/_icheck.scss
+++ b/assets/node_modules/@enhavo/form/assets/styles/module/_icheck.scss
@@ -6,4 +6,8 @@
   &:after { background:$color1b;position:absolute; top:calc(50% - 5px); left:calc(50% - 5px); width:10px; height:10px;border-radius:50%; content:'';transform:scale(0); opacity:0;}
   + label {display: inline-block;vertical-align: middle; margin-left:5px;cursor:pointer;font-size:0.85rem;}
   input {top:0;left:0;width:100%;height:100%;margin:0;padding:0;}
+  &.readonly { pointer-events: none; background: $grey2; border-color: $grey3;
+    &:after { background: $grey3; }
+    + label { pointer-events: none; }
+  }
 }

--- a/assets/node_modules/@enhavo/form/type/CheckboxType.ts
+++ b/assets/node_modules/@enhavo/form/type/CheckboxType.ts
@@ -20,5 +20,9 @@ export default class CheckboxType extends FormType
                 $count.text('(' + count + ')');
             });
         }
+
+        if (this.$element.attr('readonly')) {
+            this.$element.closest('.icheckbox').addClass('readonly');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

FormBundle's BooleanType previously ignored the html attribute "readonly". The "disabled" attribute worked, but had no accompanying style. This PR adds both the readonly functionality and styles for both readonly and disabled.
