### PR TITLE
[MediaBundle][MediaLibraryBundle] Changed behaviour of media library bundle

### DIFF
--- a/assets/node_modules/@enhavo/media-library/Data.ts
+++ b/assets/node_modules/@enhavo/media-library/Data.ts
@@ -19,6 +19,7 @@ export default class Data
     dropZone: boolean = false;
     dropZoneActive: boolean = false;
     columns: Column[] = [];
+    uploadRoute: string;
 }
 
 export class File

--- a/assets/node_modules/@enhavo/media-library/components/MediaLibraryComponent.vue
+++ b/assets/node_modules/@enhavo/media-library/components/MediaLibraryComponent.vue
@@ -116,6 +116,7 @@ export default class extends Vue {
     }
 
     mounted() {
+        console.log(this.mediaLibrary.data);
         let element = this.$refs.upload;
 
         $(document).on('upload', function () {
@@ -150,7 +151,7 @@ export default class extends Vue {
                 this.getMediaLibrary().loaded();
             },
             add: (event, data) => {
-                data.url = this.getRouter().generate('enhavo_media_upload', {});
+                data.url = this.getRouter().generate(this.mediaLibrary.data.uploadRoute, {});
                 data.submit();
                 this.getMediaLibrary().loading();
                 this.getMediaLibrary().setProgress(0);

--- a/src/Enhavo/Bundle/MediaBundle/Event/PostUploadEvent.php
+++ b/src/Enhavo/Bundle/MediaBundle/Event/PostUploadEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Enhavo\Bundle\MediaBundle\Event;
+
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PostUploadEvent extends Event
+{
+    const DEFAULT_EVENT_NAME = 'enhavo_media.post_upload';
+
+    private FileInterface $subject;
+
+    public function __construct(FileInterface $subject)
+    {
+        $this->subject = $subject;
+    }
+
+    /**
+     * @return FileInterface
+     */
+    public function getSubject(): FileInterface
+    {
+        return $this->subject;
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/routes/admin/upload.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/routes/admin/upload.yaml
@@ -2,6 +2,7 @@ enhavo_media_upload:
     path:  /file/add
     defaults:
         _controller: enhavo_media.controller.upload::uploadAction
+        event_name: ~
     options:
         expose: true
 

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
@@ -135,6 +135,7 @@ services:
             - '@enhavo_media.factory.format'
             - '@enhavo_media.media.media_manager'
             - '@validator'
+            - '@event_dispatcher'
             - '%enhavo_media.upload_validation.groups%'
             - '%enhavo_media.enable_garbage_collection%'
         calls:

--- a/src/Enhavo/Bundle/MediaLibraryBundle/EventListener/FileUploadSubscriber.php
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/EventListener/FileUploadSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Enhavo\Bundle\MediaLibraryBundle\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Enhavo\Bundle\MediaBundle\Event\PostUploadEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class FileUploadSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            PostUploadEvent::DEFAULT_EVENT_NAME => 'defaultPostUpload',
+            'enhavo_media_library.post_upload_library' => 'libraryPostUpload',
+        );
+    }
+
+    public function defaultPostUpload(PostUploadEvent $event)
+    {
+        $file = $event->getSubject();
+
+        $file->setLibrary(false);
+        $this->entityManager->flush();
+    }
+
+    public function libraryPostUpload(PostUploadEvent $event)
+    {
+        $file = $event->getSubject();
+
+        $file->setLibrary(true);
+        $file->setGarbage(false);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/app/config.yml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/app/config.yml
@@ -120,8 +120,6 @@ enhavo_media:
                 format: enhavoMediaLibraryVideo
                 mimetypes: [video/mp4]
 
-    enable_garbage_collection: false
-
 enhavo_taxonomy:
     taxonomies:
         media_library_tag:

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routes/admin/file.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routes/admin/file.yaml
@@ -29,6 +29,8 @@ enhavo_media_library_file_files:
         _sylius:
             sorting:
                 createdAt: desc
+            criteria:
+                library: true
             filters:
                 filename:
                     type: text

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routes/admin/upload.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routes/admin/upload.yaml
@@ -1,0 +1,7 @@
+enhavo_media_library_upload:
+    path:  /file/add-library
+    defaults:
+        _controller: enhavo_media.controller.upload::uploadAction
+        event_name: enhavo_media_library.post_upload_library
+    options:
+        expose: true

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routing.yml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 enhavo_media_library_media_library:
-  resource:   "@EnhavoMediaLibraryBundle/Resources/config/routing/media_library.yml"
+  resource:   "@EnhavoMediaLibraryBundle/Resources/config/routes/admin/*"
   prefix:     /

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
@@ -12,6 +12,12 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    Enhavo\Bundle\MediaLibraryBundle\EventListener\FileUploadSubscriber:
+        arguments:
+            - '@doctrine.orm.entity_manager'
+        tags:
+            - { name: kernel.event_subscriber }
+
     Enhavo\Bundle\MediaLibraryBundle\Form\Extension\MediaExtension:
         tags:
             - { name: form.type_extension, extended_type: Enhavo\Bundle\MediaBundle\Form\Type\MediaType }

--- a/src/Enhavo/Bundle/MediaLibraryBundle/View/Type/MediaLibraryViewType.php
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/View/Type/MediaLibraryViewType.php
@@ -50,12 +50,19 @@ class MediaLibraryViewType extends AbstractViewType
             $this->util->getViewerOption('actions', $requestConfiguration)
         ]);
 
+        $uploadRoute = $this->util->mergeConfig([
+            $this->getUploadRoute($options),
+            $options['upload_route'],
+            $this->util->getViewerOption('upload_route', $requestConfiguration)
+        ]);
+
         $data->set('items', $options['items']);
         $options['data']['content_types'] = $options['content_types'];
         $options['data']['multiple'] = $options['multiple'];
         $options['data']['mode'] = $options['mode'];
         $options['data']['tags'] = $options['tags'];
         $options['data']['limit'] = $options['limit'];
+        $options['data']['uploadRoute'] = $uploadRoute;
         $data->set('data', $options['data']);
         $data->set('messages', []);
         $data->set('actions', $this->actionManager->createActionsViewData($actions));
@@ -80,6 +87,7 @@ class MediaLibraryViewType extends AbstractViewType
             'request' => null,
             'metadata' => null,
             'actions' => [],
+            'upload_route' => null
         ]);
     }
 
@@ -142,5 +150,10 @@ class MediaLibraryViewType extends AbstractViewType
             ];
         }
         return $actions;
+    }
+
+    private function getUploadRoute($options): string
+    {
+        return 'enhavo_media_library_upload';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11
| License       | MIT

Changed behaviour of media library bundle from showing all files to just files uploaded via the media library screen; reenabled media garbage collection for files not uploaded via media library; added post upload event to react to file upload including configurable event name to distinguish between different upload routes
