### PR TITLE
fix: updateIndex loop on FormList

### DIFF
--- a/assets/node_modules/@enhavo/form/form/model/FormList.ts
+++ b/assets/node_modules/@enhavo/form/form/model/FormList.ts
@@ -1,7 +1,6 @@
 import {Form} from "@enhavo/vue-form/model/Form";
 import {FormFactory} from "@enhavo/vue-form/form/FormFactory";
 import {FormPosition} from "@enhavo/form/form/model/FormPosition";
-import {FormEventDispatcher} from "@enhavo/vue-form/form/FormEventDispatcher";
 import {MoveEvent} from "@enhavo/form/form/event/MoveEvent";
 import {DeleteEvent} from "@enhavo/form/form/event/DeleteEvent";
 import {CreateEvent} from "@enhavo/form/form/event/CreateEvent";
@@ -76,7 +75,7 @@ export class FormList extends Form
             if (item.hasOwnProperty(key)) {
                 if (typeof item[key] === "string") {
                     item[key] = item[key].replace(new RegExp(this.prototypeName, 'g'), index);
-                } else if (typeof item[key] === "object" && key !== 'parent') {
+                } else if (typeof item[key] === "object" && (key == 'children' || key == 'prototype')) {
                     this.updateIndex(item[key], index);
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | no
| Tickets       | no
| License       | MIT

* fix updateIndex loop on FormList. The update index need only to go throw children and prototype otherwise it may run into loops
