### PR TITLE
Fix media twig function accept null

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Twig/MediaExtension.php
+++ b/src/Enhavo/Bundle/MediaBundle/Twig/MediaExtension.php
@@ -84,23 +84,39 @@ class MediaExtension extends AbstractExtension
         }
     }
 
-    public function getMediaFilename(File $file)
+    public function getMediaFilename(?File $file)
     {
+        if($file === null) {
+            return '';
+        }
+
         return $file->getFilename();
     }
 
-    public function getMediaParameter(File $file, $parameterName)
+    public function getMediaParameter(?File $file, $parameterName)
     {
+        if($file === null) {
+            return '';
+        }
+
         return $file->getParameter($parameterName);
     }
 
-    public function getMediaExtension(File $file)
+    public function getMediaExtension(?File $file)
     {
+        if($file === null) {
+            return '';
+        }
+
         return strtolower($file->getExtension());
     }
 
-    public function isPicture(File $file)
+    public function isPicture(?File $file)
     {
+        if($file === null) {
+            return false;
+        }
+
         if($this->getMediaExtension($file) == 'jpg' || $this->getMediaExtension($file) == 'jpeg' || $this->getMediaExtension($file) == 'png' || $this->getMediaExtension($file) == 'gif'){
             return true;
         }
@@ -130,4 +146,4 @@ class MediaExtension extends AbstractExtension
         }
         return null;
     }
-} 
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9, 0.10
| License       | MIT

Twig function like `media_parameter` should accept `null` as file and return empty string like `media_url` does. This helps to keep the twig code more clean, instead of adding `if` cases all the time