### PR TITLE
Fix wrong translation reference

### DIFF
--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/Tests/EventListener/ReferenceSubscriberTest.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/Tests/EventListener/ReferenceSubscriberTest.php
@@ -51,14 +51,17 @@ class ReferenceSubscriberTest extends SubscriberTest
         $this->em->getEventManager()->addEventSubscriber($subscriber);
         $this->updateSchema();
 
-        $entityContainer = new EntityContainer();
-        $entityContainer->setName('container_one');
         $node = new NodeOne();
         $node->setName('one');
+
         $entity = new Entity();
         $entity->setName('node_one');
         $entity->setNode($node);
+
+        $entityContainer = new EntityContainer();
+        $entityContainer->setName('container_one');
         $entityContainer->setEntity($entity);
+
         $this->em->persist($entityContainer);
         $this->em->flush();
         $this->em->clear();
@@ -89,6 +92,44 @@ class ReferenceSubscriberTest extends SubscriberTest
 
         $this->em->clear();
         unset($entity);
+    }
+
+    public function testReferenceSameObject()
+    {
+        $this->bootstrap(__DIR__ . "/../Fixtures/Entity/Reference");
+
+        $dependencies = $this->createDependencies([
+            Entity::class => [
+                'reference' => [
+                    'node' => [
+                        'nameField' => 'nodeName',
+                        'idField' => 'nodeId'
+                    ]
+                ]
+            ]
+        ]);
+
+        $subscriber = $this->createInstance($dependencies);
+        $this->em->getEventManager()->addEventSubscriber($subscriber);
+        $this->updateSchema();
+
+        $node = new NodeOne();
+        $node->setName('same');
+
+        $entityOne = new Entity();
+        $entityOne->setName('entity_one');
+        $entityOne->setNode($node);
+
+        $entityTwo = new Entity();
+        $entityTwo->setName('entity_two');
+        $entityTwo->setNode($node);
+
+        $this->em->persist($entityOne);
+        $this->em->persist($entityTwo);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertCount(1, $this->em->getRepository(NodeOne::class)->findAll());
     }
 }
 

--- a/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
@@ -43,14 +43,21 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
 
         // If the data is null but we have a data_class, we have to create it here,
         // because the translator can only work on concrete objects.
-        // To wait until the form create the data is to late,
+        // To wait until the form create the data is too late,
         // we need the data already in the TranslationType children.
+        $setData = false;
         if ($data === null) {
+            $setData = true;
             $data = new $dataClass;
         }
 
         if (!$this->translationManager->isTranslatable($data)) {
             return;
+        }
+
+        // To prevent side effects we only setData in the form if necessary
+        if ($setData) {
+            $form->setData($data);
         }
 
         foreach ($form->all() as $property => $child) {

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Form/Type/TranslationTypeTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Form/Type/TranslationTypeTest.php
@@ -109,6 +109,36 @@ class TranslationTypeTest extends TypeTestCase
         $this->assertEquals('Hello', $form->getData()->getText());
     }
 
+    public function testSameReferenceForSubmitAndTranslationData()
+    {
+        $this->translationManager->method('isTranslation')->willReturn(true);
+        $this->translationManager->method('isEnabled')->willReturn(true);
+        $this->translationManager->method('isTranslatable')->willReturnCallback(function ($dataClass) {
+            return $dataClass instanceof MockTranslationModel || $dataClass === MockTranslationModel::class;
+        });
+        $this->translationManager->method('getLocales')->willReturn(['en', 'de']);
+        $this->translationManager->method('getDefaultLocale')->willReturn('en');
+        $this->translationManager->method('getTranslations')->willReturn([]);
+
+        $translationData = null;
+        $this->translationManager->method('setTranslation')->willReturnCallback(function($data, $property, $locale, $value) use (&$translationData) {
+            $translationData = $data;
+        });
+
+        $form = $this->factory->create(MockTranslationFormType::class);
+
+        $form->submit([
+            'text' => [
+                'en' => 'Hello',
+                'de' => 'Hallo'
+            ]
+        ]);
+
+        $formData = $form->getData();
+
+        $this->assertTrue($translationData === $formData);
+    }
+
     public function testView()
     {
         $this->translationManager->method('getLocales')->willReturn(['en', 'de']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9, 0.10
| License       | MIT

After saving translation for block entities, the references of the form was not the same as the translation reference, this leads to duplicate block entities and messed up translations.