### PR TITLE
Add theming to forms

### DIFF
--- a/assets/node_modules/@enhavo/app/encore/AppTestPackage.js
+++ b/assets/node_modules/@enhavo/app/encore/AppTestPackage.js
@@ -37,7 +37,7 @@ class AppTestPackage
             if(".ts".match(rule.test)) {
                 delete rule.exclude;
                 rule.use.forEach(function(loader) {
-                    if(loader.loader === 'ts-loader') {
+                    if(loader.loader.match(/ts-loader/)) {
                         loader.options.allowTsInNodeModules = true;
                         loader.options.transpileOnly = true;
                     }

--- a/assets/node_modules/@enhavo/vue-form/data/FormData.ts
+++ b/assets/node_modules/@enhavo/vue-form/data/FormData.ts
@@ -1,6 +1,6 @@
 export class FormData
 {
-    children: FormData[];
+    children: object|any;
     value: string;
     name: string;
     label: string;

--- a/assets/node_modules/@enhavo/vue-form/form/Form.ts
+++ b/assets/node_modules/@enhavo/vue-form/form/Form.ts
@@ -4,6 +4,7 @@ import * as _ from "lodash";
 import {Util} from "@enhavo/vue-form/form/Util";
 import axios, {AxiosPromise,Method} from "axios";
 import * as qs from "qs";
+import {Theme} from "@enhavo/vue-form/form/Theme";
 
 export class Form extends RootFormData
 {
@@ -20,38 +21,18 @@ export class Form extends RootFormData
 
         let searchElement: FormData = this;
         for (let property of propertyChain) {
-            searchElement = this.getChild(searchElement, property);
-            if (searchElement === null) {
+            if (searchElement.children.hasOwnProperty(property)) {
+                searchElement = searchElement.children[property];
+            } else {
                 return null;
             }
         }
         return searchElement;
     }
 
-    private getChild(form: FormData, name: string)
+    public setTheme(theme: Theme)
     {
-        for (let child of form.children) {
-            if (child.name === name) {
-                return child;
-            }
-        }
-        return null;
-    }
-
-    public setTheme(theme: object)
-    {
-        this.updateComponent(this, theme);
-    }
-
-    private updateComponent(form: FormData, theme: object)
-    {
-        if (theme.hasOwnProperty(form.component)) {
-            form.component = theme[form.component];
-        }
-
-        if (theme.hasOwnProperty(form.rowComponent)) {
-            form.rowComponent = theme[form.rowComponent];
-        }
+        theme.apply(this);
     }
 
     public serializeForm()

--- a/assets/node_modules/@enhavo/vue-form/form/Theme.ts
+++ b/assets/node_modules/@enhavo/vue-form/form/Theme.ts
@@ -1,0 +1,42 @@
+import {FormData} from "@enhavo/vue-form/data/FormData";
+
+export class Theme
+{
+    private components: object = {};
+    private callbacks: Array<(form: FormData) => void> = [];
+
+    component(name: string, component: any)
+    {
+        this.components[name] = component;
+    }
+
+    forEach(callback: (form: FormData) => void)
+    {
+        this.callbacks.push(callback);
+    }
+
+    apply(form: FormData)
+    {
+        this.updateComponent(form);
+        for (let key in form.children) {
+            if (form.children.hasOwnProperty(key)) {
+                this.apply(form.children[key]);
+            }
+        }
+    }
+
+    private updateComponent(form: FormData)
+    {
+        if (this.components.hasOwnProperty(form.component)) {
+            form.component = this.components[form.component];
+        }
+
+        if (this.components.hasOwnProperty(form.rowComponent)) {
+            form.rowComponent = this.components[form.rowComponent];
+        }
+
+        for (let callback of this.callbacks) {
+            callback(form);
+        }
+    }
+}

--- a/assets/node_modules/@enhavo/vue-form/index.ts
+++ b/assets/node_modules/@enhavo/vue-form/index.ts
@@ -1,4 +1,4 @@
-import {Vue as _Vue, PluginObject} from "vue";
+import _Vue, {PluginObject} from "vue";
 import FormChoiceComponent from '@enhavo/vue-form/components/FormChoiceComponent.vue';
 import FormChoiceExpandedComponent from '@enhavo/vue-form/components/FormChoiceExpandedComponent.vue';
 import FormChoiceCollapsedComponent from '@enhavo/vue-form/components/FormChoiceCollapsedComponent.vue';

--- a/assets/node_modules/@enhavo/vue-form/tests/form/FormTest.mocha.ts
+++ b/assets/node_modules/@enhavo/vue-form/tests/form/FormTest.mocha.ts
@@ -1,0 +1,36 @@
+import {FormData} from "@enhavo/vue-form/data/FormData";
+import {Form} from "@enhavo/vue-form/form/Form";
+import {Theme} from "@enhavo/vue-form/form/Theme";
+const assert = require("chai").assert;
+
+describe('vue-form/form/Form', () => {
+    let grandChildData = new FormData();
+    grandChildData.name = 'text';
+    grandChildData.children = {};
+
+    let childData = new FormData();
+    childData.name = 'something';
+    childData.children = {text:grandChildData};
+
+    let formData = new FormData();
+    formData.name = 'root';
+    formData.children = {something: childData};
+
+    let form = Form.create(formData);
+
+    describe('get property "something"', () => {
+        let element = form.get('something');
+
+        it('should have received "something" ', () => {
+            assert.equal(element.name, 'something');
+        });
+    });
+
+    describe('get property "something.text"', () => {
+        let element = form.get('something.text');
+
+        it('should have received "text" ', () => {
+            assert.equal(element.name, 'text');
+        });
+    });
+});

--- a/assets/node_modules/@enhavo/vue-form/tests/form/ThemeTest.mocha.ts
+++ b/assets/node_modules/@enhavo/vue-form/tests/form/ThemeTest.mocha.ts
@@ -1,0 +1,56 @@
+import {FormData} from "@enhavo/vue-form/data/FormData";
+import {Form} from "@enhavo/vue-form/form/Form";
+import {Theme} from "@enhavo/vue-form/form/Theme";
+const assert = require("chai").assert;
+
+describe('vue-form/form/Theme', () => {
+    let childData = new FormData();
+    childData.rowComponent = 'form-row'
+    childData.component = 'form-text'
+    childData.children = {};
+
+    let formData = new FormData();
+    formData.rowComponent = 'form-row'
+    formData.component = null
+    childData.disabled = true;
+    childData.required = true;
+    formData.children = {text: childData};
+
+    let form = Form.create(formData);
+
+    describe('adding a row component', () => {
+        let theme = new Theme();
+        theme.component('form-row', 'form-row-custom');
+        form.setTheme(theme);
+
+        it('should be changed the row component', () => {
+            assert.equal(form.rowComponent, 'form-row-custom');
+        });
+    });
+
+    describe('adding a component', () => {
+        let theme = new Theme();
+        theme.component('form-text', 'form-custom-text');
+        form.setTheme(theme);
+
+        it('should be changed the child row component', () => {
+            assert.equal(form.children.text.component, 'form-custom-text');
+        });
+    });
+
+    describe('adding two forEach', () => {
+        let theme = new Theme();
+        theme.forEach((data: FormData) => {
+            data.required = false;
+        });
+        theme.forEach((data: FormData) => {
+            data.disabled = false;
+        });
+        form.setTheme(theme);
+
+        it('should be changed the values', () => {
+            assert.strictEqual(form.required, false);
+            assert.strictEqual(form.disabled, false);
+        });
+    });
+});

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,6 +2,9 @@ module.exports = function(config) {
     config.set({
         frameworks: ['mocha', 'chai'],
         files: ['public/build/test/**/*.js'],
+        preprocessors: {
+            '**/*.js': ['sourcemap']
+        },
         reporters: ['progress'],
         port: 9876,
         colors: true,

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-mocha": "^2.0.1",
+    "karma-sourcemap-loader": "^0.3.8",
     "mocha": "^8.0.1",
     "webpack-notifier": "^1.7.0"
   }

--- a/src/Enhavo/Bundle/VueFormBundle/EnhavoVueFormBundle.php
+++ b/src/Enhavo/Bundle/VueFormBundle/EnhavoVueFormBundle.php
@@ -3,6 +3,7 @@
 namespace Enhavo\Bundle\VueFormBundle;
 
 use Enhavo\Bundle\VueFormBundle\DependencyInjection\Compiler\VueTypeCompilerPass;
+use Enhavo\Bundle\VueFormBundle\Form\VueTypeInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -16,7 +17,7 @@ class EnhavoVueFormBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-
         $container->addCompilerPass(new VueTypeCompilerPass());
+        $container->registerForAutoconfiguration(VueTypeInterface::class)->addTag('vue.type');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes
| Backport      | 0.10
| License       | MIT

You can pass now a `Theme` object to `Form` to change components and properties
