### PR TITLE
add missing on-delete set null for many-to-one related files

### DIFF
--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/doctrine/Article.orm.xml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/doctrine/Article.orm.xml
@@ -8,6 +8,7 @@
                 <cascade-persist />
                 <cascade-refresh />
             </cascade>
+            <join-column on-delete="SET NULL" />
         </many-to-one>
 
         <one-to-one field="content" target-entity="Enhavo\Bundle\BlockBundle\Model\NodeInterface">

--- a/src/Enhavo/Bundle/BlockBundle/Resources/config/doctrine-block/Enhavo.Bundle.BlockBundle.Model.Block.PictureBlock.orm.xml
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/config/doctrine-block/Enhavo.Bundle.BlockBundle.Model.Block.PictureBlock.orm.xml
@@ -9,6 +9,7 @@
                 <cascade-persist />
                 <cascade-refresh />
             </cascade>
+            <join-column on-delete="SET NULL" />
         </many-to-one>
     </entity>
 </doctrine-mapping>

--- a/src/Enhavo/Bundle/BlockBundle/Resources/config/doctrine-block/Enhavo.Bundle.BlockBundle.Model.Block.TextPictureBlock.orm.xml
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/config/doctrine-block/Enhavo.Bundle.BlockBundle.Model.Block.TextPictureBlock.orm.xml
@@ -13,6 +13,7 @@
                 <cascade-persist />
                 <cascade-refresh />
             </cascade>
+            <join-column on-delete="SET NULL" />
         </many-to-one>
     </entity>
 </doctrine-mapping>

--- a/src/Enhavo/Bundle/CalendarBundle/Resources/config/doctrine/Appointment.orm.xml
+++ b/src/Enhavo/Bundle/CalendarBundle/Resources/config/doctrine/Appointment.orm.xml
@@ -29,6 +29,7 @@
                 <cascade-persist />
                 <cascade-refresh />
             </cascade>
+            <join-column on-delete="SET NULL" />
         </many-to-one>
     </entity>
 </doctrine-mapping>

--- a/src/Enhavo/Bundle/SettingBundle/Resources/config/doctrine/MediaValue.orm.xml
+++ b/src/Enhavo/Bundle/SettingBundle/Resources/config/doctrine/MediaValue.orm.xml
@@ -19,6 +19,7 @@
                 <cascade-persist />
                 <cascade-refresh />
             </cascade>
+            <join-column on-delete="SET NULL" />
         </many-to-one>
 
         <many-to-many field="files" target-entity="Enhavo\Bundle\MediaBundle\Model\FileInterface">

--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/doctrine/TranslationFile.orm.xml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/doctrine/TranslationFile.orm.xml
@@ -15,6 +15,7 @@
                 <cascade-persist/>
                 <cascade-refresh/>
             </cascade>
+            <join-column on-delete="SET NULL" />
         </many-to-one>
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

could not delete files in media-library if related to article. so i searched for relations with the missing on-delete cascade rule.
