### PR TITLE
Allow autowiring TokenGeneratorInterface

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
@@ -36,6 +36,9 @@ services:
         arguments:
             - []
 
+    Enhavo\Bundle\AppBundle\Util\TokenGeneratorInterface:
+        alias: enhavo_app.util.secure_url_token_generator
+
     Enhavo\Bundle\AppBundle\Template\TemplateManager:
         alias: enhavo_app.template.manager
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11, 0.10, 0.9
| License       | MIT

* Allow autowiring for `TokenGeneratorInterface`
