### PR TITLE
remove property unique-id from product-picture relation

### DIFF
--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/doctrine/Product.orm.xml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/doctrine/Product.orm.xml
@@ -43,10 +43,10 @@
             </cascade>
             <join-table name="shop_product_pictures">
                 <join-columns>
-                    <join-column name="product_id" referenced-column-name="id" unique="true" />
+                    <join-column name="product_id" referenced-column-name="id"/>
                 </join-columns>
                 <inverse-join-columns>
-                    <join-column name="picture_id" referenced-column-name="id" unique="true" />
+                    <join-column name="picture_id" referenced-column-name="id"/>
                 </inverse-join-columns>
             </join-table>
         </many-to-many>

--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/doctrine/ProductVariant.orm.xml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/doctrine/ProductVariant.orm.xml
@@ -34,10 +34,10 @@
             </cascade>
             <join-table name="shop_product_variant_pictures">
                 <join-columns>
-                    <join-column name="product_variant_id" referenced-column-name="id" unique="true" />
+                    <join-column name="product_variant_id" referenced-column-name="id"/>
                 </join-columns>
                 <inverse-join-columns>
-                    <join-column name="picture_id" referenced-column-name="id" unique="true" />
+                    <join-column name="picture_id" referenced-column-name="id"/>
                 </inverse-join-columns>
             </join-table>
         </many-to-many>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 
| Tickets       | 
| License       | MIT

Remove property unique from product images join column to be able to assign multiple images to one product and vice versa.
