### PR TITLE
[AppBundle] Fixed entries in list views disappearing based on orderby

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Filter/FilterQuery.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/FilterQuery.php
@@ -251,7 +251,7 @@ class FilterQuery
         $joinPrefixes = $this->createJoinAliases($index, count($joins));
         foreach($joins as $joinProperty) {
             $joinPrefix = array_shift($joinPrefixes);
-            $query->innerJoin(sprintf('%s.%s', $joinPrefix, $joinProperty), $joinPrefixes[0]);
+            $query->leftJoin(sprintf('%s.%s', $joinPrefix, $joinProperty), $joinPrefixes[0]);
         }
         return $joinPrefixes[0];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

Fixed entries in list views disappearing based on orderby due to innerjoin being used in FilterQuery.
