### PR TITLE
[FormBundle] fix enhavo_auto_complete_entity_widget not rendering attributes

### DIFF
--- a/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
+++ b/src/Enhavo/Bundle/FormBundle/Resources/views/admin/form/form/fields.html.twig
@@ -151,7 +151,7 @@
 {% endblock %}
 
 {% block enhavo_auto_complete_entity_widget %}
-    <div data-auto-complete-entity="{{ auto_complete_data|json_encode|e }}">
+    <div data-auto-complete-entity="{{ auto_complete_data|json_encode|e }}" {{ block('attributes') }}>
         {% set valueString = '' %}
         {% if multiple %}
             {% set valueValues = [] %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.10
| License       | MIT

fix enhavo_auto_complete_entity_widget not rendering attributes
