### PR TITLE
fix warning in browser console: Property "enabled" was accessed during render but is not defined on instance.

### DIFF
--- a/assets/node_modules/@enhavo/app/list/components/ListComponent.vue
+++ b/assets/node_modules/@enhavo/app/list/components/ListComponent.vue
@@ -26,7 +26,7 @@
                         :class="{'dragging': list.data.dragging}"
                     >
                         <template #item="{ element }">
-                            <div class="list-group-item" :class="{ 'not-draggable': !enabled }">
+                            <div class="list-group-item">
                                 <list-item v-bind:data="element"></list-item>
                             </div>
                         </template>


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

<!--
fix warning in browser console: Property "enabled" was accessed during render but is not defined on instance.
-->
