### PR TITLE
replace unknown twig function widget_render with widget in shop-bundle

### DIFF
--- a/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/cart/summary.html.twig
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/cart/summary.html.twig
@@ -6,7 +6,7 @@
 
 {% block main %}
     <section>
-        {{ widget_render('shop_cart_summary') }}
+        {{ widget('shop_cart_summary') }}
     </section>
     <a href="{{ path('enhavo_shop_theme_checkout') }}">Checkout</a>
 {% endblock %}

--- a/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/checkout/confirm.html.twig
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/checkout/confirm.html.twig
@@ -12,11 +12,11 @@
     <h1>Confirm</h1>
 
     <div>
-        {{ widget_render('shop_coupon_redeem', {order: order}) }}
+        {{ widget('shop_coupon_redeem', {order: order}) }}
     </div>
 
     <div>
-        {{ widget_render('shop_cart_summary', {immutable: true, cart: order}) }}
+        {{ widget('shop_cart_summary', {immutable: true, cart: order}) }}
     </div>
 
     <div>

--- a/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/checkout/login.html.twig
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/checkout/login.html.twig
@@ -8,7 +8,7 @@
 {% block main %}
     <h1>Login</h1>
     <div>
-        {{ widget_render('login', {failurePath: 'enhavo_shop_theme_checkout_login'}) }}
+        {{ widget('login', {failurePath: 'enhavo_shop_theme_checkout_login'}) }}
     </div>
     <div>Sie haben noch kein Konto</div>
 

--- a/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/order/detail.html.twig
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/order/detail.html.twig
@@ -3,7 +3,7 @@
 {% trans_default_domain 'EnhavoShopBundle' %}
 
 {% block main %}
-    {{ widget_render('shop_cart_summary', {cart: order, immutable: true}) }}
+    {{ widget('shop_cart_summary', {cart: order, immutable: true}) }}
     <form method="POST" action="{{ path('enhavo_shop_theme_user_order_transfer', {id: order.id}) }}">
         <button type="submit">{{ 'order.action.transfer'|trans }}</button>
     </form>

--- a/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/order/show.html.twig
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/order/show.html.twig
@@ -3,7 +3,7 @@
 {% trans_default_domain 'EnhavoShopBundle' %}
 
 {% block main %}
-    {{ widget_render('shop_cart_summary', {cart: order, immutable: true}) }}
+    {{ widget('shop_cart_summary', {cart: order, immutable: true}) }}
     {% if not order.isPayed %}
         <form method="POST" action="{{ path('enhavo_shop_theme_payment_purchase', {token: order.token}) }}">
             <button type="submit">{{ 'order.action.purchase'|trans }}</button>

--- a/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/product/show.html.twig
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/product/show.html.twig
@@ -6,5 +6,5 @@
 
 {% block main %}
     <h1>{{ product.title }}</h1>
-    {{ widget_render('shop_product_configurator', { product: product }) }}
+    {{ widget('shop_product_configurator', { product: product }) }}
 {% endblock %}

--- a/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/user/address.html.twig
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/views/theme/shop/user/address.html.twig
@@ -3,5 +3,5 @@
 {% trans_default_domain 'EnhavoShopBundle' %}
 
 {% block main %}
-    {{ widget_render('shop_user_address') }}
+    {{ widget('shop_user_address') }}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  no
| Doc PR?       | no
| Backport      | 
| Tickets       | 
| License       | MIT

Replace outdated twig function widget_render with new widget()-function in shop-bundle
