### PR TITLE
[TaxonomyBundle] TermInterface parent can't be set to null via DnD

### DIFF
--- a/src/Enhavo/Bundle/TaxonomyBundle/Model/TermInterface.php
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Model/TermInterface.php
@@ -77,9 +77,10 @@ interface TermInterface
     public function getParent(): ?TermInterface;
 
     /**
-     * @param TermInterface $parent
+     * @param TermInterface|null $parent
+     * @return void
      */
-    public function setParent(TermInterface $parent): void;
+    public function setParent(?TermInterface $parent): void;
 
     /**
      * @param TermInterface $child


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| License       | MIT

When rearanging terms in listDataView an exception occured when trying to remove an item from its parent and also when sorting items.
This already was fixed in Term->setParent but still was missing in TermInterface.