### PR TITLE
fix: create template from prototype of media form

### DIFF
--- a/assets/node_modules/@enhavo/media/type/MediaConfig.ts
+++ b/assets/node_modules/@enhavo/media/type/MediaConfig.ts
@@ -7,4 +7,5 @@ export default interface MediaConfig
     extensions: Array<UploadExtension>;
     upload: boolean;
     edit: boolean;
+    prototypeName: string;
 }

--- a/assets/node_modules/@enhavo/media/type/MediaRow.ts
+++ b/assets/node_modules/@enhavo/media/type/MediaRow.ts
@@ -80,7 +80,7 @@ export default class MediaRow
     createItem(meta:MediaItemMeta): MediaItem
     {
         let template = this.$element.parents('[data-media-type]').find('[data-media-item-template]').text();
-        template = template.replace(/__name__/g, this.index.toString());
+        template = template.replace(new RegExp(this.media.getConfig().prototypeName, 'g'), this.index.toString());
         let html = $.parseHTML(template)[0];
         let item = new MediaItem(html, meta, this);
         item.setFilename(meta.filename);

--- a/src/Enhavo/Bundle/MediaBundle/Form/Type/MediaType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Form/Type/MediaType.php
@@ -76,6 +76,7 @@ class MediaType extends AbstractType
             'extensions' => $view->vars['extensions'],
             'upload' => $options['upload'],
             'edit' => $options['edit'],
+            'prototypeName' => $options['prototype_name'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

* fix: create template from prototype of media form. It was not checking the prototype name
