### PR TITLE
Fix delete and create node

### DIFF
--- a/src/Enhavo/Bundle/BlockBundle/Resources/config/doctrine/Node.orm.xml
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/config/doctrine/Node.orm.xml
@@ -26,6 +26,9 @@
         </one-to-many>
 
         <many-to-one field="parent" target-entity="Enhavo\Bundle\BlockBundle\Model\NodeInterface" inversed-by="children">
+            <cascade>
+                <cascade-persist />
+            </cascade>
             <join-column on-delete="CASCADE" />
         </many-to-one>
 

--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceChange.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceChange.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Enhavo\Bundle\DoctrineExtensionBundle\EventListener;
+
+class ReferenceChange
+{
+    /** @var object */
+    private $entity;
+
+    /** @var string */
+    private $property;
+
+    /** @var mixed */
+    private $value;
+
+    /**
+     * ReferenceChange constructor.
+     * @param object $entity
+     * @param string $property
+     * @param mixed $value
+     */
+    public function __construct(object $entity, string $property, $value)
+    {
+        $this->entity = $entity;
+        $this->property = $property;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @return object
+     */
+    public function getEntity(): object
+    {
+        return $this->entity;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
@@ -11,6 +11,7 @@ namespace Enhavo\Bundle\DoctrineExtensionBundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Events;
@@ -130,63 +131,74 @@ class ReferenceSubscriber implements EventSubscriber
     }
 
     /**
-     * Update entity before flush to prevent a possible after flush
+     * Update entity before flush to prevent possible changes after flush
      *
      * @param PreFlushEventArgs $args
      */
     public function preFlush(PreFlushEventArgs $args)
     {
         $uow = $args->getEntityManager()->getUnitOfWork();
-        $result = $uow->getIdentityMap();
+        $em = $args->getEntityManager();
+        $identityMap = $uow->getIdentityMap();
 
-        foreach($this->getAllMetadata() as $metadata) {
-            if(isset($result[$metadata->getClassName()])) {
-                foreach ($result[$metadata->getClassName()] as $entity) {
-                    foreach($metadata->getReferences() as $reference) {
+        foreach ($this->getAllMetadata() as $metadata) {
+            if (isset($identityMap[$metadata->getClassName()])) {
+                foreach ($identityMap[$metadata->getClassName()] as $entity) {
+                    foreach ($metadata->getReferences() as $reference) {
                         $this->updateEntity($reference, $entity);
+                        $this->updatePersist($reference, $entity, $em);
                     }
+                }
+            }
 
+            foreach ($uow->getScheduledEntityInsertions() as $entity) {
+                if (get_class($entity) === $metadata->getClassName()) {
+                    foreach ($metadata->getReferences() as $reference) {
+                        $this->updateEntity($reference, $entity);
+                        $this->updatePersist($reference, $entity, $em);
+                    }
                 }
             }
         }
     }
 
+    private function updatePersist(Reference $reference, $entity, EntityManagerInterface $em)
+    {
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $targetProperty = $propertyAccessor->getValue($entity, $reference->getProperty());
+
+        if($targetProperty && $em->getUnitOfWork()->getEntityState($targetProperty) !== UnitOfWork::STATE_MANAGED) {
+            $em->persist($targetProperty);
+        }
+    }
+
     /**
-     * Check if entity is not up to date an trigger flush again if needed
+     * Check if entity is not up to date and execute changes
      *
      * @param PostFlushEventArgs $args
      */
     public function postFlush(PostFlushEventArgs $args)
     {
-        $change = false;
-
-        $em = $args->getEntityManager();
         $uow = $args->getEntityManager()->getUnitOfWork();
         $result = $uow->getIdentityMap();
 
-        foreach($this->getAllMetadata() as $metadata) {
-            if(isset($result[$metadata->getClassName()])) {
+        $changes = [];
+
+        foreach ($this->getAllMetadata() as $metadata) {
+            if (isset($result[$metadata->getClassName()])) {
                 foreach ($result[$metadata->getClassName()] as $entity) {
-                    foreach($metadata->getReferences() as $reference) {
-                        $updated = $this->updateEntity($reference, $entity);
-                        if($updated) {
-                            $change = true;
-                        }
-
-                        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-                        $targetProperty = $propertyAccessor->getValue($entity, $reference->getProperty());
-
-                        if($targetProperty && $uow->getEntityState($targetProperty) !== UnitOfWork::STATE_MANAGED) {
-                            $em->persist($targetProperty);
-                            $change = true;
+                    foreach ($metadata->getReferences() as $reference) {
+                        $entityChanges = $this->updateEntity($reference, $entity);
+                        foreach ($entityChanges as $entityChange) {
+                            $changes[] = $entityChange;
                         }
                     }
                 }
             }
         }
 
-        if($change) {
-            $em->flush();
+        if (count($changes)) {
+            $this->executeChanges($changes, $args->getEntityManager());
         }
     }
 
@@ -195,49 +207,72 @@ class ReferenceSubscriber implements EventSubscriber
      *
      * @param Reference $reference
      * @param object $entity
-     * @return boolean
+     * @return ReferenceChange[]
      */
     private function updateEntity(Reference $reference, $entity)
     {
-        $change = false;
+        $changes = [];
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $targetProperty = $propertyAccessor->getValue($entity, $reference->getProperty());
 
         // if entity state is still proxy, we try to load its entity to make sure that target property is correct
-        if($entity instanceof Proxy && $targetProperty === null) {
+        if ($entity instanceof Proxy && $targetProperty === null) {
             $this->loadEntity($reference, $entity);
             $targetProperty = $propertyAccessor->getValue($entity, $reference->getProperty());
         }
 
-        if($targetProperty) {
+        if ($targetProperty) {
             // update id property
             $idProperty = $propertyAccessor->getValue($entity, $reference->getIdField());
             $id = $propertyAccessor->getValue($targetProperty, 'id');
             if($idProperty != $id) {
                 $propertyAccessor->setValue($entity, $reference->getIdField(), $id);
-                $change = true;
+                $changes[] = new ReferenceChange($entity, $reference->getIdField(), $id);
             }
 
             // update class property
             $classProperty = $propertyAccessor->getValue($entity, $reference->getNameField());
             $class = $this->entityResolver->getName($targetProperty);
-            if($classProperty != $class) {
+            if ($classProperty != $class) {
                 $propertyAccessor->setValue($entity, $reference->getNameField(), $class);
-                $change = true;
+                $changes[] = new ReferenceChange($entity, $reference->getNameField(), $class);
             }
         } else {
-            if(null !== $propertyAccessor->getValue($entity, $reference->getIdField())) {
+            if (null !== $propertyAccessor->getValue($entity, $reference->getIdField())) {
                 $propertyAccessor->setValue($entity, $reference->getIdField(), null);
-                $change = true;
+                $changes[] = new ReferenceChange($entity, $reference->getIdField(), null);
             }
 
-            if(null !== $propertyAccessor->getValue($entity, $reference->getNameField())) {
+            if (null !== $propertyAccessor->getValue($entity, $reference->getNameField())) {
                 $propertyAccessor->setValue($entity, $reference->getNameField(), null);
-                $change = true;
+                $changes[] = new ReferenceChange($entity, $reference->getNameField(), null);
             }
         }
 
-        return $change;
+        return $changes;
+    }
+
+    /**
+     * @param ReferenceChange[] $changes
+     * @param EntityManagerInterface $em
+     */
+    private function executeChanges($changes, EntityManagerInterface $em)
+    {
+        $queries = [];
+        foreach ($changes as $change) {
+            $query = $em->createQueryBuilder()
+                ->update(get_class($change->getEntity()), 'e')
+                ->set(sprintf('e.%s', $change->getProperty()), ':value')
+                ->setParameter('value', $change->getValue())
+                ->getQuery()
+            ;
+
+            $queries[] = $query;
+        }
+
+        foreach ($queries as $query) {
+            $query->execute();
+        }
     }
 }

--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
@@ -260,6 +260,7 @@ class ReferenceSubscriber implements EventSubscriber
     private function executeChanges($changes, EntityManagerInterface $em)
     {
         $queries = [];
+        $entities = [];
         foreach ($changes as $change) {
             $query = $em->createQueryBuilder()
                 ->update(get_class($change->getEntity()), 'e')
@@ -269,10 +270,18 @@ class ReferenceSubscriber implements EventSubscriber
             ;
 
             $queries[] = $query;
+
+            if (!in_array($change->getEntity(), $entities)) {
+                $entities[] = $change->getEntity();
+            }
         }
 
         foreach ($queries as $query) {
             $query->execute();
+        }
+
+        foreach ($entities as $entity) {
+            $em->refresh($entity);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Backport      | 0.9, 0.10
| License       | MIT

When deleting and add a block node in the same request, the `ReferenceListener` call the flush multiple times. That leads to a doctrine dirty entity exception. The `postFlush` is triggered before doctrine cleanup all his temporarily metadata. I guess this a problem, so now we track the changes and execute them separate without a doctrine flush routine.

