### PR TITLE
Use 0.9 branch for subtree split and 0.10 for backport

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,6 +15,14 @@ pull_request_rules:
                 branches:
                     - "0.8"
 
+    -   name: backport 0.10
+        conditions:
+            - label=backport-0.10
+        actions:
+            backport:
+                branches:
+                    - "0.10"
+
     -   name: delete head branch after merge
         conditions:
             - merged

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - master
             - 0.10
+            - 0.9
 
 jobs:
     push-subtree:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Use also `0.9` branch for subtree split and `0.10` for backports
