### PR TITLE
[AppBundle] Fixed label of filters type BetweenFilterType displayed as json

### DIFF
--- a/assets/node_modules/@enhavo/app/action/model/FilterAction.ts
+++ b/assets/node_modules/@enhavo/app/action/model/FilterAction.ts
@@ -17,8 +17,14 @@ export default class FilterAction extends DropdownAction
         for (let i in this.filterManager.filters) {
             let action = this.singleFilterActionFactory.createNew();
             action.filterKey = this.filterManager.filters[i].key;
-            action.label = this.filterManager.filters[i].label;
             action.setActive(this.filterManager.filters[i].active);
+
+            if (typeof this.filterManager.filters[i].label == "object" && this.filterManager.filters[i].label.hasOwnProperty('label')) {
+                action.label = ((Object)(this.filterManager.filters[i].label)).label;
+            } else {
+                action.label = this.filterManager.filters[i].label;
+            }
+
             this.items.push(action);
         }
     }

--- a/assets/node_modules/@enhavo/app/action/model/FilterAction.ts
+++ b/assets/node_modules/@enhavo/app/action/model/FilterAction.ts
@@ -17,14 +17,8 @@ export default class FilterAction extends DropdownAction
         for (let i in this.filterManager.filters) {
             let action = this.singleFilterActionFactory.createNew();
             action.filterKey = this.filterManager.filters[i].key;
+            action.label = this.filterManager.filters[i].label;
             action.setActive(this.filterManager.filters[i].active);
-
-            if (typeof this.filterManager.filters[i].label == "object" && this.filterManager.filters[i].label.hasOwnProperty('label')) {
-                action.label = ((Object)(this.filterManager.filters[i].label)).label;
-            } else {
-                action.label = this.filterManager.filters[i].label;
-            }
-
             this.items.push(action);
         }
     }

--- a/assets/node_modules/@enhavo/app/grid/filter/components/FilterBetweenComponent.vue
+++ b/assets/node_modules/@enhavo/app/grid/filter/components/FilterBetweenComponent.vue
@@ -1,20 +1,20 @@
 <template>
     <div class="view-table-filter-search">
-        <input @keyup="keyup" type="text" v-model="data.value.from" :placeholder="data.label.from" :class="['filter-form-field', {'has-value': hasFromValue}]">
-        <input @keyup="keyup" type="text" v-model="data.value.to" :placeholder="data.label.to" :class="['filter-form-field', {'has-value': hasToValue}]">
+        <input @keyup="keyup" type="text" v-model="data.value.from" :placeholder="data.labelFrom" :class="['filter-form-field', {'has-value': hasFromValue}]">
+        <input @keyup="keyup" type="text" v-model="data.value.to" :placeholder="data.labelTo" :class="['filter-form-field', {'has-value': hasToValue}]">
     </div>
 </template>
 
 <script lang="ts">
     import { Vue, Component, Prop } from "vue-property-decorator";
