### PR TITLE
[BlockBundle] Fix missing linebreak in make:enhavo:block

### DIFF
--- a/src/Enhavo/Bundle/BlockBundle/Resources/skeleton/block/doctrine.tpl.php
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/skeleton/block/doctrine.tpl.php
@@ -39,6 +39,7 @@
             targetEntity: <?= $relation->getTargetEntity() ?>
 
             inversedBy: <?= $relation->getInversedBy() ?>
+
             joinColumn:
                 onDelete: SET NULL
 

--- a/src/Enhavo/Bundle/BlockBundle/Resources/skeleton/block/item-doctrine.tpl.php
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/skeleton/block/item-doctrine.tpl.php
@@ -46,6 +46,7 @@
             targetEntity: <?= $relation->getTargetEntity() ?>
 
             inversedBy: <?= $relation->getInversedBy() ?>
+
             joinColumn:
                 onDelete: SET NULL
 
@@ -72,5 +73,3 @@
                         onDelete: cascade
 
 <?php endforeach; ?>
-
-    lifecycleCallbacks: {  }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

there was a linebreak missing when block maker created manyToOne doctrine yaml
