### PR TITLE
[AppBundle] Fixed bug when opening a menu link in a new browser tab

### DIFF
--- a/assets/node_modules/@enhavo/app/assets/styles/components/_menu.scss
+++ b/assets/node_modules/@enhavo/app/assets/styles/components/_menu.scss
@@ -68,7 +68,7 @@
   .menu-child {color:$grey4;}
 
   .menu-item {
-    &.selected {color:#fff;box-shadow: inset 4px 0 0 $color1b;}
+    &.selected, &.selected:visited {color:#fff;box-shadow: inset 4px 0 0 $color1b;}
   }
 
   .menu-child-title {padding:0 17px;display: flex; align-items: flex-start; justify-content: flex-start;cursor:pointer;min-height:46px;position:relative;

--- a/src/Enhavo/Bundle/AppBundle/Menu/Menu/BaseMenu.php
+++ b/src/Enhavo/Bundle/AppBundle/Menu/Menu/BaseMenu.php
@@ -66,7 +66,7 @@ class BaseMenu extends AbstractMenu
     private function generateMainUrl($url, $options)
     {
         $state = StateEncoder::encode([
-            'views' => [['url' => $url]],
+            'views' => [['url' => $url, 'id' => 2]],
             'storage' => [['key' => 'menu-active-key', 'value' => $options['key']]]
         ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

When you right click on an enhavo menu item and open it in a new browser tab, the resulting page would have a view without a valid id, which could then lead to javascript errors and infinite loading overlays on subsequent calls. This bugfix fixes that issue.
It also fixed a style error if a menu items a-element has the :visited state.