### PR TITLE
Save PolyCollection expand state

### DIFF
--- a/assets/node_modules/@enhavo/form/loader/PolyCollectionLoader.ts
+++ b/assets/node_modules/@enhavo/form/loader/PolyCollectionLoader.ts
@@ -6,16 +6,19 @@ import prototypeManager from "@enhavo/form/prototype/PrototypeManager";
 import FormRegistry from "@enhavo/app/form/FormRegistry";
 import View from "@enhavo/app/view/View";
 import Translator from "@enhavo/core/Translator";
+import EventDispatcher from "@enhavo/app/view-stack/EventDispatcher";
 
 export default class PolyCollectionLoader extends AbstractLoader
 {
     private view: View;
     private translator: Translator;
+    private eventDispatcher: EventDispatcher;
 
-    constructor(view: View, translator: Translator) {
+    constructor(view: View, translator: Translator, eventDispatcher: EventDispatcher) {
         super();
         this.view = view;
         this.translator = translator;
+        this.eventDispatcher = eventDispatcher;
     }
 
     public insert(element: HTMLElement): void
@@ -23,7 +26,7 @@ export default class PolyCollectionLoader extends AbstractLoader
         let elements = this.findElements(element, '[data-poly-collection]');
         for(element of elements) {
             let config = <PolyCollectionConfig>$(element).data('poly-collection-config');
-            FormRegistry.registerType(new PolyCollectionType(element, config, prototypeManager, this.view, this.translator));
+            FormRegistry.registerType(new PolyCollectionType(element, config, prototypeManager, this.view, this.translator, this.eventDispatcher));
         }
     }
 }

--- a/assets/node_modules/@enhavo/form/services/loader.yaml
+++ b/assets/node_modules/@enhavo/form/services/loader.yaml
@@ -55,6 +55,7 @@ services:
         arguments:
             - '@enhavo/app/view/View'
             - '@enhavo/core/Translator'
+            - '@enhavo/app/view-stack/EventDispatcher'
         tags:
             - 'enhavo_app.form'
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes
| Backport      | 0.9, 0.10
| License       | MIT

Save the expand/collapse state of the PolyCollectionType. Only the root state will be saved.
