### PR TITLE
Vue form children  are always array now

### DIFF
--- a/assets/node_modules/@enhavo/form/components/FormListComponent.vue
+++ b/assets/node_modules/@enhavo/form/components/FormListComponent.vue
@@ -71,17 +71,10 @@ export default class extends Vue
 
     created()
     {
-        /**
-         * If the data we get is not an array, we have to convert it into an array to take care of the order
-         */
-        if (!Array.isArray(this.form.children)) {
-            this.form.children = Object.values(this.form.children);
-        }
-
         if (this.form.index === null) {
             let index = -1;
-            for (let key of Object.keys(this.form.children)) {
-                let childIndex = parseInt(this.form.children[key].name);
+            for (let child of this.form.children) {
+                let childIndex = parseInt(child.name);
                 if (childIndex > index) {
                     index = childIndex;
                 }
@@ -142,8 +135,8 @@ export default class extends Vue
     private updateParents(form: FormData, parent: FormData)
     {
         form.parent = parent;
-        for (let key of Object.keys(form.children)) {
-            this.updateParents(form.children[key], form);
+        for (let child of form.children) {
+            this.updateParents(child, form);
         }
     }
 
@@ -182,9 +175,9 @@ export default class extends Vue
         let i = 0;
         for (let child of this.form.children) {
             let grandChildren = child.children;
-            for (let formKey in grandChildren) {
-                if (grandChildren.hasOwnProperty(formKey) && grandChildren[formKey].position === true) {
-                    grandChildren[formKey].value = i;
+            for (let grandChild of grandChildren) {
+                if (grandChild.position === true) {
+                    grandChild.value = i;
                     i++;
                 }
             }
@@ -207,16 +200,16 @@ export default class extends Vue
         form.fullName = this.form.fullName + '[' + form.name + ']';
         form.parent = this.form;
 
-        for (let key of Object.keys(form.children)) {
-            this.updateFullName(form.children[key]);
+        for (let child of form.children) {
+            this.updateFullName(child);
         }
     }
 
     private updateFullName(form: FormData)
     {
         form.fullName = form.parent.fullName + '[' + form.name + ']';
-        for (let key of Object.keys(form.children)) {
-            this.updateFullName(form.children[key]);
+        for (let child of form.children) {
+            this.updateFullName(child);
         }
     }
 }

--- a/assets/node_modules/@enhavo/vue-form/components/FormChoiceExpandedComponent.vue
+++ b/assets/node_modules/@enhavo/vue-form/components/FormChoiceExpandedComponent.vue
@@ -1,6 +1,6 @@
 <template>
     <div :id="form.id" ref="element">
-        <template v-for="child in form.children">
+        <template v-for="child of form.children">
             <form-widget :form="child"></form-widget>
             <form-label :form="child"></form-label>
         </template>

--- a/assets/node_modules/@enhavo/vue-form/components/FormRowsComponent.vue
+++ b/assets/node_modules/@enhavo/vue-form/components/FormRowsComponent.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="child.rowComponent" v-for="child in form.children" :form="child" :key="child.name" />
+    <component :is="child.rowComponent" v-for="child of form.children" :form="child" :key="child.name" />
 </template>
 
 <script lang="ts">

--- a/assets/node_modules/@enhavo/vue-form/data/FormData.ts
+++ b/assets/node_modules/@enhavo/vue-form/data/FormData.ts
@@ -25,9 +25,16 @@ export class FormData
 
         let searchElement: FormData = this;
         for (let property of propertyChain) {
-            if (searchElement.children.hasOwnProperty(property)) {
-                searchElement = searchElement.children[property];
-            } else {
+            let hasPropertyChild = false;
+            for (let child of searchElement.children) {
+                if (child.name === property) {
+                    hasPropertyChild = true;
+                    searchElement = child;
+                    break;
+                }
+            }
+
+            if (!hasPropertyChild) {
                 return null;
             }
         }

--- a/src/Enhavo/Bundle/FormBundle/Form/VueType/ListVueType.php
+++ b/src/Enhavo/Bundle/FormBundle/Form/VueType/ListVueType.php
@@ -27,7 +27,7 @@ class ListVueType extends AbstractVueType
         $data['allowDelete'] = $view->vars['allow_delete'];
         $data['allowAdd'] = $view->vars['allow_add'];
         $data['blockName'] = $view->vars['block_name'];
-        $data['prototype'] = $this->vueForm->createData($view->vars['prototype']);
+        $data['prototype'] = isset($view->vars['prototype']) ? $this->vueForm->createData($view->vars['prototype']) : null;
         $data['prototypeName'] = $view->vars['prototype_name'];
         $data['index'] = null;
         $data['draggableGroup'] = $view->vars['draggable_group'];

--- a/src/Enhavo/Bundle/VueFormBundle/Form/VueData.php
+++ b/src/Enhavo/Bundle/VueFormBundle/Form/VueData.php
@@ -151,7 +151,9 @@ class VueData implements \IteratorAggregate, \Countable, \ArrayAccess
 
         $array['children'] = [];
         foreach ($this->getChildren() as $key => $child) {
-            $array['children'][$key] = $child->toArray();
+            $childArray = $child->toArray();
+            $childArray['name'] = $key;
+            $array['children'][] = $childArray;
         }
         return $array;
     }

--- a/src/Enhavo/Bundle/VueFormBundle/Form/VueForm.php
+++ b/src/Enhavo/Bundle/VueFormBundle/Form/VueForm.php
@@ -103,7 +103,7 @@ class VueForm
     {
         if ($data['compound']) {
             $returnData = [];
-            foreach ($data['children'] as $key => $child) {
+            foreach ($data['children'] as $child) {
                 $returnData[$child['name']] = $this->submit($child);
             }
             return $returnData;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

* Vue form children are always array now. Accessing object via key can be difficult in some places. Arrays are more easy to handle, especially in adding and removing.
