### PR TITLE
Fix media deadlock and improve error output

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
@@ -129,6 +129,12 @@ class FileController extends ResourceController
      */
     private function getResponse($file): Response
     {
+        $path = $file->getContent()->getFilePath();
+
+        if (!file_exists($path))  {
+            throw $this->createNotFoundException('File not exists, please refresh format');
+        }
+
         $fileSize = filesize($file->getContent()->getFilePath());
         if (!$this->getStreamingDisabled() && $this->getStreamingThreshold() < $fileSize) {
             $response = new StreamedResponse(function () use ($file) {

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/BackgroundFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/BackgroundFilter.php
@@ -23,15 +23,10 @@ class BackgroundFilter extends AbstractFilter
     {
         $content = $this->getContent($file);
 
-        try {
-            $imagine = new Imagine();
-            $imagine = $imagine->load($content->getContent());
-            $imagine = $this->format($imagine, $setting);
-            $imagine->save($content->getFilePath(), array('format' => $setting->getSetting('format')));
-        } catch (RuntimeException $e) {
-            // if image cant be created we make an empty file
-            file_put_contents($content->getFilePath(), '');
-        }
+        $imagine = new Imagine();
+        $imagine = $imagine->load($content->getContent());
+        $imagine = $this->format($imagine, $setting);
+        $imagine->save($content->getFilePath(), array('format' => $setting->getSetting('format')));
     }
 
     public function format(ImageInterface $image, FilterSetting $setting)

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageBlurFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageBlurFilter.php
@@ -18,22 +18,18 @@ class ImageBlurFilter extends AbstractFilter
     public function apply($file, FilterSetting $setting)
     {
         $content = $this->getContent($file);
-        try {
-            if(class_exists('\\Imagick')) {
-                $image = new \Imagick($content->getFilePath());
-                $image->blurImage($setting->getSetting('radius', 5), $setting->getSetting('sigma', 3));
-                file_put_contents($content->getFilePath(), $image);
-            } else {
-                $imagine = new Imagine();
-                $imagine = $imagine->load($content->getContent());
-                $imagine->effects()->blur($setting->getSetting('sigma', 3));
-                $imagine->save($content->getFilePath(), [
-                    'format' => $this->getImageFormat($content)
-                ]);
-            }
-        } catch (RuntimeException $e) {
-            // if image cant be created we make an empty file
-            file_put_contents($content->getFilePath(), '');
+
+        if(class_exists('\\Imagick')) {
+            $image = new \Imagick($content->getFilePath());
+            $image->blurImage($setting->getSetting('radius', 5), $setting->getSetting('sigma', 3));
+            file_put_contents($content->getFilePath(), $image);
+        } else {
+            $imagine = new Imagine();
+            $imagine = $imagine->load($content->getContent());
+            $imagine->effects()->blur($setting->getSetting('sigma', 3));
+            $imagine->save($content->getFilePath(), [
+                'format' => $this->getImageFormat($content)
+            ]);
         }
     }
 

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageFilter.php
@@ -31,40 +31,37 @@ class ImageFilter extends AbstractFilter
     {
         $content = $this->getContent($file);
 
-        try {
-            $format = $this->getFormat($content, $setting);
-            if($format == 'gif' && class_exists('Imagick') && $this->isAnimatedGif($content->getContent())) {
-                $imagine = new ImagickImagine();
-                $image = $imagine->load($content->getContent());
-                $image->layers()->coalesce();
-                $resultImage = $image->copy();
-                $resultImage = $this->resize($resultImage, $setting);
-                $options = $this->getSaveOptions($format, $setting);
-                $options['animated'] = true;
-                $resultImage->save($content->getFilePath(), $options);
-            } elseif($format == 'bmp' && class_exists('Imagick') ) {
-                $imagine = new ImagickImagine();
-                $image = $imagine->load($content->getContent());
-                $resultImage = $image->copy();
-                $resultImage = $this->resize($resultImage, $setting);
-                $resultImage->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
-            } elseif(class_exists('Imagick') ) {
-                $imagine = new ImagickImagine();
-                $imagine = $imagine->load($content->getContent());
-                $imagine = $this->resize($imagine, $setting);
-                $imagine->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
-            } else {
-                $imagine = new Imagine();
-                $imagine = $imagine->load($content->getContent());
-                $imagine = $this->resize($imagine, $setting);
-                $imagine->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
-            }
-            $this->setMimeType($file, $this->getMimeTypeFromImageFormat($format));
-            $this->setExtension($file, $format);
-        } catch (RuntimeException $e) {
-            // if image cant be created we make an empty file
-            file_put_contents($content->getFilePath(), '');
+        $format = $this->getFormat($content, $setting);
+
+        if ($format == 'gif' && class_exists('Imagick') && $this->isAnimatedGif($content->getContent())) {
+            $imagine = new ImagickImagine();
+            $image = $imagine->load($content->getContent());
+            $image->layers()->coalesce();
+            $resultImage = $image->copy();
+            $resultImage = $this->resize($resultImage, $setting);
+            $options = $this->getSaveOptions($format, $setting);
+            $options['animated'] = true;
+            $resultImage->save($content->getFilePath(), $options);
+        } elseif($format == 'bmp' && class_exists('Imagick') ) {
+            $imagine = new ImagickImagine();
+            $image = $imagine->load($content->getContent());
+            $resultImage = $image->copy();
+            $resultImage = $this->resize($resultImage, $setting);
+            $resultImage->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
+        } elseif(class_exists('Imagick') ) {
+            $imagine = new ImagickImagine();
+            $imagine = $imagine->load($content->getContent());
+            $imagine = $this->resize($imagine, $setting);
+            $imagine->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
+        } else {
+            $imagine = new Imagine();
+            $imagine = $imagine->load($content->getContent());
+            $imagine = $this->resize($imagine, $setting);
+            $imagine->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
         }
+
+        $this->setMimeType($file, $this->getMimeTypeFromImageFormat($format));
+        $this->setExtension($file, $format);
     }
 
     /**
@@ -238,7 +235,7 @@ class ImageFilter extends AbstractFilter
         }
         $newImage = $imagine->create(new Box($width, $height), $backgroundColor);
         $newImage->resize(new Box($width, $height));
-        
+
         $size = $image->getSize();
         if($size->getHeight() !== $height) {
             $y =  intval($height / 2) - intval($size->getHeight() / 2);

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageZoomFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageZoomFilter.php
@@ -20,24 +20,19 @@ class ImageZoomFilter extends AbstractFilter
     {
         $content = $this->getContent($file);
 
-        try {
-            $imagine = new Imagine();
-            $imagine = $imagine->load($content->getContent());
-            $factor = $setting->getSetting('zoom', 1);
+        $imagine = new Imagine();
+        $imagine = $imagine->load($content->getContent());
+        $factor = $setting->getSetting('zoom', 1);
 
-            $size = $imagine->getSize();
-            $height = intval(round($size->getHeight()*$factor));
-            $width =  intval(round($size->getWidth()*$factor));
+        $size = $imagine->getSize();
+        $height = intval(round($size->getHeight()*$factor));
+        $width =  intval(round($size->getWidth()*$factor));
 
-            $imagine->resize(new Box($width, $height));
+        $imagine->resize(new Box($width, $height));
 
-            $imagine->save($content->getFilePath(), [
-                'format' => $this->getImageFormat($content)
-            ]);
-        } catch (RuntimeException $e) {
-            // if image cant be created we make an empty file
-            file_put_contents($content->getFilePath(), '');
-        }
+        $imagine->save($content->getFilePath(), [
+            'format' => $this->getImageFormat($content)
+        ]);
     }
 
     public function getType()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9, 0.10
| License       | MIT

Fix deadlock, which occurred when creating a format and an error was thrown. Also improve error message and avoid create empty files on error.