### PR TITLE
Remove key from concrete type

### DIFF
--- a/src/Enhavo/Bundle/SettingBundle/Setting/AbstractSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/AbstractSettingType.php
@@ -2,7 +2,6 @@
 
 namespace Enhavo\Bundle\SettingBundle\Setting;
 
-use Enhavo\Bundle\SettingBundle\Model\ValueAccessInterface;
 use Enhavo\Component\Type\AbstractType;
 
 /**
@@ -12,42 +11,42 @@ use Enhavo\Component\Type\AbstractType;
  */
 abstract class AbstractSettingType extends AbstractType implements SettingTypeInterface
 {
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
         if ($this->parent) {
-            return $this->parent->init($options);
+            return $this->parent->init($options, $key);
         }
         return null;
     }
 
-    public function getValue(array $options)
+    public function getValue(array $options, $key = null)
     {
         if ($this->parent) {
-            return $this->parent->getValue($options);;
+            return $this->parent->getValue($options, $key);
         }
         return null;
     }
 
-    public function getFormType(array $options)
+    public function getFormType(array $options, $key = null)
     {
         if ($this->parent) {
-            return $this->parent->getFormType($options);
+            return $this->parent->getFormType($options, $key);
         }
         return null;
     }
 
-    public function getFormTypeOptions(array $options)
+    public function getFormTypeOptions(array $options, $key = null)
     {
         if ($this->parent) {
-            return $this->parent->getFormTypeOptions($options);
+            return $this->parent->getFormTypeOptions($options, $key);
         }
         return [];
     }
 
-    public function getViewValue(array $options, $value)
+    public function getViewValue(array $options, $value, $key = null)
     {
         if ($this->parent) {
-            return $this->parent->getViewValue($options, $value);
+            return $this->parent->getViewValue($options, $value, $key);
         }
         return (string) $value->getValue();
     }

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Setting.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Setting.php
@@ -13,26 +13,26 @@ class Setting extends AbstractContainerType
 {
     public function getValue()
     {
-        return $this->type->getValue($this->options);
+        return $this->type->getValue($this->options, $this->key);
     }
 
     public function init()
     {
-        return $this->type->init($this->options);
+        return $this->type->init($this->options, $this->key);
     }
 
     public function getFormType()
     {
-        return $this->type->getFormType($this->options);
+        return $this->type->getFormType($this->options, $this->key);
     }
 
     public function getFormTypeOptions()
     {
-        return $this->type->getFormTypeOptions($this->options);
+        return $this->type->getFormTypeOptions($this->options, $this->key);
     }
 
     public function getViewValue($value)
     {
-        return $this->type->getViewValue($this->options, $value);
+        return $this->type->getViewValue($this->options, $value, $this->key);
     }
 }

--- a/src/Enhavo/Bundle/SettingBundle/Setting/SettingTypeInterface.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/SettingTypeInterface.php
@@ -11,13 +11,13 @@ use Enhavo\Component\Type\TypeInterface;
  */
 interface SettingTypeInterface extends TypeInterface
 {
-    public function init(array $options);
+    public function init(array $options, $key = null);
 
-    public function getValue(array $options);
+    public function getValue(array $options, $key = null);
 
-    public function getFormType(array $options);
+    public function getFormType(array $options, $key = null);
 
-    public function getFormTypeOptions(array $options);
+    public function getFormTypeOptions(array $options, $key = null);
 
-    public function getViewValue(array $options, $value);
+    public function getViewValue(array $options, $value, $key = null);
 }

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/BaseSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/BaseSettingType.php
@@ -35,37 +35,37 @@ class BaseSettingType extends AbstractSettingType implements SettingTypeInterfac
         $this->em = $em;
     }
 
-    public function getSettingEntity($options): SettingEntity
+    public function getSettingEntity($options, $key): SettingEntity
     {
         /** @var SettingEntity $settingEntity */
-        $settingEntity = $this->repository->findOneBy(['key' => $this->key]);
+        $settingEntity = $this->repository->findOneBy(['key' => $key]);
         if ($settingEntity === null) {
             $settingEntity = $this->factory->createNew();
-            $settingEntity->setKey($this->key);
+            $settingEntity->setKey($key);
             $this->em->persist($settingEntity);
         }
 
-        $settingEntity->setLabel($options['label'] ?? $this->key);
+        $settingEntity->setLabel($options['label'] ?? $key);
         $settingEntity->setTranslationDomain($options['translation_domain']);
         $settingEntity->setGroup($options['group']);
 
         return $settingEntity;
     }
 
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $this->getSettingEntity($options);
+        $this->getSettingEntity($options, $key);
     }
 
