### PR TITLE
Add special pages configuration

### DIFF
--- a/src/Enhavo/Bundle/PageBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/PageBundle/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Enhavo\Bundle\PageBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -20,13 +21,36 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('enhavo_page');
         $rootNode = $treeBuilder->getRootNode();
 
-        $rootNode
-            // Driver used by the resource bundle
+        $this->addSpecialPageConfiguration($rootNode);
+        $this->addResourceConfiguration($rootNode);
+
+        return $treeBuilder;
+    }
+
+    public function addSpecialPageConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('special_pages')
+                    ->useAttributeAsKey('code')
+                    ->prototype('array')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('label')->isRequired()->end()
+                            ->scalarNode('translation_domain')->defaultValue(null)->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function addResourceConfiguration(NodeDefinition $node)
+    {
+        $node
             ->children()
                 ->scalarNode('driver')->defaultValue('doctrine/orm')->end()
             ->end()
 
-            // The resources
             ->children()
                 ->arrayNode('resources')
                     ->addDefaultsIfNotSet()
@@ -58,7 +82,5 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
-
-        return $treeBuilder;
     }
 }

--- a/src/Enhavo/Bundle/PageBundle/DependencyInjection/EnhavoPageExtension.php
+++ b/src/Enhavo/Bundle/PageBundle/DependencyInjection/EnhavoPageExtension.php
@@ -26,8 +26,7 @@ class EnhavoPageExtension extends AbstractResourceExtension implements PrependEx
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $this->registerResources('enhavo_page', $config['driver'], $config['resources'], $container);
 
