### PR TITLE
[MediaLibrary] Prevent error in creating format to cause whole list v…

### DIFF
--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
@@ -46,7 +46,7 @@ services:
             - '@Enhavo\Bundle\MediaLibraryBundle\Media\MediaLibraryManager'
             - '@sylius.resource_controller.resources_collection_provider'
             - '@enhavo_media.repository.file'
-            - '@enhavo_media.media.private_url_generator'
+            - '@enhavo_media.media.public_url_generator'
         tags:
             - { name: enhavo_app.view }
 


### PR DESCRIPTION
…iew to fail

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11
| License       | MIT

Uncoupled generation of formats from list view pagination request so that an error in a single file will not cause the whole list view to stop working.