-    import AbstractFilter from "@enhavo/app/grid/filter/model/AbstractFilter";
+    import BetweenFilter from "@enhavo/app/grid/filter/model/BetweenFilter";
 
     @Component
     export default class FilterTextComponent extends Vue {
         name: string = 'filter-between';
 
         @Prop()
-        data: AbstractFilter;
+        data: BetweenFilter;
 
         get hasFromValue(): boolean {
             if(this.data.value.from == "") {

--- a/assets/node_modules/@enhavo/app/grid/filter/components/FilterDateBetweenComponent.vue
+++ b/assets/node_modules/@enhavo/app/grid/filter/components/FilterDateBetweenComponent.vue
@@ -1,24 +1,24 @@
 <template>
     <div class="view-table-filter-search">
-        <datepicker :typeable="true" :format="data.format" :language="locale" :placeholder="data.label.from" :monday-first="true" v-model="data.value.from" @closed="closed"></datepicker>
-        <datepicker :typeable="true" :format="data.format" :language="locale" :placeholder="data.label.to" :monday-first="true" v-model="data.value.to" @closed="closed"></datepicker>
+        <datepicker :typeable="true" :format="data.format" :language="locale" :placeholder="data.labelFrom" :monday-first="true" v-model="data.value.from" @closed="closed"></datepicker>
+        <datepicker :typeable="true" :format="data.format" :language="locale" :placeholder="data.labelTo" :monday-first="true" v-model="data.value.to" @closed="closed"></datepicker>
     </div>
 </template>
 
 <script lang="ts">
     import { Vue, Component, Prop } from "vue-property-decorator";
-    import AbstractFilter from "@enhavo/app/grid/filter/model/AbstractFilter";
     import {en, de} from 'vuejs-datepicker/dist/locale'
+    import DateBetweenFilter from "@enhavo/app/grid/filter/model/DateBetweenFilter";
 
     @Component
     export default class FilterTextComponent extends Vue {
         name: string = 'filter-date-between';
 
         @Prop()
-        data: AbstractFilter;
+        data: DateBetweenFilter;
 
         get locale() {
-            if(data.locale == 'de') {
+            if(this.data.locale == 'de') {
                 return de
             }
             return en;

--- a/assets/node_modules/@enhavo/app/grid/filter/model/BetweenFilter.ts
+++ b/assets/node_modules/@enhavo/app/grid/filter/model/BetweenFilter.ts
@@ -3,6 +3,8 @@ import AbstractFilter from "@enhavo/app/grid/filter/model/AbstractFilter";
 export default class BetweenFilter extends AbstractFilter
 {
     value: Between;
+    labelFrom: string;
+    labelTo: string;
 
     reset() {
         this.value.from = this.initialValue;

--- a/src/Enhavo/Bundle/AppBundle/Filter/Type/BetweenFilterType.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/Type/BetweenFilterType.php
@@ -25,12 +25,9 @@ class BetweenFilterType extends AbstractFilterType
             ],
             'initialValue' => null,
             'label' => [
-                'from' => $options['label_from'] ?
-                    $this->translator->trans($options['label_from'], [], $options['translation_domain']) :
-                    $this->getLabel($options),
-                'to' => $options['label_to'] ?
-                    $this->translator->trans($options['label_to'], [], $options['translation_domain']) :
-                    $this->getLabel($options),
+                'label' => $this->getMainLabel($options),
+                'from' => $this->getLabelFrom($options),
+                'to' => $this->getLabelTo($options),
             ],
         ]);
 
@@ -50,6 +47,27 @@ class BetweenFilterType extends AbstractFilterType
             $this->buildFromQuery($query, $options, $fromValue);
             $this->buildToQuery($query, $options, $toValue);
         }
+    }
+
+    protected function getMainLabel($options): string
+    {
+        return $options['label'] ?
+            $this->translator->trans($options['label'], [], $options['translation_domain']) :
+            $this->getLabelFrom($options);
+    }
+
+    protected function getLabelFrom($options): string
+    {
+        return $options['label_from'] ?
+            $this->translator->trans($options['label_from'], [], $options['translation_domain']) :
+            $this->getLabel($options);
+    }
+
+    protected function getLabelTo($options): string
+    {
+        return $options['label_to'] ?
+            $this->translator->trans($options['label_to'], [], $options['translation_domain']) :
+            $this->getLabel($options);
     }
 
     protected function buildFromQuery(FilterQuery$query, $options, $fromValue)

--- a/src/Enhavo/Bundle/AppBundle/Filter/Type/BetweenFilterType.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/Type/BetweenFilterType.php
@@ -24,11 +24,9 @@ class BetweenFilterType extends AbstractFilterType
                 'to' => '',
             ],
             'initialValue' => null,
-            'label' => [
-                'label' => $this->getMainLabel($options),
-                'from' => $this->getLabelFrom($options),
-                'to' => $this->getLabelTo($options),
-            ],
+            'label' => $this->getMainLabel($options),
+            'labelFrom' => $this->getLabelFrom($options),
+            'labelTo' => $this->getLabelTo($options),
         ]);
 
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

As part of the recent filters rework, the labels of filters are now displayed in a dropdown menu. But the BetweenFilterType stored its labels as an object instead of a string, which lead to filters of this type displaying a stringified json as label. This should fix this issue.