### PR TITLE
Set created and updated properly on Content when created/updated via ViewTypes

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/View/Type/UpdateViewType.php
+++ b/src/Enhavo/Bundle/AppBundle/View/Type/UpdateViewType.php
@@ -80,10 +80,10 @@ class UpdateViewType extends AbstractViewType
         if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH']) && $form->isSubmitted()) {
             if ($form->isValid()) {
                 $resource = $form->getData();
-                $appEventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $resource);
+                $appEventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
                 $eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
                 $this->em->flush();
-                $appEventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $resource);
+                $appEventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
                 $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
                 $this->flashBag->add('success', $this->translator->trans('form.message.success', [], 'EnhavoAppBundle'));
                 $route = $request->get('_route');

--- a/src/Enhavo/Bundle/ContentBundle/EventListener/UpdatedSubscriber.php
+++ b/src/Enhavo/Bundle/ContentBundle/EventListener/UpdatedSubscriber.php
@@ -8,16 +8,15 @@
 
 namespace Enhavo\Bundle\ContentBundle\EventListener;
 
-use Enhavo\Bundle\ContentBundle\Content\Publishable;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Enhavo\Bundle\ContentBundle\Entity\Content;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PublishSubscriber implements EventSubscriberInterface
+class UpdatedSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents()
     {
         return array(
-            'enhavo_app.pre_create' => 'preSave',
             'enhavo_app.pre_update' => 'preSave'
         );
     }
@@ -26,10 +25,8 @@ class PublishSubscriber implements EventSubscriberInterface
     {
         $resource = $event->getSubject();
 
-        if ($resource instanceof Publishable) {
-            if ($resource->isPublic() && $resource->getPublicationDate() === null) {
-                $resource->setPublicationDate(new \DateTime());
-            }
+        if ($resource instanceof Content) {
+            $resource->setUpdated(new \DateTime());
         }
     }
 }

--- a/src/Enhavo/Bundle/ContentBundle/Factory/ContentFactory.php
+++ b/src/Enhavo/Bundle/ContentBundle/Factory/ContentFactory.php
@@ -7,6 +7,19 @@ use Enhavo\Bundle\AppBundle\Factory\Factory;
 class ContentFactory extends Factory
 {
     /**
+     * @return Content
+     */
+    public function createNew(): Content
+    {
+        /** @var Content $resource */
+        $resource = parent::createNew();
+        $resource->setCreated(new \DateTime());
+        $resource->setUpdated(new \DateTime());
+
+        return $resource;
+    }
+
+    /**
      * @param Content|null $originalResource
      * @return Content
      */

--- a/src/Enhavo/Bundle/ContentBundle/Resources/config/doctrine/Content.orm.xml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/config/doctrine/Content.orm.xml
@@ -17,12 +17,8 @@
         <field name="publishedUntil" type="datetime" nullable="true" />
         <field name="noIndex" type="boolean" nullable="true" />
         <field name="noFollow" type="boolean" nullable="true" />
-        <field name="created" type="datetime" >
-            <gedmo:timestampable on="create" />
-        </field>
-        <field name="updated" type="datetime">
-            <gedmo:timestampable on="update" />
-        </field>
+        <field name="created" type="datetime" />
+        <field name="updated" type="datetime" />
         <field name="openGraphTitle" type="text" nullable="true" />
         <field name="openGraphDescription" type="text" nullable="true" />
 

--- a/src/Enhavo/Bundle/ContentBundle/Resources/config/services.yaml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/config/services.yaml
@@ -56,6 +56,10 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    Enhavo\Bundle\ContentBundle\EventListener\UpdatedSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }
+
     Enhavo\Bundle\ContentBundle\Controller\SitemapController:
         arguments:
             - '@enhavo_content.sitemap.generator'


### PR DESCRIPTION
fix created and updated are not set properly on content when created/updated via ViewTypes

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

created and updated are not set properly on content when created/updated via ViewTypes
