### PR TITLE
Use video api in video block

### DIFF
--- a/src/Enhavo/Bundle/BlockBundle/Block/Type/VideoBlockType.php
+++ b/src/Enhavo/Bundle/BlockBundle/Block/Type/VideoBlockType.php
@@ -8,7 +8,6 @@
 
 namespace Enhavo\Bundle\BlockBundle\Block\Type;
 
-use Enhavo\Bundle\AppBundle\Behat\Context\ContainerAwareTrait;
 use Enhavo\Bundle\AppBundle\View\ViewData;
 use Enhavo\Bundle\BlockBundle\Model\Block\VideoBlock;
 use Enhavo\Bundle\BlockBundle\Factory\VideoBlockFactory;

--- a/src/Enhavo/Bundle/BlockBundle/Block/Type/VideoBlockType.php
+++ b/src/Enhavo/Bundle/BlockBundle/Block/Type/VideoBlockType.php
@@ -8,14 +8,29 @@
 
 namespace Enhavo\Bundle\BlockBundle\Block\Type;
 
+use Enhavo\Bundle\AppBundle\Behat\Context\ContainerAwareTrait;
+use Enhavo\Bundle\AppBundle\View\ViewData;
 use Enhavo\Bundle\BlockBundle\Model\Block\VideoBlock;
 use Enhavo\Bundle\BlockBundle\Factory\VideoBlockFactory;
 use Enhavo\Bundle\BlockBundle\Form\Type\VideoBlockType as VideoBlockFormType;
 use Enhavo\Bundle\BlockBundle\Block\AbstractBlockType;
+use Enhavo\Bundle\BlockBundle\Model\BlockInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class VideoBlockType extends AbstractBlockType
 {
+    /** @var ContainerInterface */
+    private $container;
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
     public function configureOptions(OptionsResolver $optionsResolver)
     {
         $optionsResolver->setDefaults([
@@ -27,6 +42,18 @@ class VideoBlockType extends AbstractBlockType
             'translation_domain' => 'EnhavoBlockBundle',
             'groups' => ['default', 'content']
         ]);
+    }
+
+    public function createViewData(BlockInterface $block, ViewData $viewData, $resource, array $options)
+    {
+        if (!$this->container->has('Enhavo\Bundle\ContentBundle\Factory\VideoFactory')) {
+            throw new \Exception('You have to use the "enhavo/content-bundle" to use the video block');
+        }
+
+        $videoFactory = $this->container->get('Enhavo\Bundle\ContentBundle\Factory\VideoFactory');
+
+        /** @var $block VideoBlock */
+        $viewData['video'] = $videoFactory->create($block->getUrl());
     }
 
     public static function getName(): ?string

--- a/src/Enhavo/Bundle/BlockBundle/Resources/config/services/block.yaml
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/config/services/block.yaml
@@ -20,6 +20,8 @@ services:
             - { name: enhavo_block.block }
 
     Enhavo\Bundle\BlockBundle\Block\Type\VideoBlockType:
+        arguments:
+            - '@service_container'
         tags:
             - { name: enhavo_block.block }
 

--- a/src/Enhavo/Bundle/BlockBundle/Tests/Block/Type/VideoBlockTypeTest.php
+++ b/src/Enhavo/Bundle/BlockBundle/Tests/Block/Type/VideoBlockTypeTest.php
@@ -11,6 +11,7 @@ namespace Enhavo\Bundle\BlockBundle\Tests\Block\Type;
 use Enhavo\Bundle\BlockBundle\Block\Type\VideoBlockType;
 use PHPUnit\Framework\TestCase;
 use Enhavo\Bundle\BlockBundle\Block\BlockTypeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class VideoBlockTypeTest extends TestCase
@@ -22,7 +23,9 @@ class VideoBlockTypeTest extends TestCase
 
     public function testConfigureOption()
     {
-        $type = new VideoBlockType();
+        $serviceMock = $this->getMockBuilder(ContainerInterface::class)->getMock();
+
+        $type = new VideoBlockType($serviceMock);
         $options = $this->createOptions($type);
         $this->assertIsArray($options);
     }

--- a/src/Enhavo/Bundle/ContentBundle/Exception/VideoException.php
+++ b/src/Enhavo/Bundle/ContentBundle/Exception/VideoException.php
@@ -2,7 +2,7 @@
 
 namespace Enhavo\Bundle\ContentBundle\Exception;
 
-class VideoException
+class VideoException extends \Exception
 {
     public static function noProviderFound($url)
     {

--- a/src/Enhavo/Bundle/ContentBundle/Resources/config/services.yaml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/config/services.yaml
@@ -72,6 +72,7 @@ services:
             - { name: console.command }
 
     Enhavo\Bundle\ContentBundle\Factory\VideoFactory:
+        public: true
         calls:
             - ['addProvider', ['@Enhavo\Bundle\ContentBundle\Video\VimeoProvider']]
             - ['addProvider', ['@Enhavo\Bundle\ContentBundle\Video\YoutubeProvider']]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Backport      | 0.10
| License       | MIT

* Video block uses video api from `ContentBundle`