-        $container->setParameter('enhavo_page.routing.page.strategy', $config['resources']['page']['routing']['strategy']);
-        $container->setParameter('enhavo_page.routing.page.route', $config['resources']['page']['routing']['route']);
+        $container->setParameter('enhavo_page.special_pages', $config['special_pages']);
 
         $configFiles = array(
             'services.yaml',

--- a/src/Enhavo/Bundle/PageBundle/Form/Type/SpecialPageType.php
+++ b/src/Enhavo/Bundle/PageBundle/Form/Type/SpecialPageType.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Enhavo\Bundle\PageBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class SpecialPageType extends AbstractType
+{
+    /** @var array */
+    private $specialPages;
+
+    /** @var TranslatorInterface */
+    private $translator;
+
+    /**
+     * SpecialPageType constructor.
+     * @param array $specialPages
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(array $specialPages, TranslatorInterface $translator)
+    {
+        $this->specialPages = $specialPages;
+        $this->translator = $translator;
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => $this->getChoices(),
+            'placeholder' => '---'
+        ]);
+    }
+
+    private function getChoices()
+    {
+        $choices = [];
+        foreach ($this->specialPages as $code => $specialPage) {
+            $label = $this->translator->trans($specialPage['label'], [], $specialPage['translation_domain']);
+            $choices[$label] = $code;
+        }
+        return $choices;
+    }
+}

--- a/src/Enhavo/Bundle/PageBundle/Page/PageManager.php
+++ b/src/Enhavo/Bundle/PageBundle/Page/PageManager.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Enhavo\Bundle\PageBundle\Page;
+use Enhavo\Bundle\PageBundle\Entity\Page;
+use Enhavo\Bundle\PageBundle\Repository\PageRepository;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\RouterInterface;
+
+class PageManager
+{
+    /** @var PageRepository */
+    private $pageRepository;
+
+    /** @var RouterInterface */
+    private $router;
+
+    /**
+     * PageManager constructor.
+     * @param PageRepository $pageRepository
+     * @param RouterInterface $router
+     */
+    public function __construct(PageRepository $pageRepository, RouterInterface $router)
+    {
+        $this->pageRepository = $pageRepository;
+        $this->router = $router;
+    }
+
+    public function getPagePath($code, $parameters, $referenceType)
+    {
+        $page = $this->pageRepository->findOneBy([
+            'code' => $code
+        ]);
+
+        if(!$page instanceof Page) {
+            return $this->getDefaultLink($code);
+        }
+
+        if($page->getRoute() === null) {
+            return $this->getDefaultLink($code);
+        }
+
+        try {
+            return $this->router->generate($page->getRoute(), $parameters, $referenceType);
+        } catch (RouteNotFoundException $e) {
+            return $this->getDefaultLink($code);
+        }
+    }
+
+    private function getDefaultLink($code)
+    {
+        return sprintf('#%s', $code);
+    }
+}

--- a/src/Enhavo/Bundle/PageBundle/Resources/config/services.yaml
+++ b/src/Enhavo/Bundle/PageBundle/Resources/config/services.yaml
@@ -2,19 +2,19 @@ services:
     Enhavo\Bundle\PageBundle\Form\Type\PageType:
         arguments:
             - '%enhavo_page.model.page.class%'
+            - '%enhavo_page.special_pages%'
         tags:
-            - { name: form.type, alias: enhavo_page_page }
+            - { name: form.type }
 
     Enhavo\Bundle\PageBundle\Form\Type\PageChoiceType:
         arguments:
             - '%enhavo_page.model.page.class%'
         tags:
-            - { name: form.type, alias: 'enhavo_page_page_choice' }
+            - { name: form.type }
 
     Enhavo\Bundle\PageBundle\Twig\PagePathExtension:
         arguments:
-            - '@enhavo_page.repository.page'
-            - '@router'
+            - '@Enhavo\Bundle\PageBundle\Page\PageManager'
         tags:
             - { name: twig.extension }
 
@@ -41,3 +41,15 @@ services:
             - '%enhavo_page.model.page.class%'
             - '@enhavo_block.factory.node'
             - '@enhavo_routing.factory.route'
+
+    Enhavo\Bundle\PageBundle\Page\PageManager:
+        arguments:
+            - '@enhavo_page.repository.page'
+            - '@router'
+
+    Enhavo\Bundle\PageBundle\Form\Type\SpecialPageType:
+        arguments:
+            - '%enhavo_page.special_pages%'
+            - '@translator'
+        tags:
+            - { name: form.type }

--- a/src/Enhavo/Bundle/PageBundle/Resources/translations/EnhavoPageBundle.de.yaml
+++ b/src/Enhavo/Bundle/PageBundle/Resources/translations/EnhavoPageBundle.de.yaml
@@ -27,6 +27,7 @@ page:
     never: 'Nie'
     assigned: 'zugeordnet'
     parent: 'Elternseite'
+    special_page: 'Spezialseite'
   batch:
     action:
       publish: 'Veröffentlichen'

--- a/src/Enhavo/Bundle/PageBundle/Resources/translations/EnhavoPageBundle.en.yaml
+++ b/src/Enhavo/Bundle/PageBundle/Resources/translations/EnhavoPageBundle.en.yaml
@@ -27,6 +27,7 @@ page:
     never: 'Never'
     assigned: 'assigned'
     parent: 'Parent'
+    special_page: 'Special page'
   batch:
     action:
       publish: 'Publish'

--- a/src/Enhavo/Bundle/PageBundle/Resources/views/admin/resource/page/page.html.twig
+++ b/src/Enhavo/Bundle/PageBundle/Resources/views/admin/resource/page/page.html.twig
@@ -1,5 +1,6 @@
 {% if form.link is defined %}{{ form_row(form.link) }}{% endif %}
-{{ form_row(form.title) }}
-{{ form_row(form.parent) }}
-{{ form_row(form.public) }}
-{{ form_row(form._token) }}
+{% if form.title is defined %}{{ form_row(form.title) }}{% endif %}
+{% if form.parent is defined %}{{ form_row(form.parent) }}{% endif %}
+{% if form.public is defined %}{{ form_row(form.public) }}{% endif %}
+{% if form.code is defined %}{{ form_row(form.code) }}{% endif %}
+{% if form._token is defined %}{{ form_row(form._token) }}{% endif %}

--- a/src/Enhavo/Bundle/PageBundle/Twig/PagePathExtension.php
+++ b/src/Enhavo/Bundle/PageBundle/Twig/PagePathExtension.php
@@ -2,10 +2,8 @@
 
 namespace Enhavo\Bundle\PageBundle\Twig;
 
-use Enhavo\Bundle\PageBundle\Entity\Page;
+use Enhavo\Bundle\PageBundle\Page\PageManager;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Extension\AbstractExtension;
@@ -13,25 +11,16 @@ use Twig\TwigFunction;
 
 class PagePathExtension extends AbstractExtension
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $pageRepository;
+    /** @var PageManager */
+    private $pageManager;
 
     /**
-     * @var RouterInterface
+     * PagePathExtension constructor.
+     * @param PageManager $pageManager
      */
-    private $router;
-
-    public function __construct(RepositoryInterface $pageRepository, RouterInterface $router)
+    public function __construct(PageManager $pageManager)
     {
-        $this->pageRepository =  $pageRepository;
-        $this->router = $router;
-    }
-
-    public function getGlobals()
-    {
-        return array();
+        $this->pageManager = $pageManager;
     }
 
     public function getFunctions()
@@ -43,32 +32,6 @@ class PagePathExtension extends AbstractExtension
 
     public function getPagePath($code, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        $page = $this->pageRepository->findOneBy([
-            'code' => $code
-        ]);
-
-        if(!$page instanceof Page) {
-            return $this->getDefaultLink($code);
-        }
-
-        if($page->getRoute() === null) {
-            return $this->getDefaultLink($code);
-        }
-
-        try {
-            return $this->router->generate($page->getRoute(), $parameters, $referenceType);
-        } catch (RouteNotFoundException $e) {
-            return $this->getDefaultLink($code);
-        }
-    }
-
-    protected function getDefaultLink($code)
-    {
-        return sprintf('#%s', $code);
-    }
-
-    public function getName()
-    {
-        return 'page_path_extension';
+        return $this->pageManager->getPagePath($code, $parameters, $referenceType);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes
| Backport      | 0.9, 0.10
| License       | MIT

Add `special_pages` configuration to have a dropdown for the code field. If no `special_pages` is defined we skip the dropdown
