### PR TITLE
Fix persist

### DIFF
--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/Tests/Fixtures/Entity/Reference/NodeContainer.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/Tests/Fixtures/Entity/Reference/NodeContainer.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: gseidel
+ * Date: 2020-06-12
+ * Time: 16:02
+ */
+
+namespace Enhavo\Bundle\DoctrineExtensionBundle\Tests\Fixtures\Entity\Reference;
+
+
+/**
+ * @Entity
+ */
+class NodeContainer implements NodeInterface
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @Column(type="string", length=255, nullable=true)
+     */
+    private $name;
+
+    /**
+     * @ManyToOne(targetEntity="Entity", cascade={"all"})
+     */
+    private $entity;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getEntity()
+    {
+        return $this->entity;
+    }
+
+    public function setEntity($entity): void
+    {
+        $this->entity = $entity;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Backport      | 0.9, 0.10
| License       | MIT

If we have a chain of node entities, which uses the `ReferenceListener`, some entities are not saved, because a lacking persist calls.