### PR TITLE
[TranslationBundle] Fix for TranslationSlugGenerator service definition

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/generator.yaml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/generator.yaml
@@ -26,6 +26,7 @@ services:
         arguments:
             - '@Enhavo\Bundle\TranslationBundle\Translation\TranslationManager'
             - '@Enhavo\Bundle\TranslationBundle\Translator\Text\TextTranslator'
+            - '@doctrine.orm.entity_manager'
         calls:
             - [setContainer, ['@service_container']]
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.9
| License       | MIT

Fix for TranslationSlugGenerator service definition missing a parameter.