### PR TITLE
Term parent can't be set to null when rearanging via DnD

### DIFF
--- a/src/Enhavo/Bundle/TaxonomyBundle/Entity/Term.php
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Entity/Term.php
@@ -186,9 +186,10 @@ class Term implements TermInterface, ResourceInterface
     }
 
     /**
-     * @param TermInterface $parent
+     * @param TermInterface|null $parent
+     * @return void
      */
-    public function setParent(TermInterface $parent): void
+    public function setParent(?TermInterface $parent): void
     {
         $this->parent = $parent;
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

