### PR TITLE
Allow frame targets _blank and _self

### DIFF
--- a/src/Enhavo/Bundle/FormBundle/Formatter/HtmlSanitizer.php
+++ b/src/Enhavo/Bundle/FormBundle/Formatter/HtmlSanitizer.php
@@ -36,8 +36,6 @@ class HtmlSanitizer
 
         $config = \HTMLPurifier_Config::createDefault();
         $config->set('Cache.SerializerPath', $this->serializationPath);
-
-        $config->set('Cache.SerializerPath', $this->serializationPath);
         $config->set('Attr.AllowedFrameTargets', ['_blank', '_self']);
 
         foreach ($options as $key => $optionValue) {

--- a/src/Enhavo/Bundle/FormBundle/Formatter/HtmlSanitizer.php
+++ b/src/Enhavo/Bundle/FormBundle/Formatter/HtmlSanitizer.php
@@ -37,6 +37,9 @@ class HtmlSanitizer
         $config = \HTMLPurifier_Config::createDefault();
         $config->set('Cache.SerializerPath', $this->serializationPath);
 
+        $config->set('Cache.SerializerPath', $this->serializationPath);
+        $config->set('Attr.AllowedFrameTargets', ['_blank', '_self']);
+
         foreach ($options as $key => $optionValue) {
             $config->set($key, $optionValue);
         }

--- a/src/Enhavo/Bundle/FormBundle/Tests/Formatter/HtmlSanitizerTest.php
+++ b/src/Enhavo/Bundle/FormBundle/Tests/Formatter/HtmlSanitizerTest.php
@@ -21,5 +21,6 @@ class HtmlSanitizerTest extends TestCase
         $this->assertEquals('<p>Test</p>', $sanitizer->sanitize('<script>Hello</script><p>Test</p>'));
         $this->assertEquals('Hello<p>Test</p>', $sanitizer->sanitize('<iframe>Hello</iframe><p>Test</p>'));
         $this->assertEquals('Test', $sanitizer->sanitize('Test'));
+        $this->assertEquals('<a href="url" target="_blank" rel="noreferrer noopener">Test</a>', $sanitizer->sanitize('<a href="url" target="_blank">Test</a>'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Backport    | 0.10
| License       | MIT

* Allow frame targets _blank and _self in `html_sanatize`
