### PR TITLE
Trigger onMove event also on drag&drop for connected lists

### DIFF
--- a/assets/node_modules/@enhavo/form/form/helper/FormListHelper.ts
+++ b/assets/node_modules/@enhavo/form/form/helper/FormListHelper.ts
@@ -142,6 +142,8 @@ export class FormListHelper
 
         if (event.moved && this.form.onMove) {
             this.form.onMove(event.moved.element);
+        } else if (event.added && this.form.onMove) {
+            this.form.onMove(event.added.element);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | no
| License       | MIT

* Trigger `onMove` event also on drag&drop for connected lists
