### PR TITLE
[UserBundle] Fixed reset password mail text not working in german locale

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Resources/translations/EnhavoUserBundle.de.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/translations/EnhavoUserBundle.de.yaml
@@ -67,7 +67,7 @@ reset_password:
             error: 'Der Benutzername existiert nicht.'
     mail:
         subject: 'Passwort zurücksetzen'
-        message: |
+        text: |
             Hallo %username%!
 
             Besuchen Sie bitte folgende Seite, um Ihr Passwort zurückzusetzen: %confirmation_url%


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

[UserBundle] Fixed reset password mail text not working in german locale