### PR TITLE
[AppBundle]Fixed menu hover style not working on menu link with :visited state

### DIFF
--- a/assets/node_modules/@enhavo/app/assets/styles/components/_menu.scss
+++ b/assets/node_modules/@enhavo/app/assets/styles/components/_menu.scss
@@ -72,7 +72,7 @@
   }
 
   .menu-child-title {padding:0 17px;display: flex; align-items: flex-start; justify-content: flex-start;cursor:pointer;min-height:46px;position:relative;
-    &:hover {color:#fff;}
+    &:hover, &:hover:visited {color:#fff;}
     i {
       &.open-indicator {position:absolute;right:18px;}
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

If menu links had the :visited state, the color change on :hover no longer worked. This PR fixes this error.