### PR TITLE
return FormData in serializeForm

### DIFF
--- a/assets/node_modules/@enhavo/vue-form/form/Util.ts
+++ b/assets/node_modules/@enhavo/vue-form/form/Util.ts
@@ -28,14 +28,6 @@ export class Util
 
     static serializeForm(form: HTMLFormElement)
     {
-        let formData = new FormData(form);
-        let obj = {};
-
-        let keys = Array.from(formData.keys());
-        for (let key of keys) {
-            obj[key] = formData.get(key);
-        }
-
-        return obj;
+        return new FormData(form);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 
| Tickets       | 
| License       | MIT

Returns FormData object instead of generating the object itself, causing several checkbox inputs not to be sent
