### PR TITLE
[CommentBundle] Removed cascade remove from comment to thread

### DIFF
--- a/src/Enhavo/Bundle/CommentBundle/Resources/config/doctrine/Comment.orm.xml
+++ b/src/Enhavo/Bundle/CommentBundle/Resources/config/doctrine/Comment.orm.xml
@@ -18,7 +18,6 @@
         <many-to-one field="thread" target-entity="Enhavo\Bundle\CommentBundle\Model\ThreadInterface" fetch="EAGER" inversed-by="comments">
             <cascade>
                 <cascade-persist />
-                <cascade-remove />
                 <cascade-refresh />
             </cascade>
         </many-to-one>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc PR?       | no
| Backport      | 0.11, 0.12
| License       | MIT

Removed cascade remove setting from comment to thread. This setting meant that deleting a comment would lead to deleting the whole comment thread, which is obviously not the intention.