### PR TITLE
[ContentBundle] provided url must contain any data to be checked

### DIFF
--- a/src/Enhavo/Bundle/ContentBundle/Factory/VideoFactory.php
+++ b/src/Enhavo/Bundle/ContentBundle/Factory/VideoFactory.php
@@ -19,10 +19,13 @@ class VideoFactory
         $this->providers[] = $provider;
     }
 
+    /**
+     * @throws VideoException
+     */
     public function create($url): Video
     {
         foreach ($this->providers as $provider) {
-            if ($provider->isSupported($url)) {
+            if ($url && $provider->isSupported($url)) {
                 return $provider->create($url);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | yes/no
| Backport      | 0.10
| License       | MIT

If in e.g. VideoBlock the URL was not provided the following error occured:
Argument 1 passed to Enhavo\Bundle\ContentBundle\Video\VimeoProvider::isSupported() must be of the type string, null given, called in .../vendor/enhavo/content-bundle/Factory/VideoFactory.php on line 25