### PR TITLE
Added button to DateType/DateTimeType to clear the date

### DIFF
--- a/assets/node_modules/@enhavo/form/assets/styles/form.scss
+++ b/assets/node_modules/@enhavo/form/assets/styles/form.scss
@@ -5,6 +5,7 @@
 
 @import '~@enhavo/app/assets/styles/form';
 
+@import 'module/date';
 @import 'module/form';
 @import 'module/icheck';
 @import 'module/list';

--- a/assets/node_modules/@enhavo/form/assets/styles/module/_date.scss
+++ b/assets/node_modules/@enhavo/form/assets/styles/module/_date.scss
@@ -1,0 +1,3 @@
+.date-type { position: relative;
+  .clear-button { position: absolute; right: 0; top: 0; display: inline-block; background: $grey5; border-radius: 0 10px 10px 0; width: 32px; height: 100%; padding-top: 8px; text-align: center; cursor: pointer; }
+}

--- a/assets/node_modules/@enhavo/form/type/DateTimeType.ts
+++ b/assets/node_modules/@enhavo/form/type/DateTimeType.ts
@@ -21,5 +21,9 @@ export default class DateTimeType extends FormType
 
         $.datetimepicker.setLocale('de');
         this.$element.datetimepicker(options);
+
+        this.$element.parent().find('[data-clear-date-button]').on('click', () => {
+            this.$element.val('');
+        });
     }
 }

--- a/assets/node_modules/@enhavo/form/type/DateType.ts
+++ b/assets/node_modules/@enhavo/form/type/DateType.ts
@@ -22,5 +22,9 @@ export default class DateType extends FormType
 
         $.datetimepicker.setLocale('de');
         this.$element.datetimepicker(options);
+
+        this.$element.parent().find('[data-clear-date-button]').on('click', () => {
+            this.$element.val('');
+        });
     }
 }

--- a/src/Enhavo/Bundle/ContentBundle/Form/Type/ContentType.php
+++ b/src/Enhavo/Bundle/ContentBundle/Form/Type/ContentType.php
@@ -61,7 +61,8 @@ class ContentType extends AbstractType
 
         $builder->add('published_until', DateTimeType::class, array(
             'label' => 'form.label.published_until',
-            'translation_domain' => 'EnhavoContentBundle'
+            'translation_domain' => 'EnhavoContentBundle',
+            'allow_clear' => true
         ));
 
         $builder->add('openGraphTitle', TextType::class, array(

--- a/src/Enhavo/Bundle/FormBundle/Form/Type/DateTimeType.php
+++ b/src/Enhavo/Bundle/FormBundle/Form/Type/DateTimeType.php
@@ -35,6 +35,7 @@ class DateTimeType extends AbstractType
         if (!$options['allow_typing']) {
             $view->vars['attr']['readonly'] = 'readonly';
         }
+        $view->vars['allowClear'] = $options['allow_clear'];
     }
 
     public function getBlockPrefix()
@@ -59,6 +60,7 @@ class DateTimeType extends AbstractType
             'format' => 'dd.MM.yyyy HH:mm',
             'config' => $this->defaultDateTimePickerConfig,
             'allow_typing' => false,
+            'allow_clear' => false,
             'attr' => [
                 'data-date-time-picker' => null,
                 'autocomplete' => 'off'

--- a/src/Enhavo/Bundle/FormBundle/Form/Type/DateType.php
+++ b/src/Enhavo/Bundle/FormBundle/Form/Type/DateType.php
@@ -35,6 +35,7 @@ class DateType extends AbstractType
         if (!$options['allow_typing']) {
             $view->vars['attr']['readonly'] = 'readonly';
         }
+        $view->vars['allowClear'] = $options['allow_clear'];
     }
 
     public function getBlockPrefix()
@@ -59,6 +60,7 @@ class DateType extends AbstractType
             'format' => 'dd.MM.yyyy',
             'config' => $this->defaultDateTimePickerConfig,
             'allow_typing' => false,
+            'allow_clear' => false,
             'attr' => [
                 'data-date-picker' => null,
                 'autocomplete' => 'off'

--- a/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
+++ b/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
@@ -1,14 +1,16 @@
 {% extends 'form_div_layout.html.twig' %}
 
 {% block enhavo_datetime_widget -%}
-    <div class="input-container">
+    <div class="input-container date-type">
         <input class="datetimepicker" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}"{% endif %} type="text" />
+        {% if allowClear %}<span class="clear-button" data-clear-date-button><i class="icon icon-clear"></i></span>{% endif %}
     </div>
 {%- endblock %}
 
 {% block enhavo_date_widget -%}
-    <div class="input-container">
+    <div class="input-container date-type">
         <input class="datepicker" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}"{% endif %} type="text" />
+        {% if allowClear %}<span class="clear-button" data-clear-date-button><i class="icon icon-clear"></i></span>{% endif %}
     </div>
 {%- endblock %}
 

--- a/src/Enhavo/Bundle/SliderBundle/Form/Type/SlideType.php
+++ b/src/Enhavo/Bundle/SliderBundle/Form/Type/SlideType.php
@@ -52,7 +52,8 @@ class SlideType extends AbstractType
 
         $builder->add('publishedUntil', DateType::class, array(
             'label' => 'form.label.published_until',
-            'translation_domain' => 'EnhavoContentBundle'
+            'translation_domain' => 'EnhavoContentBundle',
+            'allow_clear' => true
         ));
 
         $builder->add('public', BooleanType::class, array(
@@ -78,4 +79,4 @@ class SlideType extends AbstractType
     {
         return 'enhavo_slider_slide';
     }
-} 
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc PR?       | no
| License       | MIT

Added option "allow_clear" (default false) to DateType and DateTimeType. If true, a button is added to the form element which will empty the form field, allowing you to clear the date.