### PR TITLE
Add confirm delete option to PolyCollectionType

### DIFF
--- a/assets/node_modules/@enhavo/form/loader/PolyCollectionLoader.ts
+++ b/assets/node_modules/@enhavo/form/loader/PolyCollectionLoader.ts
@@ -4,15 +4,26 @@ import PolyCollectionConfig from "@enhavo/form/type/PolyCollectionConfig";
 import * as $ from "jquery";
 import prototypeManager from "@enhavo/form/prototype/PrototypeManager";
 import FormRegistry from "@enhavo/app/form/FormRegistry";
+import View from "@enhavo/app/view/View";
+import Translator from "@enhavo/core/Translator";
 
 export default class PolyCollectionLoader extends AbstractLoader
 {
+    private view: View;
+    private translator: Translator;
+
+    constructor(view: View, translator: Translator) {
+        super();
+        this.view = view;
+        this.translator = translator;
+    }
+
     public insert(element: HTMLElement): void
     {
         let elements = this.findElements(element, '[data-poly-collection]');
         for(element of elements) {
             let config = <PolyCollectionConfig>$(element).data('poly-collection-config');
-            FormRegistry.registerType(new PolyCollectionType(element, config, prototypeManager));
+            FormRegistry.registerType(new PolyCollectionType(element, config, prototypeManager, this.view, this.translator));
         }
     }
 }

--- a/assets/node_modules/@enhavo/form/services/loader.yaml
+++ b/assets/node_modules/@enhavo/form/services/loader.yaml
@@ -52,6 +52,9 @@ services:
 
     '@enhavo/form/loader/PolyCollectionLoader':
         chunk: 'form'
+        arguments:
+            - '@enhavo/app/view/View'
+            - '@enhavo/core/Translator'
         tags:
             - 'enhavo_app.form'
 

--- a/assets/node_modules/@enhavo/form/type/PolyCollectionConfig.ts
+++ b/assets/node_modules/@enhavo/form/type/PolyCollectionConfig.ts
@@ -3,4 +3,5 @@ export default class PolyCollectionConfig
     prototypeStorage: string;
     entryKeys: string;
     collapsed: boolean;
+    confirmDelete: boolean;
 }

--- a/assets/node_modules/@enhavo/form/type/PolyCollectionItem.ts
+++ b/assets/node_modules/@enhavo/form/type/PolyCollectionItem.ts
@@ -122,7 +122,11 @@ export default class PolyCollectionItem
 
     public remove()
     {
-        FormDispatcher.dispatchRemove(this.getElement());
-        this.polyCollection.removeItem(this);
+        this.polyCollection.confirmDelete((confirm: boolean) => {
+            if (confirm) {
+                FormDispatcher.dispatchRemove(this.getElement());
+                this.polyCollection.removeItem(this);
+            }
+        });
     }
 }

--- a/assets/node_modules/@enhavo/form/type/PolyCollectionType.ts
+++ b/assets/node_modules/@enhavo/form/type/PolyCollectionType.ts
@@ -7,6 +7,9 @@ import PolyCollectionItemAddButton from "@enhavo/form/type/PolyCollectionItemAdd
 import FormType from "@enhavo/app/form/FormType";
 import {PrototypeManager} from "@enhavo/form/prototype/PrototypeManager";
 import Prototype from "@enhavo/form/prototype/Prototype";
+import View from "@enhavo/app/view/View";
+import Confirm from "@enhavo/app/view/Confirm";
+import Translator from "@enhavo/core/Translator";
 
 export default class PolyCollectionType extends FormType
 {
@@ -26,12 +29,18 @@ export default class PolyCollectionType extends FormType
 
     private prototypes: Prototype[];
 
-    constructor(element: HTMLElement, config: PolyCollectionConfig, prototypeManager: PrototypeManager)
+    private view: View;
+
+    private translator: Translator;
+
+    constructor(element: HTMLElement, config: PolyCollectionConfig, prototypeManager: PrototypeManager, view: View, translator: Translator)
     {
         super(element);
         this.$container = this.$element.children('[data-poly-collection-container]');
         this.config = config;
         this.prototypeManager = prototypeManager;
+        this.translator = translator;
+        this.view = view;
         this.initPrototypes();
         this.initMenu();
         this.initActions();
@@ -274,6 +283,19 @@ export default class PolyCollectionType extends FormType
             if(typeof callback != "undefined") {
                 callback();
             }
+        }
+    }
+
+    public confirmDelete(callback: (confirm: boolean) => void)
+    {
+        if (this.config.confirmDelete) {
+            this.view.confirm(new Confirm(this.translator.trans('enhavo_app.view.message.delete'), () => {
+                callback(true);
+            }, () => {
+                callback(false);
+            }, this.translator.trans('enhavo_app.view.label.cancel'), this.translator.trans('enhavo_app.view.label.ok')));
+        } else {
+            callback(true);
         }
     }
 

--- a/src/Enhavo/Bundle/AppBundle/Resources/translations/javascript.de.yml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/translations/javascript.de.yml
@@ -19,6 +19,7 @@ enhavo_app:
         message:
             not_saved: 'Schließen ohne zu speichern?'
             unmark_after_filter: 'Nach dem Ausführen gehen alle selektierten Einträge verloren'
+            delete: 'Löschen?'
         label:
             ok: 'Ok'
             cancel: 'Abbrechen'

--- a/src/Enhavo/Bundle/AppBundle/Resources/translations/javascript.en.yml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/translations/javascript.en.yml
@@ -19,6 +19,7 @@ enhavo_app:
         message:
             not_saved: 'Close without saving?'
             unmark_after_filter: 'After applying the filter, all selected rows will be unselected'
+            delete: 'Delete?'
         label:
             ok: 'Ok'
             cancel: 'Cancel'

--- a/src/Enhavo/Bundle/FormBundle/Form/Type/PolyCollectionType.php
+++ b/src/Enhavo/Bundle/FormBundle/Form/Type/PolyCollectionType.php
@@ -93,6 +93,7 @@ class PolyCollectionType extends AbstractType
             'entryKeys' => $this->buildEntryKeys($options),
             'prototypeStorage' => $options['prototype_storage'],
             'collapsed' => $options['collapsed'],
+            'confirmDelete' => $options['confirm_delete'],
         ];
 
         $view->vars['custom_name_property'] = $options['custom_name_property'];
@@ -146,7 +147,8 @@ class PolyCollectionType extends AbstractType
             'prototype_storage' => null,
             'by_reference' => false,
             'custom_name_property' => null,
-            'add_label' => ''
+            'add_label' => '',
+            'confirm_delete' => false
         ]);
 
         $resolver->setRequired(array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Backport      | 0.10
| License       | MIT

Add `confirm_delete` option to `PolyCollectionType` to better protected items if needed
