### PR TITLE
add missing removeShipments function called in OrderShipmentProcessor

### DIFF
--- a/src/Enhavo/Bundle/ShopBundle/Entity/Order.php
+++ b/src/Enhavo/Bundle/ShopBundle/Entity/Order.php
@@ -165,6 +165,14 @@ class Order extends SyliusOrder implements OrderInterface
         return $this->shipments;
     }
 
+    public function removeShipments()
+    {
+        $shipments = $this->getShipments();
+        foreach ($shipments as $shipment) {
+            $this->removeShipment($shipment);
+        }
+    }
+
     public function setEmail(?string $email)
     {
         $this->email = $email;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc PR?       | no
| Backport      | 
| Tickets       | 
| License       | MIT

<!--
OrderShipmentProcessor calls the function $order->removeShipments() which did not exist before. So i add this function to the order entity
-->
