### PR TITLE
[AppBundle] Added general groupby id to FilterQuery to prevent errors…

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Filter/FilterQuery.php
+++ b/src/Enhavo/Bundle/AppBundle/Filter/FilterQuery.php
@@ -86,6 +86,7 @@ class FilterQuery
         $this->queryBuilder = new QueryBuilder($em);
         $this->queryBuilder->select($this->getAlias());
         $this->queryBuilder->from($class, $this->getAlias());
+        $this->queryBuilder->addGroupBy($this->alias . '.id');
     }
 
     public function addOrderBy($property, $order, $joinProperty = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

[AppBundle] Added general groupby id to FilterQuery to prevent errors caused by joining oneToMany/manyToMany properties in filters
