### PR TITLE
html preview for icon font in dev

### DIFF
--- a/assets/node_modules/@enhavo/app/assets/fonts/enhavo-icons.font.js
+++ b/assets/node_modules/@enhavo/app/assets/fonts/enhavo-icons.font.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const EncoreUtil = require('@enhavo/core/EncoreUtil');
+const Encore = require('@symfony/webpack-encore');
 
 module.exports = {
     'files': [
@@ -11,6 +12,7 @@ module.exports = {
     'baseSelector': '.icon',
     'types': ['eot', 'woff', 'woff2', 'ttf', 'svg'],
     'fileName': 'fonts/[fontname].[hash].[ext]',
+    'html': Encore.isDev(),
     'htmlTemplate': path.resolve(__dirname, 'enhavo-icons.html.hbs'),
     'codepoints': {
         '3d_rotation': 0xf101,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes
| Backport      | 0.10
| License       | MIT

Add html preview file for icon font if encore/webpack is executed in dev environment
