### PR TITLE
add command status return value in enhavo commands

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Command/InitCommand.php
+++ b/src/Enhavo/Bundle/AppBundle/Command/InitCommand.php
@@ -42,5 +42,6 @@ class InitCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->manager->init($output);
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/BlockBundle/Command/CleanUpCommand.php
+++ b/src/Enhavo/Bundle/BlockBundle/Command/CleanUpCommand.php
@@ -50,6 +50,6 @@ class CleanUpCommand extends Command
 
         if ($isDryRun) $output->writeln('This was a dry run, no actual changes were made.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/BlockBundle/Command/DebugBlockUseCommand.php
+++ b/src/Enhavo/Bundle/BlockBundle/Command/DebugBlockUseCommand.php
@@ -69,10 +69,12 @@ class DebugBlockUseCommand extends Command
             $this->logger->error(sprintf('Unknown block named "%s". Name must be a key registered under enhavo_block.blocks.', $type));
             $this->logger->info(sprintf('Registered blocks: %s', implode(', ', array_keys($this->blockConfig))));
             $this->logger->info('');
-            return;
+            return Command::FAILURE;
         }
 
         $this->find($type, $id);
+
+        return Command::SUCCESS;
     }
 
     private function find($type, $id)

--- a/src/Enhavo/Bundle/CalendarBundle/Command/ImportCommand.php
+++ b/src/Enhavo/Bundle/CalendarBundle/Command/ImportCommand.php
@@ -40,5 +40,6 @@ class ImportCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->manager->import();
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/ContentBundle/Command/SitemapDumpCommand.php
+++ b/src/Enhavo/Bundle/ContentBundle/Command/SitemapDumpCommand.php
@@ -46,5 +46,6 @@ class SitemapDumpCommand extends Command
         $this->fs->dumpFile($fullPath, $this->sitemapGenerator->generate());
 
         $output->writeln(sprintf('Sitemap file created in "%s"', $this->path));
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Command/CleanUpCommand.php
+++ b/src/Enhavo/Bundle/MediaBundle/Command/CleanUpCommand.php
@@ -114,7 +114,7 @@ class CleanUpCommand extends Command
         $output->writeln('Cleanup complete.');
         if ($this->isDryRun) $output->writeln('This was a dry run, no actual files were deleted.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Enhavo/Bundle/MediaBundle/Command/RefreshFormatCommand.php
+++ b/src/Enhavo/Bundle/MediaBundle/Command/RefreshFormatCommand.php
@@ -132,9 +132,9 @@ class RefreshFormatCommand extends Command
         $output->writeln('<info>Refreshing finished</info>');
 
         if (count($errors)) {
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Command/UpdateFileCommand.php
+++ b/src/Enhavo/Bundle/MediaBundle/Command/UpdateFileCommand.php
@@ -74,5 +74,6 @@ class UpdateFileCommand extends Command
 
         $this->em->flush();
         $output->writeln('Files updated');
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/NewsletterBundle/Command/SendNewsletterCommand.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Command/SendNewsletterCommand.php
@@ -89,5 +89,6 @@ class SendNewsletterCommand extends Command
         $output->writeln('Delivery finished');
 
         $this->release();
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/SearchBundle/Command/ElasticInstallCommand.php
+++ b/src/Enhavo/Bundle/SearchBundle/Command/ElasticInstallCommand.php
@@ -46,16 +46,16 @@ class ElasticInstallCommand extends Command
                 $option = $questionHelper->ask($input, $output, $question);
 
                 if (strtolower($option) === 'n') {
-                    return 0;
+                    return Command::SUCCESS;
                 } elseif (strtolower($option) === 'y') {
                     $this->download($input, $output);
-                    return 0;
+                    return Command::SUCCESS;
                 }
             }
         }
 
         $this->download($input, $output);
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function download(InputInterface $input, OutputInterface $output)

--- a/src/Enhavo/Bundle/SearchBundle/Command/IndexCommand.php
+++ b/src/Enhavo/Bundle/SearchBundle/Command/IndexCommand.php
@@ -36,5 +36,7 @@ class IndexCommand extends Command
         $engine->initialize();
 
         $output->writeln('Initialize finished');
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/SearchBundle/Command/ReindexCommand.php
+++ b/src/Enhavo/Bundle/SearchBundle/Command/ReindexCommand.php
@@ -32,5 +32,7 @@ class ReindexCommand extends Command
         $engine->reindex();
 
         $output->writeln('Indexing finished');
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/ThemeBundle/Command/ThemeDebugCommand.php
+++ b/src/Enhavo/Bundle/ThemeBundle/Command/ThemeDebugCommand.php
@@ -42,5 +42,6 @@ class ThemeDebugCommand extends Command
         foreach($themes as $theme) {
             $output->writeln(sprintf('Found theme "%s"', $theme->getKey()));
         }
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/ThemeBundle/Command/WebpackBuildCommand.php
+++ b/src/Enhavo/Bundle/ThemeBundle/Command/WebpackBuildCommand.php
@@ -41,5 +41,6 @@ class WebpackBuildCommand extends Command
         if (!$process->isSuccessful()) {
             throw new ProcessFailedException($process);
         }
+        return Command::SUCCESS;
     }
 }

--- a/src/Enhavo/Bundle/UserBundle/Command/ActivateUserCommand.php
+++ b/src/Enhavo/Bundle/UserBundle/Command/ActivateUserCommand.php
@@ -80,6 +80,8 @@ EOT
         $this->userManager->activate($user);
 
         $output->writeln(sprintf('User "%s" has been activated.', $username));
+
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Enhavo/Bundle/UserBundle/Command/ChangePasswordCommand.php
+++ b/src/Enhavo/Bundle/UserBundle/Command/ChangePasswordCommand.php
@@ -91,6 +91,7 @@ EOT
         $this->userManager->changePassword($user);
 
         $output->writeln(sprintf('Changed password for user <comment>%s</comment>', $username));
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Enhavo/Bundle/UserBundle/Command/CreateUserCommand.php
+++ b/src/Enhavo/Bundle/UserBundle/Command/CreateUserCommand.php
@@ -113,6 +113,8 @@ EOT
         $this->userManager->add($user);
 
         $output->writeln(sprintf('Created user <comment>%s</comment>', $user->getUsername()));
+
+        return Command::SUCCESS;
     }
 
     /**

--- a/src/Enhavo/Bundle/UserBundle/Command/RoleCommand.php
+++ b/src/Enhavo/Bundle/UserBundle/Command/RoleCommand.php
@@ -96,5 +96,6 @@ EOT
         }
 
         $this->userManager->update($user);
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 
| Tickets       | 
| License       | MIT

Status return values were added to the commands, which were introduced in Symfony 5. 
