### PR TITLE
[UserBundle] Changed login to allow both username and email

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Controller/ResetPasswordController.php
+++ b/src/Enhavo/Bundle/UserBundle/Controller/ResetPasswordController.php
@@ -70,7 +70,7 @@ class ResetPasswordController extends AbstractUserController
 
                 /** @var ResetPassword $data */
                 $data = $form->getData();
-                $user = $this->userRepository->findByUsername($data->getUsername());
+                $user = $this->userRepository->loadUserByIdentifier($data->getUsername());
 
                 $message = $this->translator->trans('reset_password.flash.message.success', [], 'EnhavoUserBundle');
                 $this->addFlash('success', $message);

--- a/src/Enhavo/Bundle/UserBundle/Repository/UserRepository.php
+++ b/src/Enhavo/Bundle/UserBundle/Repository/UserRepository.php
@@ -66,8 +66,19 @@ class UserRepository extends EntityRepository implements UserLoaderInterface
         ]);
     }
 
-    public function loadUserByUsername($username)
+    public function loadUserByIdentifier($identifier)
     {
-        return $this->findByUsername($username);
+        $user = $this->findByUsername($identifier);
+        if ($user) {
+            return $user;
+        }
+        $user = $this->findByEmail($identifier);
+        return $user;
+    }
+
+    public function loadUserByUsername(string $username)
+    {
+        // Deprecated but still required by the interface
+        return $this->loadUserByIdentifier($username);
     }
 }

--- a/src/Enhavo/Bundle/UserBundle/Validator/Constraints/UserExistsValidator.php
+++ b/src/Enhavo/Bundle/UserBundle/Validator/Constraints/UserExistsValidator.php
@@ -27,7 +27,7 @@ class UserExistsValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (is_string($value)) {
-            $user = $this->userRepository->findByUsername($value);
+            $user = $this->userRepository->loadUserByIdentifier($value);
             if ($user === null) {
                 $this->context->buildViolation($constraint->message)->addViolation();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc PR?       | no
| License       | MIT

Changed user loading in login from deprecated repository->loadUserByUsername() to new repository->loadUserByIdentifier().
Allow login both by username and by email.