### PR TITLE
[MediaBundle] fix clamdscan cannot access tmp file

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Validator/Constraints/ClamAvValidator.php
+++ b/src/Enhavo/Bundle/MediaBundle/Validator/Constraints/ClamAvValidator.php
@@ -37,6 +37,8 @@ class ClamAvValidator extends ConstraintValidator
         }
 
         $path = $value instanceof FileObject ? $value->getPathname() : (string) $value;
+        $perm = fileperms($path) | 0644;
+        chmod($path, $perm);
         $command = sprintf('%s %s', $constraint->clamscanPath ?? $this->config['clamscan_path'], $path);
         $process = new Process(explode(' ', $command));
         $exitCode = $process->run();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

If a daemon is used to scan for viruses, the daemon can't access tmp files because they are only allowed to r/w by www-data.
