### PR TITLE
[FormBundle] Find only the closest parent with attribute to count selected items

### DIFF
--- a/assets/node_modules/@enhavo/form/type/CheckboxType.ts
+++ b/assets/node_modules/@enhavo/form/type/CheckboxType.ts
@@ -10,7 +10,7 @@ export default class CheckboxType extends FormType
             radioClass: 'icheckbox'
         });
 
-        let $formRow = this.$element.parents('[data-form-row]');
+        let $formRow = this.$element.closest('[data-form-row]');
         let $count = $formRow.find('[data-selected-count]');
 
         if ($count.length) { // if there is a data-selected-count element, then multiple must have been true

--- a/assets/node_modules/@enhavo/form/type/SelectType.ts
+++ b/assets/node_modules/@enhavo/form/type/SelectType.ts
@@ -17,7 +17,7 @@ export default class SelectType extends FormType
         let data = this.$element.data('select2-options');
         this.$element.select2();
 
-        let $count = this.$element.parents('[data-form-row]').find('[data-selected-count]');
+        let $count = this.$element.closest('[data-form-row]').find('[data-selected-count]');
         if (this.$element.attr('multiple') && $count.length) {
             this.$element.on("change", (event: Select2JQueryEventObject) => {
                 let count = event.val.length;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.10
| License       | MIT

If CheckBox or SelectType was in located a subform, count of selected checkboxes did not work properly.
