### PR TITLE
fix: remove unique email from create update groups

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/app/config.yaml
@@ -16,7 +16,8 @@ enhavo_user:
                 translation_domain: 'EnhavoUserBundle'
                 form:
                     class: Enhavo\Bundle\UserBundle\Form\Type\RegistrationType
-                    options: []
+                    options:
+                        validation_groups: [register, unique_email]
 
             registration_check:
                 template: theme/security/registration/check.html.twig

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/routes/admin/user.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/routes/admin/user.yaml
@@ -21,7 +21,7 @@ enhavo_user_user_create:
             redirect: enhavo_user_user_update
             form:
                 options:
-                    validation_groups: [create]
+                    validation_groups: [create, unique_email]
             viewer:
 
 enhavo_user_user_update:
@@ -32,6 +32,9 @@ enhavo_user_user_update:
     defaults:
         _controller: enhavo_user.controller.user::updateAction
         _sylius:
+            form:
+                options:
+                    validation_groups: [update, unique_email]
             viewer:
 
 enhavo_user_user_table:

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/validation.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/validation.yaml
@@ -2,7 +2,10 @@ Enhavo\Bundle\UserBundle\Model\User:
     constraints:
         - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
             fields: email
-            groups: [register, create, update]
+            groups: [unique_email]
+        - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
+              fields: username
+              groups: [unique_username]
     properties:
         email:
             - Email:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | no
| License       | MIT

* remove unique email from create update groups to easily change behavior inside a project
