### PR TITLE
remove stringify function in submitAsync function

### DIFF
--- a/assets/node_modules/@enhavo/vue-form/form/Form.ts
+++ b/assets/node_modules/@enhavo/vue-form/form/Form.ts
@@ -45,7 +45,7 @@ export class Form extends RootFormData
         return axios({
             method: <Method>this.element.method,
             url: this.element.action,
-            data: qs.stringify(this.serializeForm()),
+            data: this.serializeForm(),
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
                 'X-Requested-With': 'XMLHttpRequest'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.10
| Tickets       | 
| License       | MIT

<!--
After using FormDataObject in serializeForm, stringify must be removed to avoid errors
-->
