### PR TITLE
Fix order recalculating after changes on the cart 

### DIFF
--- a/src/Enhavo/Bundle/ShopBundle/EventListener/OrderRecalculationSubscriber.php
+++ b/src/Enhavo/Bundle/ShopBundle/EventListener/OrderRecalculationSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Enhavo\Bundle\ShopBundle\EventListener;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\CartActions;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Order\SyliusCartEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class OrderRecalculationSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private OrderProcessorInterface $orderProcessor
+    )
+    {
+
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            CartActions::ADD => 'recalculateOrder',
+            CartActions::REMOVE => 'recalculateOrder',
+            SyliusCartEvents::CART_CHANGE => 'recalculateOrder',
+        ];
+    }
+
+    public function recalculateOrder(GenericEvent $event): void
+    {
+        $order = $event->getSubject();
+        $this->orderProcessor->process($order);
+    }
+}

--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/services/services.yaml
@@ -42,6 +42,12 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    Enhavo\Bundle\ShopBundle\EventListener\OrderRecalculationSubscriber:
+        arguments:
+            - '@Sylius\Component\Order\Processor\OrderProcessorInterface'
+        tags:
+            - { name: kernel.event_subscriber }
+
     Enhavo\Bundle\ShopBundle\EventListener\ProductSubscriber:
         arguments:
             - '@enhavo_shop.product_manager'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11
| License       | MIT

* Fix order recalculating after changes on the cart. The recalculation was missing after changes in sylius order or order item controller
