### PR TITLE
Fix translation extension

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Form/Extension/TranslationExtension.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/Extension/TranslationExtension.php
@@ -46,7 +46,7 @@ class TranslationExtension extends AbstractTypeExtension
         return $options['compound'] && $this->translationManager->isEnabled() && $this->translationManager->isTranslation();
     }
 
-    public function getExtendedTypes()
+    public static function getExtendedTypes()
     {
         return [FormType::class];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Backport      | 0.10
| License       | MIT

The function `getExtendedTypes` should be static. 
