### PR TITLE
remove loading screen after shop transition action

### DIFF
--- a/assets/node_modules/@enhavo/app/action/model/SaveAction.ts
+++ b/assets/node_modules/@enhavo/app/action/model/SaveAction.ts
@@ -3,6 +3,7 @@ import AbstractAction from "@enhavo/app/action/model/AbstractAction";
 import LoadingEvent from "@enhavo/app/view-stack/event/LoadingEvent";
 import View from "@enhavo/app/view/View";
 import EventDispatcher from "@enhavo/app/view-stack/EventDispatcher";
+import * as URI from "urijs";
 
 export default class SaveAction extends AbstractAction
 {
@@ -25,9 +26,11 @@ export default class SaveAction extends AbstractAction
         let $form = $('form');
 
         if (this.url) {
-            $form.attr('action', this.url);
+            let uri = new URI(this.url);
+            uri = uri.addQuery('view_id', this.view.getId());
+            $form.attr('action', uri);
         }
-
+        
         $form.submit();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11
| Tickets       | 
| License       | MIT

Add the view_id to url in saveAction if url exists.  Removes the form loading screen after new enhavo transition actions 

