### PR TITLE
Fix tinymce links

### DIFF
--- a/assets/node_modules/@enhavo/form/type/WysiwygType.ts
+++ b/assets/node_modules/@enhavo/form/type/WysiwygType.ts
@@ -26,7 +26,7 @@ export default class WysiwygType extends FormType
         let editorCss = this.$element.data('editor-css');
         let options = {
             base_url: "/build/enhavo", // Because we use dynamic imports, we need to specify the base path to prevent a loading bug in firefox (https://github.com/tinymce/tinymce-docs/issues/1466)
-            toolbar1: "undo redo | styleselect bold italic underline | link | alignleft aligncenter alignright alignjustify | outdent indent | forecolor backcolor | code",
+            toolbar1: "undo redo | styleselect bold italic underline | forecolor backcolor | link | alignleft aligncenter alignright alignjustify | outdent indent | bullist numlist | code",
             target: this.$element.get(0),
             menubar: false,
             branding: false,

--- a/assets/node_modules/@enhavo/form/type/WysiwygType.ts
+++ b/assets/node_modules/@enhavo/form/type/WysiwygType.ts
@@ -26,7 +26,7 @@ export default class WysiwygType extends FormType
         let editorCss = this.$element.data('editor-css');
         let options = {
             base_url: "/build/enhavo", // Because we use dynamic imports, we need to specify the base path to prevent a loading bug in firefox (https://github.com/tinymce/tinymce-docs/issues/1466)
-            toolbar1: "undo redo | styleselect bold italic underline | link | alignleft aligncenter alignright alignjustify | outdent indent | forecolor backcolor",
+            toolbar1: "undo redo | styleselect bold italic underline | link | alignleft aligncenter alignright alignjustify | outdent indent | forecolor backcolor | code",
             target: this.$element.get(0),
             menubar: false,
             branding: false,
@@ -40,6 +40,7 @@ export default class WysiwygType extends FormType
             convert_fonts_to_spans: true,
             resize: false,
             relative_urls: false,
+            remove_script_host:false,
             plugins: ["advlist autolink lists link image charmap print preview anchor",
                 "searchreplace visualblocks code fullscreen",
                 "insertdatetime media table paste autoresize"],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Backport      | 0.9, 0.10
| License       | MIT

- If you add a link in tinymce with a domain which is the same as the browser it will be removed. This is very critical if we want to add urls for a mailing where the full domain is necessary.
- Add the code button to have more control of the code
- Add List buttons and rearrange
