### PR TITLE
[MediaBundle] Added composer requirement to doctrine/orm ^2.14 becaus…

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/composer.json
+++ b/src/Enhavo/Bundle/MediaBundle/composer.json
@@ -13,6 +13,7 @@
   ],
   "require": {
     "php": "^8.0",
+    "doctrine/orm": "^2.14",
     "enhavo/app-bundle": "dev-master",
     "enhavo/doctrine-extension-bundle": "dev-master",
     "spatie/image-optimizer": "^1.0",


### PR DESCRIPTION
…e of event listener compatibility

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11
| License       | MIT

The event classes used in DoctrineSubscriber events have been introduced to doctrine in version 2.14, so we're incompatible with previous versions.