### PR TITLE
[TaxonomyBundle] TermInterface parent can't be set to null via DnD

### DIFF
--- a/src/Enhavo/Bundle/TaxonomyBundle/Model/TermInterface.php
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Model/TermInterface.php
@@ -39,7 +39,7 @@ interface TermInterface
     /** @return Term[] */
     public function getParents(): array;
 
-    public function setParent(TermInterface $parent): void;
+    public function setParent(?TermInterface $parent): void;
 
     public function addChildren(TermInterface $child);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11
| License       | MIT

When rearanging terms in listDataView an exception occured when trying to remove an item from its parent and also when sorting items.
This already was fixed in Term->setParent but still was missing in TermInterface.