-    public function getFormTypeOptions(array $options)
+    public function getFormTypeOptions(array $options, $key = null)
     {
         return [];
     }
 
-    public function getValue(array $options)
+    public function getValue(array $options, $key = null)
     {
         /** @var SettingEntity $settingEntity */
-        $settingEntity = $this->repository->findOneBy(['key' => $this->key]);
+        $settingEntity = $this->repository->findOneBy(['key' => $key]);
 
         if ($settingEntity === null) {
             throw SettingNotExists::entityNotFound();

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/BooleanSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/BooleanSettingType.php
@@ -27,9 +27,9 @@ class BooleanSettingType extends AbstractSettingType
         $this->translator = $translator;
     }
 
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $settingEntity = $this->parent->getSettingEntity($options);
+        $settingEntity = $this->parent->getSettingEntity($options, $key);
 
         if ($settingEntity->getValue() === null) {
             $settingEntity->setValue(new BasicValue(BasicValue::TYPE_BOOLEAN, $settingEntity));
@@ -38,7 +38,7 @@ class BooleanSettingType extends AbstractSettingType
         }
     }
 
-    public function getViewValue(array $options, $value)
+    public function getViewValue(array $options, $value, $key = null)
     {
         if ($value && $value->getValue()) {
             return $this->translator->trans('label.yes', [], 'EnhavoAppBundle');

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/CurrencySettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/CurrencySettingType.php
@@ -26,7 +26,7 @@ class CurrencySettingType extends AbstractSettingType
         return 'currency';
     }
 
-    public function getViewValue(array $options, $value)
+    public function getViewValue(array $options, $value, $key = null)
     {
         return $this->formatter->getCurrency((int)$value->getValue(), $options['currency'], $options['view_position']);
     }

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/DateTimeSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/DateTimeSettingType.php
@@ -14,9 +14,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class DateTimeSettingType extends AbstractSettingType
 {
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $settingEntity = $this->parent->getSettingEntity($options);
+        $settingEntity = $this->parent->getSettingEntity($options, $key);
 
         if ($options['date'] && $options['time']) {
             $type = DateValue::TYPE_DATETIME;
@@ -38,7 +38,7 @@ class DateTimeSettingType extends AbstractSettingType
         }
     }
 
-    public function getViewValue(array $options, $value)
+    public function getViewValue(array $options, $value, $key = null)
     {
         /** @var \DateTime $date */
         $date = $value->getValue();

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/EntitySettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/EntitySettingType.php
@@ -9,12 +9,12 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class EntitySettingType extends AbstractSettingType
 {
-    public function getFormType(array $options)
+    public function getFormType(array $options, $key = null)
     {
         return EntityType::class;
     }
 
-    public function getFormTypeOptions(array $options)
+    public function getFormTypeOptions(array $options, $key = null)
     {
         return [
             'class' => $options['class'],
@@ -23,7 +23,7 @@ class EntitySettingType extends AbstractSettingType
         ];
     }
 
-    public function getViewValue(array $options, $value)
+    public function getViewValue(array $options, $value, $key = null)
     {
         if ($value === null) {
             return '';

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/FloatSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/FloatSettingType.php
@@ -14,9 +14,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FloatSettingType extends AbstractSettingType
 {
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $settingEntity = $this->parent->getSettingEntity($options);
+        $settingEntity = $this->parent->getSettingEntity($options, $key);
 
         if ($settingEntity->getValue() === null) {
             $settingEntity->setValue(new BasicValue(BasicValue::TYPE_FLOAT, $settingEntity));

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/IntegerSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/IntegerSettingType.php
@@ -14,9 +14,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class IntegerSettingType extends AbstractSettingType
 {
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $settingEntity = $this->parent->getSettingEntity($options);
+        $settingEntity = $this->parent->getSettingEntity($options, $key);
 
         if ($settingEntity->getValue() === null) {
             $settingEntity->setValue(new BasicValue(BasicValue::TYPE_INT, $settingEntity));

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/MediaSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/MediaSettingType.php
@@ -29,9 +29,9 @@ class MediaSettingType extends AbstractSettingType
         $this->fileFactory = $fileFactory;
     }
 
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $settingEntity = $this->parent->getSettingEntity($options);
+        $settingEntity = $this->parent->getSettingEntity($options, $key);
 
         if ($settingEntity->getValue() === null) {
             $settingEntity->setValue(new MediaValue($options['multiple'], $settingEntity));
@@ -50,7 +50,7 @@ class MediaSettingType extends AbstractSettingType
         }
     }
 
-    public function getViewValue(array $options, $value)
+    public function getViewValue(array $options, $value, $key = null)
     {
         if ($options['multiple']) {
             $data = [];

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/ParameterSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/ParameterSettingType.php
@@ -10,12 +10,12 @@ class ParameterSettingType extends AbstractSettingType
 {
     use ContainerAwareTrait;
 
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
         // nothing to do here
     }
 
-    public function getValue(array $options)
+    public function getValue(array $options, $key = null)
     {
         return $this->container->getParameter($options['key']);
     }

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/StringSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/StringSettingType.php
@@ -14,9 +14,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class StringSettingType extends AbstractSettingType
 {
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $settingEntity = $this->parent->getSettingEntity($options);
+        $settingEntity = $this->parent->getSettingEntity($options, $key);
 
         if ($settingEntity->getValue() === null) {
             $settingEntity->setValue(new BasicValue(BasicValue::TYPE_VARCHAR, $settingEntity));

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/TextSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/TextSettingType.php
@@ -15,9 +15,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TextSettingType extends AbstractSettingType
 {
-    public function init(array $options)
+    public function init(array $options, $key = null)
     {
-        $settingEntity = $this->parent->getSettingEntity($options);
+        $settingEntity = $this->parent->getSettingEntity($options, $key);
 
         if ($settingEntity->getValue() === null) {
             $settingEntity->setValue(new TextValue($settingEntity));
@@ -28,7 +28,7 @@ class TextSettingType extends AbstractSettingType
         }
     }
 
-    public function getViewValue(array $options, $value)
+    public function getViewValue(array $options, $value, $key = null)
     {
         return strip_tags($value->getValue());
     }

--- a/src/Enhavo/Bundle/SettingBundle/Setting/Type/ValueAccessSettingType.php
+++ b/src/Enhavo/Bundle/SettingBundle/Setting/Type/ValueAccessSettingType.php
@@ -14,23 +14,23 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class ValueAccessSettingType extends AbstractSettingType
 {
-    public function getSettingEntity($options)
+    public function getSettingEntity($options, $key)
     {
-        return $this->parent->getSettingEntity($options);
+        return $this->parent->getSettingEntity($options, $key);
     }
 
-    public function getValue(array $options)
+    public function getValue(array $options, $key = null)
     {
-        $value = $this->parent->getValue($options);
+        $value = $this->parent->getValue($options, $key);
         return $value->getValue();
     }
 
-    public function getFormType(array $options)
+    public function getFormType(array $options, $key = null)
     {
         return ValueAccessType::class;
     }
 
-    public function getFormTypeOptions(array $options)
+    public function getFormTypeOptions(array $options, $key = null)
     {
         return [
             'form_type' => $options['form_type'],

--- a/src/Enhavo/Bundle/SettingBundle/Tests/Setting/SettingManagerTest.php
+++ b/src/Enhavo/Bundle/SettingBundle/Tests/Setting/SettingManagerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Enhavo\Bundle\SettingBundle\Tests\Setting;
+
+use Enhavo\Bundle\SettingBundle\Setting\Setting;
+use Enhavo\Bundle\SettingBundle\Setting\SettingManager;
+use Enhavo\Component\Type\FactoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SettingManagerTest extends TestCase
+{
+    public function createDependencies()
+    {
+        $dependencies = new SettingManagerDependencies();
+        $dependencies->factory = $this->getMockBuilder(FactoryInterface::class)->getMock();
+        $dependencies->settingConfig = [];
+        return $dependencies;
+    }
+
+    public function createInstance(SettingManagerDependencies $dependencies)
+    {
+        $instance = new SettingManager($dependencies->factory, $dependencies->settingConfig);
+        return $instance;
+    }
+
+    public function testGetters()
+    {
+        $dependencies = $this->createDependencies();
+        $dependencies->factory->method('create')->willReturnCallback(function($config, $key) {
+            $setting = new SettingMock();
+            $setting->key = $key;
+            $setting->config = $config;
+            return $setting;
+        });
+        $dependencies->settingConfig = [
+            'my-setting' => [
+                'type' => 'something',
+                'value' => 'hello',
+                'form_type' => 'hello_form',
+                'form_type_options' => 'hello_options',
+                'view_value' => 'hello_view'
+            ],
+            'other-setting' => [
+                'type' => 'foobar',
+                'value' => 'world'
+            ]
+        ];
+
+        $manager = $this->createInstance($dependencies);
+
+        /** @var SettingMock $setting */
+        $setting = $manager->getSetting('my-setting');
+        $this->assertEquals('my-setting', $setting->key);
+        $this->assertArrayHasKey('type', $setting->config);
+        $this->assertEquals('something', $setting->config['type']);
+
+        $this->assertEquals('hello', $manager->getValue('my-setting'));
+        $this->assertEquals('world', $manager->getValue('other-setting'));
+        $this->assertEquals('hello', $manager->getValue('my-setting'), 'Test caching');
+
+        $this->assertEquals('hello_form', $manager->getFormType('my-setting'));
+        $this->assertEquals('hello_options', $manager->getFormTypeOptions('my-setting'));
+        $this->assertEquals('hello_view', $manager->getViewValue('my-setting', null));
+    }
+
+    public function testKeyNotFoundException()
+    {
+        $dependencies = $this->createDependencies();
+        $dependencies->settingConfig = [
+            // empty
+        ];
+
+        $manager = $this->createInstance($dependencies);
+
+        $this->expectException('Enhavo\Bundle\SettingBundle\Exception\SettingNotExists');
+        $manager->getSetting('something');
+    }
+}
+
+class SettingManagerDependencies
+{
+    /** @var FactoryInterface|MockObject */
+    public $factory;
+    /** @var array */
+    public $settingConfig;
+}
+
+class SettingMock extends Setting
+{
+    public $key;
+    public $config;
+
+    public function __construct() {}
+
+    public function getValue()
+    {
+        return $this->config['value'];
+    }
+
+    public function getFormType()
+    {
+        return $this->config['form_type'];
+    }
+
+    public function getFormTypeOptions()
+    {
+        return $this->config['form_type_options'];
+    }
+
+    public function getViewValue($value)
+    {
+        return $this->config['view_value'];
+    }
+}

--- a/src/Enhavo/Component/Type/AbstractContainerType.php
+++ b/src/Enhavo/Component/Type/AbstractContainerType.php
@@ -40,10 +40,8 @@ abstract class AbstractContainerType
 
         $resolver = new OptionsResolver();
         foreach($this->parents as $parent) {
-            $parent->setKey($key);
             $parent->configureOptions($resolver);
         }
-        $this->type->setKey($key);
         $this->type->configureOptions($resolver);
 
         $this->options = $resolver->resolve($options);

--- a/src/Enhavo/Component/Type/AbstractType.php
+++ b/src/Enhavo/Component/Type/AbstractType.php
@@ -15,9 +15,6 @@ class AbstractType implements TypeInterface
     /** @var self|null */
     protected $parent;
 
-    /** @var string|null */
-    protected $key;
-
     public function setParent(TypeInterface $parent)
     {
         $this->parent = $parent;
@@ -31,14 +28,6 @@ class AbstractType implements TypeInterface
     public static function getName(): ?string
     {
         return null;
-    }
-
-    /**
-     * @param string|null $key
-     */
-    public function setKey(?string $key): void
-    {
-        $this->key = $key;
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Enhavo/Component/Type/TypeInterface.php
+++ b/src/Enhavo/Component/Type/TypeInterface.php
@@ -32,11 +32,6 @@ interface TypeInterface
     public function setParent(TypeInterface $parent);
 
     /**
-     * @param $key string|null
-     */
-    public function setKey(?string $key);
-
-    /**
      * @param OptionsResolver $resolver
      */
     public function configureOptions(OptionsResolver $resolver);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Doc PR?       | no
| Backport      | 0.10
| License       | MIT

The `key` in a type shouldn't be a property, because the type exists only once, while a container holding a type can exists more often with different keys, so we are not able to provide a key inside a type.