### PR TITLE
Fix reapply translation type

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
@@ -54,6 +54,11 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
         }
 
         foreach ($form->all() as $property => $child) {
+            // prevent reapply
+            if (get_class($child->getConfig()->getType()->getInnerType()) === TranslationType::class) {
+                continue;
+            }
+
             if ($this->translationManager->isTranslatable($data, $property)) {
                 $this->replaceChild($data, $property, $form, $child);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

For `PolyCollectionType` forms, the `TranslationType` was applied twice. Somehow, the behaviour changed here, but couldn't find out why. This bugfix prevent applying the `TranslationType` a second time
