### PR TITLE
Don't throw exception if user has wrong type

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Security/UserChecker.php
+++ b/src/Enhavo/Bundle/UserBundle/Security/UserChecker.php
@@ -17,7 +17,7 @@ class UserChecker implements UserCheckerInterface
     public function checkPreAuth(UserInterface $user)
     {
         if (!$user instanceof EnhavoUserInterface) {
-            throw new UserNotSupportedException(sprintf('User has to be of type "%s"', EnhavoUserInterface::class ));
+           return;
         }
 
         if (false === $user->isEnabled()) {
@@ -28,7 +28,7 @@ class UserChecker implements UserCheckerInterface
     public function checkPostAuth(UserInterface $user)
     {
         if (!$user instanceof EnhavoUserInterface) {
-            throw new UserNotSupportedException(sprintf('User has to be of type "%s"', EnhavoUserInterface::class ));
+            return;
         }
 
         if (false === $user->isEnabled()) {

--- a/src/Enhavo/Bundle/UserBundle/Tests/Security/UserCheckerTest.php
+++ b/src/Enhavo/Bundle/UserBundle/Tests/Security/UserCheckerTest.php
@@ -34,15 +34,6 @@ class UserCheckerTest extends TestCase
         $checker->checkPreAuth($user);
     }
 
-    public function testCheckPreAuthType()
-    {
-        $user = new \Symfony\Component\Security\Core\User\User('user1', 'pw');
-        $checker = new UserChecker();
-
-        $this->expectException(UserNotSupportedException::class);
-        $checker->checkPreAuth($user);
-    }
-
     public function testCheckPostAuthEnabled()
     {
         $user = new User();
@@ -59,15 +50,6 @@ class UserCheckerTest extends TestCase
         $checker = new UserChecker();
 
         $this->expectException(BadCredentialsException::class);
-        $checker->checkPostAuth($user);
-    }
-
-    public function testCheckPostAuthType()
-    {
-        $user = new \Symfony\Component\Security\Core\User\User('user1', 'pw');
-        $checker = new UserChecker();
-
-        $this->expectException(UserNotSupportedException::class);
         $checker->checkPostAuth($user);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Backport      | 0.10
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

* Don't throw exception if user has wrong type inside `UserChecker`, because if we use multiple user authenticator, with different providers a user with different type should be allowed.
