### PR TITLE
Added responsive styles for dropdown actions

### DIFF
--- a/assets/node_modules/@enhavo/app/assets/styles/view.scss
+++ b/assets/node_modules/@enhavo/app/assets/styles/view.scss
@@ -68,3 +68,19 @@
     }
   }
 }
+@media (max-width: 768px) {
+  .app-view {
+    .actions {
+      .action {
+        .dropdown-action-list {
+          .action {padding:8px 15px 8px 5px;
+            .action-icon { margin-right:10px;
+              .icon {font-size:1.25rem;}
+            }
+            .label {line-height:1.5rem;font-size:1rem;}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

Added responsive styles for dropdown actions below 768px screen with. The dropdown menu items were quite small on mobile screens.