### PR TITLE
Fix row component

### DIFF
--- a/assets/node_modules/@enhavo/form/components/FormListComponent.vue
+++ b/assets/node_modules/@enhavo/form/components/FormListComponent.vue
@@ -10,14 +10,14 @@
                     :handle="form.draggableHandle"
                 >
                     <template #item="{ element }">
-                        <component :is="form.itemComponent"
-                                   :form="element"
-                                   :deletable="form.allowDelete"
-                                   :sortable="form.sortable"
-
-                                   @delete="deleteItem"
-                                   @up="moveItemUp"
-                                   @down="moveItemDown"
+                        <component
+                            :is="form.itemComponent"
+                            :form="element"
+                            :deletable="form.allowDelete"
+                            :sortable="form.sortable"
+                            @delete="deleteItem"
+                            @up="moveItemUp"
+                            @down="moveItemDown"
                         >
                             <template v-slot>
                                 <slot name="item"></slot>
@@ -36,7 +36,11 @@
         <slot name="button-row">
             <div class="form-list-button-row" v-if="form.allowAdd">
                 <slot name="buttons">
-                    <div class="form-list-button" @click.prevent="addItem"><i class="icon icon-add_box">+</i></div>
+                    <div class="form-list-button" @click.prevent="addItem">
+                        <slot name="add-button">
+                            <i class="icon icon-add_box">+</i>
+                        </slot>
+                    </div>
                 </slot>
             </div>
         </slot>

--- a/assets/node_modules/@enhavo/vue-form/components/FormErrorsComponent.vue
+++ b/assets/node_modules/@enhavo/vue-form/components/FormErrorsComponent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="form.error">
+    <div v-if="form.errors">
         <div v-for="error in form.errors" :key="error.message">{{ error.message }}</div>
     </div>
 </template>

--- a/assets/node_modules/@enhavo/vue-form/components/FormRowComponent.vue
+++ b/assets/node_modules/@enhavo/vue-form/components/FormRowComponent.vue
@@ -1,5 +1,6 @@
 <template>
-    <div>
+    <component v-if="form.rowComponent !== 'form-row'" :is="form.rowComponent" />
+    <div v-else>
         <form-label :form="form"></form-label>
         <form-errors :form="form"></form-errors>
         <form-widget :form="form"></form-widget>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

* Fix row component. The property `rowComonent` has no effect if using `form-row`for a non compund type.
* Allow to overwrite add button in form list
