### PR TITLE
feat: add get units discount function and improve promotion form

### DIFF
--- a/src/Enhavo/Bundle/ShopBundle/Entity/OrderItem.php
+++ b/src/Enhavo/Bundle/ShopBundle/Entity/OrderItem.php
@@ -74,7 +74,7 @@ class OrderItem extends SyliusOrderItem implements OrderItemInterface
         }
 
         $firstUnit = $this->units->first();
-        
+
         return
             $this->unitPrice +
             $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)
@@ -134,12 +134,57 @@ class OrderItem extends SyliusOrderItem implements OrderItemInterface
     public function getUnitDiscount()
     {
         $total = 0;
+        /** @var \Enhavo\Bundle\ShopBundle\Model\OrderItemUnitInterface $unit */
         $unit = $this->getUnits()->first();
+
         $adjustments = $unit->getAdjustments(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
         /** @var AdjustmentInterface $adjustment */
         foreach($adjustments as $adjustment) {
             $total += $adjustment->getAmount();
         }
+
+        $adjustments = $unit->getAdjustments(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
+        /** @var AdjustmentInterface $adjustment */
+        foreach($adjustments as $adjustment) {
+            $total += $adjustment->getAmount();
+        }
+
+        $adjustments = $unit->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
+        /** @var AdjustmentInterface $adjustment */
+        foreach($adjustments as $adjustment) {
+            $total += $adjustment->getAmount();
+        }
+
+        return $total;
+    }
+
+    public function getUnitsDiscount()
+    {
+        $total = 0;
+
+        /** @var \Enhavo\Bundle\ShopBundle\Model\OrderItemUnitInterface $unit */
+        $unit = $this->getUnits()->first();
+
+        foreach ($this->getUnits() as $unit) {
+            $adjustments = $unit->getAdjustments(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+            /** @var AdjustmentInterface $adjustment */
+            foreach($adjustments as $adjustment) {
+                $total += $adjustment->getAmount();
+            }
+
+            $adjustments = $unit->getAdjustments(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
+            /** @var AdjustmentInterface $adjustment */
+            foreach($adjustments as $adjustment) {
+                $total += $adjustment->getAmount();
+            }
+
+            $adjustments = $unit->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
+            /** @var AdjustmentInterface $adjustment */
+            foreach($adjustments as $adjustment) {
+                $total += $adjustment->getAmount();
+            }
+        }
+
         return $total;
     }
 

--- a/src/Enhavo/Bundle/ShopBundle/EventListener/PromotionSubscriber.php
+++ b/src/Enhavo/Bundle/ShopBundle/EventListener/PromotionSubscriber.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Enhavo\Bundle\ShopBundle\EventListener;
+
+use Enhavo\Bundle\AppBundle\Event\ResourceEvent;
+use Enhavo\Bundle\AppBundle\Event\ResourceEvents;
+use Enhavo\Bundle\ShopBundle\Manager\PromotionManager;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PromotionSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private PromotionManager $promotionManager
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ResourceEvents::PRE_CREATE => 'onPreSave',
+            ResourceEvents::PRE_UPDATE => 'onPreSave',
+        ];
+    }
+
+    public function onPreSave(ResourceEvent $event)
+    {
+        $subject = $event->getSubject();
+        if ($subject instanceof PromotionInterface) {
+            $this->promotionManager->update($subject);
+        }
+    }
+}

--- a/src/Enhavo/Bundle/ShopBundle/Form/Type/PromotionType.php
+++ b/src/Enhavo/Bundle/ShopBundle/Form/Type/PromotionType.php
@@ -8,14 +8,11 @@ use Sylius\Bundle\PromotionBundle\Form\Type\PromotionActionType;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionRuleType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormView;
 
 class PromotionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-
         $builder->add('startsAt', DateTimeType::class, [
             'label' => 'sylius.form.promotion.starts_at',
             'required' => false,
@@ -28,12 +25,14 @@ class PromotionType extends AbstractType
 
         $builder->add('rules', ListType::class, [
             'label' => 'sylius.form.promotion.rules',
+            'help' => 'sylius.form.promotion.rules.help',
             'button_add_label' => 'sylius.form.promotion.add_rule',
             'entry_type' => PromotionRuleType::class
         ]);
 
         $builder->add('actions', ListType::class, [
             'label' => 'sylius.form.promotion.actions',
+            'help' => 'sylius.form.promotion.actions.help',
             'button_add_label' => 'sylius.form.promotion.add_action',
             'entry_type' => PromotionActionType::class
         ]);

--- a/src/Enhavo/Bundle/ShopBundle/Manager/PromotionManager.php
+++ b/src/Enhavo/Bundle/ShopBundle/Manager/PromotionManager.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Enhavo\Bundle\ShopBundle\Manager;
+
+use Enhavo\Bundle\RoutingBundle\Slugifier\Slugifier;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+
+class PromotionManager
+{
+    public function __construct()
+    {}
+
+    public function update(PromotionInterface $promotion)
+    {
+        if ($promotion->getCode() === null) {
+            $promotion->setCode($this->generateCode($promotion->getName()));
+        }
+    }
+
+    private function generateCode($name): string
+    {
+        return substr(md5(microtime()),rand(0,26),4) . '-' . Slugifier::slugify($name);
+    }
+}

--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/services/form.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/services/form.yaml
@@ -1,3 +1,6 @@
+parameters:
+    sylius.form.type.promotion.validation_groups: ['create']
+
 services:
     Enhavo\Bundle\ShopBundle\Form\Type\ProductType:
         arguments:
@@ -102,7 +105,7 @@ services:
         tags:
             - { name: form.type }
 
-    Enhavo\Bundle\ShopBundle\Form\Type\UserAddressType:
+    Sylius\Component\Promotion\Model\Promotion:
         arguments:
             - '%enhavo_shop.model.user_address.class%'
         tags:

--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/services/services.yaml
@@ -34,6 +34,12 @@ services:
             - '@enhavo_search.search.engine'
             - '@sylius.translation_locale_provider'
 
+    enhavo_shop.promotion_manager:
+        public: true
+        alias: Enhavo\Bundle\ShopBundle\Manager\PromotionManager
+
+    Enhavo\Bundle\ShopBundle\Manager\PromotionManager:
+
     enhavo_shop.shipping_manager:
         public: true
         alias: Enhavo\Bundle\ShopBundle\Manager\ShippingManager
@@ -63,6 +69,12 @@ services:
     Enhavo\Bundle\ShopBundle\EventListener\ProductVariantSubscriber:
         arguments:
             - '@enhavo_shop.product_manager'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    Enhavo\Bundle\ShopBundle\EventListener\PromotionSubscriber:
+        arguments:
+            - '@enhavo_shop.promotion_manager'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/validation.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/validation.yaml
@@ -69,3 +69,15 @@ Enhavo\Bundle\ShopBundle\Entity\ShippingMethod:
         name:
             - NotBlank:
                   groups: ['create','update']
+
+Sylius\Component\Promotion\Model\Promotion:
+    properties:
+        name:
+            - NotBlank:
+                  groups: ['create','update']
+        rules:
+            - Valid:
+                  groups: ['create','update']
+        actions:
+            - Valid:
+                  groups: ['create','update']

--- a/src/Enhavo/Bundle/ShopBundle/Resources/translations/messages.de.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/translations/messages.de.yaml
@@ -1,3 +1,9 @@
 sylius:
   ui:
     code: 'Code'
+  form:
+    promotion:
+      rules:
+        help: Nach dem Erstellen oder Ändern eines Regeltyps muss zuerst gepeichert werden damit neue Eingabefelder erscheinen
+      actions:
+        help: Nach dem Erstellen oder Ändern eines Aktiontype muss zuerst gepeichert werden damit neue Eingabefelder erscheinen

--- a/src/Enhavo/Bundle/ShopBundle/Resources/translations/messages.en.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/translations/messages.en.yaml
@@ -1,3 +1,9 @@
 sylius:
   ui:
     code: 'Code'
+  form:
+    promotion:
+      rules:
+        help: After create or change of a rule type, you have to save first before new input fields will appear
+      actions:
+        help: After create or change of a action type, you have to save first before new input fields will appear


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc PR?       | no
| Backport      | no
| Tickets       | no
| License       | MIT

* add `getUnitsDiscount` function to `OrderItem`
* automatic code generation for promotion form
* help text for promotion form rules und action
* fix `getUnitDiscount`, check all promotion adjustments
