### PR TITLE
if array given, call_user_func_array required instead of call_user_func

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Filter/Type/EntityType.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/Type/EntityType.php
@@ -81,7 +81,7 @@ class EntityType extends AbstractFilterType
         $arguments =  $options['arguments'];
 
         if(is_array($arguments)) {
-            $entities = call_user_func([$repository, $method], $arguments);
+            $entities = call_user_func_array([$repository, $method], $arguments);
         } else {
             $entities = call_user_func([$repository, $method]);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Doc PR?       | yes/no
| Backport      | 0.9 <!-- choose version where this PR should apply as well -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix/docs. This will help people
understand your PR.
-->
