### PR TITLE
[SettingBundle] fix settings form template not found

### DIFF
--- a/src/Enhavo/Bundle/SettingBundle/Resources/config/routes/admin/setting.yaml
+++ b/src/Enhavo/Bundle/SettingBundle/Resources/config/routes/admin/setting.yaml
@@ -42,7 +42,7 @@ enhavo_setting_setting_update:
                     main:
                         label: setting.label.setting
                         translation_domain: EnhavoSettingBundle
-                        template: EnhavoSettingBundle:admin/resource/setting:main.html.twig
+                        template: admin/resource/setting/main.html.twig
 
 enhavo_setting_setting_table:
     options:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

fix settings form template not found