### PR TITLE
Add git user to subtree workflow

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -33,4 +33,6 @@ jobs:
 
             -   name: Push subtrees
                 run: |
+                    git config --global user.email "bot@enhavo.com"
+                    git config --global user.name "enhavo bot"
                     ./enhavo.phar push-subtree --yes -vvv --branch ${GITHUB_REF##*/} --force


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

Add `enhavo-bot` as git user to subtree split in case if needed for e.g. force pushes