### PR TITLE
put context to namespaces to avoid overlapping

### DIFF
--- a/src/Enhavo/Bundle/NewsletterBundle/EnhavoNewsletterBundle.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/EnhavoNewsletterBundle.php
@@ -14,10 +14,10 @@ class EnhavoNewsletterBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(
-            new TypeCompilerPass('Storage', 'enhavo_newsletter.storage', Storage::class)
+            new TypeCompilerPass('NewsletterStorage', 'enhavo_newsletter.storage', Storage::class)
         );
         $container->addCompilerPass(
-            new TypeCompilerPass('Strategy', 'enhavo_newsletter.strategy', Strategy::class)
+            new TypeCompilerPass('NewsletterStrategy', 'enhavo_newsletter.strategy', Strategy::class)
         );
         $container->addCompilerPass(new ProviderCompilerPass());
     }

--- a/src/Enhavo/Bundle/NewsletterBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/NewsletterBundle/Resources/config/services/services.yaml
@@ -119,8 +119,8 @@ services:
     Enhavo\Bundle\NewsletterBundle\Subscription\SubscriptionManager:
         public: true
         arguments:
-            - '@Enhavo\Component\Type\FactoryInterface[Storage]'
-            - '@Enhavo\Component\Type\FactoryInterface[Strategy]'
+            - '@Enhavo\Component\Type\FactoryInterface[NewsletterStorage]'
+            - '@Enhavo\Component\Type\FactoryInterface[NewsletterStrategy]'
             - '@form.factory'
             - '@event_dispatcher'
             - '%enhavo_newsletter.subscription%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.10 <!-- choose version where this PR should apply as well -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

<!--
namespaces in typcompiler passes already overlapped with backup-bundle. to avoid all type of overlapping in the future rename to NewsletterStorage etc.
-->
