### PR TITLE
Fix newsletter created at

### DIFF
--- a/src/Enhavo/Bundle/NewsletterBundle/EventListener/NewsletterSubscriber.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/EventListener/NewsletterSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Enhavo\Bundle\NewsletterBundle\EventListener;
+
+use Enhavo\Bundle\NewsletterBundle\Model\NewsletterInterface;
+use Enhavo\Bundle\NewsletterBundle\Newsletter\NewsletterManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+
+class NewsletterSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var NewsletterManager
+     */
+    private $newsletterManager;
+
+    /**
+     * NewsletterSubscriber constructor.
+     * @param NewsletterManager $newsletterManager
+     */
+    public function __construct(NewsletterManager $newsletterManager)
+    {
+        $this->newsletterManager = $newsletterManager;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'enhavo_newsletter.newsletter.pre_create' => 'preSave',
+            'enhavo_newsletter.newsletter.pre_update' => 'preSave'
+        );
+    }
+
+    public function preSave(ResourceControllerEvent $event)
+    {
+        $resource = $event->getSubject();
+        if($resource instanceof NewsletterInterface) {
+            $this->newsletterManager->update($resource);
+        }
+    }
+}

--- a/src/Enhavo/Bundle/NewsletterBundle/Model/NewsletterInterface.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Model/NewsletterInterface.php
@@ -157,4 +157,14 @@ interface NewsletterInterface
      * @param \DateTime|null $finishAt
      */
     public function setFinishAt(?\DateTime $finishAt): void;
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getCreatedAt(): ?\DateTime;
+
+    /**
+     * @param \DateTime|null $createdAt
+     */
+    public function setCreatedAt(?\DateTime $createdAt): void;
 }

--- a/src/Enhavo/Bundle/NewsletterBundle/Newsletter/NewsletterManager.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Newsletter/NewsletterManager.php
@@ -259,4 +259,11 @@ class NewsletterManager
         }
         return $this->templates[$key]['template'];
     }
+
+    public function update(NewsletterInterface $newsletter)
+    {
+        if ($newsletter->getCreatedAt() === null) {
+            $newsletter->setCreatedAt(new \DateTime());
+        }
+    }
 }

--- a/src/Enhavo/Bundle/NewsletterBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/NewsletterBundle/Resources/config/services/services.yaml
@@ -147,3 +147,10 @@ services:
     Enhavo\Bundle\NewsletterBundle\Provider\GroupProvider:
         arguments:
             - '%enhavo_newsletter.newsletter.test_receiver%'
+
+    Enhavo\Bundle\NewsletterBundle\EventListener\NewsletterSubscriber:
+        class:
+        arguments:
+            - '@Enhavo\Bundle\NewsletterBundle\Newsletter\NewsletterManager'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Enhavo/Bundle/NewsletterBundle/Tests/Storage/LocalTypeStorageTest.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Tests/Storage/LocalTypeStorageTest.php
@@ -339,6 +339,16 @@ class NotNewsletter implements NewsletterInterface
     {
 
     }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): void
+    {
+
+    }
 }
 
 class LocalTypeStorageTestDependencies


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.10
| License       | MIT

Set `createdAt` date if newsletter was created
