### PR TITLE
fix media-lib tag permissions

### DIFF
--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/app/config.yml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/app/config.yml
@@ -7,21 +7,37 @@ enhavo_app:
     apps:
         - 'media/Extension/MediaLibrary'
     roles:
-        enhavo_media_library_index:
+        enhavo_media_library_file_index:
             role: ROLE_ENHAVO_MEDIA_LIBRARY_FILE_INDEX
-            label: media_library.role.label.index
+            label: media_library.role.file.label.index
             translation_domain: EnhavoMediaLibraryBundle
-        enhavo_media_library_create:
+        enhavo_media_library_file_create:
             role: ROLE_ENHAVO_MEDIA_LIBRARY_FILE_CREATE
-            label: media_library.role.label.create
+            label: media_library.role.file.label.create
             translation_domain: EnhavoMediaLibraryBundle
-        enhavo_media_library_update:
+        enhavo_media_library_file_update:
             role: ROLE_ENHAVO_MEDIA_LIBRARY_FILE_UPDATE
-            label: media_library.role.label.update
+            label: media_library.role.file.label.update
             translation_domain: EnhavoMediaLibraryBundle
-        enhavo_media_library_delete:
+        enhavo_media_library_file_delete:
             role: ROLE_ENHAVO_MEDIA_LIBRARY_FILE_DELETE
-            label: media_library.role.label.delete
+            label: media_library.role.file.label.delete
+            translation_domain: EnhavoMediaLibraryBundle
+        enhavo_media_library_tag_index:
+            role: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_INDEX
+            label: media_library.role.tag.label.index
+            translation_domain: EnhavoMediaLibraryBundle
+        enhavo_media_library_tag_create:
+            role: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_CREATE
+            label: media_library.role.tag.label.create
+            translation_domain: EnhavoMediaLibraryBundle
+        enhavo_media_library_tag_update:
+            role: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_UPDATE
+            label: media_library.role.tag.label.update
+            translation_domain: EnhavoMediaLibraryBundle
+        enhavo_media_library_tag_delete:
+            role: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_DELETE
+            label: media_library.role.tag.label.delete
             translation_domain: EnhavoMediaLibraryBundle
 
 enhavo_media_library:

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routes/admin/tag.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routes/admin/tag.yaml
@@ -6,6 +6,7 @@ enhavo_media_library_tag_index:
     defaults:
         _controller: enhavo_taxonomy.controller.term::indexAction
         _sylius:
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_INDEX
             viewer:
                 label: media_library.label.tag
                 translation_domain: EnhavoMediaLibraryBundle
@@ -25,6 +26,7 @@ enhavo_media_library_tag_create:
     defaults:
         _controller: enhavo_taxonomy.controller.term:createAction
         _sylius:
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_CREATE
             redirect: enhavo_media_library_tag_update
             form: Enhavo\Bundle\MediaLibraryBundle\Form\Type\TagType
             factory:
@@ -40,6 +42,7 @@ enhavo_media_library_tag_update:
     defaults:
         _controller: enhavo_taxonomy.controller.term::updateAction
         _sylius:
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_UPDATE
             form: Enhavo\Bundle\MediaLibraryBundle\Form\Type\TagType
             serialization_groups: ['form']
             viewer:
@@ -55,6 +58,7 @@ enhavo_media_library_tag_table:
     defaults:
         _controller: enhavo_taxonomy.controller.term::tableAction
         _sylius:
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_INDEX
             repository:
                 method: findByTaxonomyName
                 arguments:
@@ -78,6 +82,7 @@ enhavo_media_library_tag_delete:
     defaults:
         _controller: enhavo_taxonomy.controller.term:deleteAction
         _sylius:
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_DELETE
             redirect: enhavo_media_library_tag_index
 
 enhavo_media_library_tag_batch:

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/translations/EnhavoMediaLibraryBundle.de.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/translations/EnhavoMediaLibraryBundle.de.yaml
@@ -14,8 +14,15 @@ media_library:
         label:
             create_tag: 'Tag erstellen'
     role:
-        label:
-            index: 'Media-Library list'
-            create: 'Media-Library create'
-            update: 'Media-Library update'
-            delete: 'Media-Library delete'
+        file:
+            label:
+                index: 'Media-Library-File list'
+                create: 'Media-Library-File create'
+                update: 'Media-Library-File update'
+                delete: 'Media-Library-File delete'
+        tag:
+            label:
+                index: 'Media-Library-Tag list'
+                create: 'Media-Library-Tag create'
+                update: 'Media-Library-Tag update'
+                delete: 'Media-Library-Tag delete'

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/translations/EnhavoMediaLibraryBundle.en.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/translations/EnhavoMediaLibraryBundle.en.yaml
@@ -14,8 +14,15 @@ media_library:
         label:
             create_tag: 'Create tag'
     role:
-        label:
-            index: 'Media-Library list'
-            create: 'Media-Library create'
-            update: 'Media-Library update'
-            delete: 'Media-Library delete'
+        file:
+            label:
+                index: 'Media-Library-File list'
+                create: 'Media-Library-File create'
+                update: 'Media-Library-File update'
+                delete: 'Media-Library-File delete'
+        tag:
+            label:
+                index: 'Media-Library-Tag list'
+                create: 'Media-Library-Tag create'
+                update: 'Media-Library-Tag update'
+                delete: 'Media-Library-Tag delete'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

before it was not possible to set permissions on listing/creation/update/deletion of media-library related tags
