### PR TITLE
[ContentBundle] Added missing translation

### DIFF
--- a/src/Enhavo/Bundle/ContentBundle/Resources/translations/EnhavoContentBundle.de.yaml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/translations/EnhavoContentBundle.de.yaml
@@ -8,6 +8,7 @@ form:
   label:
     title: 'Titel'
     meta_description: 'Meta Description'
+    canonical_url: 'Canonical Url'
     page_title: 'Seiten Titel'
     public: 'Öffentlich'
     no_index: 'Robots NOINDEX'

--- a/src/Enhavo/Bundle/ContentBundle/Resources/translations/EnhavoContentBundle.en.yaml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/translations/EnhavoContentBundle.en.yaml
@@ -8,6 +8,7 @@ form:
   label:
     title: 'Title'
     meta_description: 'Meta Description'
+    canonical_url: 'Canonical Url'
     page_title: 'Page Title'
     public: 'Public'
     no_index: 'Robots NOINDEX'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

There was a missing translation for form.label.canonical_url in ContentBundle. Added one.