### PR TITLE
fix: vue form with choice expanded

### DIFF
--- a/assets/node_modules/@enhavo/form/form/model/ConditionalForm.ts
+++ b/assets/node_modules/@enhavo/form/form/model/ConditionalForm.ts
@@ -23,8 +23,7 @@ export class ConditionalForm extends Form
             let form = JSON.parse(JSON.stringify(prototype));
             form = this.formFactory.create(form, this.getRoot().visitors, this);
             form.name = 'conditional';
-            this.updateFullName(form);
-            this.updateId(form);
+            form.update();
             this.replace(form);
         }
     }
@@ -44,36 +43,6 @@ export class ConditionalForm extends Form
     {
         let child = this.get('conditional');
         this.children[this.children.indexOf(child)] = form;
-    }
-
-    protected updateId(form: Form)
-    {
-        let names = [];
-        for (let parent of form.getParents().reverse()) {
-            names.push(parent.name);
-        }
-        names.push(form.name);
-        form.id = names.join('_');
-
-        for (let child of form.children) {
-            this.updateId(child);
-        }
-    }
-
-    protected updateFullName(form: Form)
-    {
-        let parents = form.getParents().reverse();
-        let fullName = parents.shift().name;
-        for (let parent of parents) {
-            fullName += '[' + parent.name + ']';
-        }
-        fullName += '[' + form.name + ']';
-
-        form.fullName = fullName;
-
-        for (let child of form.children) {
-            this.updateFullName(child);
-        }
     }
 }
 

--- a/assets/node_modules/@enhavo/form/form/model/ListForm.ts
+++ b/assets/node_modules/@enhavo/form/form/model/ListForm.ts
@@ -80,8 +80,7 @@ export class ListForm extends Form
         item = this.formFactory.create(item, this.getRoot().visitors, this);
         item.name = this.index.toString();
         item.label = prototypeName.replace(new RegExp(this.prototypeName, 'g'), item.name);
-        this.updateFullName(item);
-        this.updateId(item);
+        item.update();
         this.index++;
 
         let event = new CreateEvent(item)
@@ -223,7 +222,6 @@ export class ListForm extends Form
         this.eventDispatcher.dispatchEvent(new MoveEvent(item), 'move')
     }
 
-
     public changeOrder(event: any)
     {
         if (event.added) {
@@ -256,37 +254,7 @@ export class ListForm extends Form
         form.parent = this;
 
         for (let child of form.children) {
-            this.updateFullName(child);
-        }
-    }
-
-    protected updateId(form: Form)
-    {
-        let names = [];
-        for (let parent of form.getParents().reverse()) {
-            names.push(parent.name);
-        }
-        names.push(form.name);
-        form.id = names.join('_');
-
-        for (let child of form.children) {
-            this.updateId(child);
-        }
-    }
-
-    protected updateFullName(form: Form)
-    {
-        let parents = form.getParents().reverse();
-        let fullName = parents.shift().name;
-        for (let parent of parents) {
-            fullName += '[' + parent.name + ']';
-        }
-        fullName += '[' + form.name + ']';
-
-        form.fullName = fullName;
-
-        for (let child of form.children) {
-            this.updateFullName(child);
+            child.update();
         }
     }
 }

--- a/assets/node_modules/@enhavo/vue-form/model/ChoiceForm.ts
+++ b/assets/node_modules/@enhavo/vue-form/model/ChoiceForm.ts
@@ -9,6 +9,26 @@ export class ChoiceForm extends Form
     separator: string;
     placeholder: string;
     choices: Choice[];
+
+    init() {
+
+    }
+
+    public update(recursive: boolean = true)
+    {
+        if (this.expanded) {
+            super.update(false);
+            let fullName = this.fullName;
+            if (this.multiple) {
+                fullName += '[]';
+            }
+            for (let child of this.children) {
+                child.fullName = fullName;
+            }
+        } else {
+            super.update(recursive);
+        }
+    }
 }
 
 export class Choice
@@ -18,4 +38,3 @@ export class Choice
     value: string;
     choices: Choice[];
 }
-

--- a/assets/node_modules/@enhavo/vue-form/model/Form.ts
+++ b/assets/node_modules/@enhavo/vue-form/model/Form.ts
@@ -83,6 +83,16 @@ export class Form
         return this.value;
     }
 
+    public setValue(value: any)
+    {
+        if (this.compound) {
+            return;
+        }
+
+        this.value = value;
+        this.dispatchChange();
+    }
+
     public dispatchChange()
     {
         this.eventDispatcher.dispatchEvent(new ChangeEvent(this, this.getValue()), 'change');
@@ -97,6 +107,28 @@ export class Form
     {
         for (let child of this.children) {
             child.destroy();
+        }
+    }
+
+    public update(recursive: boolean = true)
+    {
+        let names = [];
+        for (let parent of this.getParents().reverse()) {
+            names.push(parent.name);
+        }
+        names.push(this.name);
+        this.id = names.join('_');
+
+        let fullName = '';
+        for (let name of names) {
+            fullName += '[' + name + ']';
+        }
+        this.fullName = fullName;
+
+        if (recursive) {
+            for (let child of this.children) {
+                child.update();
+            }
         }
     }
 }

--- a/src/Enhavo/Bundle/VueFormBundle/Form/Extension/ChoiceVueTypeExtension.php
+++ b/src/Enhavo/Bundle/VueFormBundle/Form/Extension/ChoiceVueTypeExtension.php
@@ -51,10 +51,22 @@ class ChoiceVueTypeExtension extends AbstractVueTypeExtension
         return $data;
     }
 
+    public function finishVueData(FormView $view, VueData $data, array $options)
+    {
+        if ($options['expanded']) {
+            foreach ($view as $childView) {
+                /** @var VueData $vueData */
+                $vueData = $childView->vars['vue_data'];
+                $vueData->set('fullName', $childView->vars['full_name']);
+            }
+        }
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'component' => 'form-choice',
+            'component_model' => 'ChoiceForm'
         ]);
     }
 

--- a/src/Enhavo/Bundle/VueFormBundle/Form/Extension/RadioVueTypeExtension.php
+++ b/src/Enhavo/Bundle/VueFormBundle/Form/Extension/RadioVueTypeExtension.php
@@ -19,7 +19,7 @@ class RadioVueTypeExtension extends AbstractVueTypeExtension
     {
         $resolver->setDefaults([
             'component' => 'form-radio',
-            'component_model' => 'FormRadio',
+            'component_model' => 'RadioForm',
         ]);
     }
 

--- a/src/Enhavo/Bundle/VueFormBundle/Form/VueForm.php
+++ b/src/Enhavo/Bundle/VueFormBundle/Form/VueForm.php
@@ -23,7 +23,6 @@ class VueForm
         return $data->toArray();
     }
 
-
     private function assembleRelations(VueData $data)
     {
         $data['root'] = false;

--- a/src/Enhavo/Bundle/VueFormBundle/Tests/Form/Extension/ChoiceVueTypeExtensionTest.php
+++ b/src/Enhavo/Bundle/VueFormBundle/Tests/Form/Extension/ChoiceVueTypeExtensionTest.php
@@ -3,18 +3,23 @@
 namespace Enhavo\Bundle\VueFormBundle\Test\Form\Extension;
 
 use Enhavo\Bundle\AppBundle\Tests\Mock\TranslatorMock;
+use Enhavo\Bundle\VueFormBundle\Form\Extension\BaseVueTypeExtension;
 use Enhavo\Bundle\VueFormBundle\Form\Extension\ChoiceVueTypeExtension;
+use Enhavo\Bundle\VueFormBundle\Form\Extension\FormVueTypeExtension;
 use Enhavo\Bundle\VueFormBundle\Form\Extension\VueTypeExtension;
 use Enhavo\Bundle\VueFormBundle\Form\VueForm;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ChoiceVueTypeExtensionTest extends TypeTestCase
 {
     protected function getTypeExtensions()
     {
+        $normalizer = $this->getMockBuilder(NormalizerInterface::class)->getMock();
         return [
             new VueTypeExtension(),
+            new FormVueTypeExtension(new TranslatorMock('_translated'), $normalizer),
             new ChoiceVueTypeExtension(new TranslatorMock('_translated')),
         ];
     }
@@ -39,5 +44,22 @@ class ChoiceVueTypeExtensionTest extends TypeTestCase
         $this->assertArrayHasKey('separator', $data);
 
         $this->assertEquals('label1_translated', $data['choices'][0]['label']);
+    }
+
+    public function testChildVarsForExtended()
+    {
+        $vueForm = new VueForm();
+        $form = $this->factory->create(ChoiceType::class, null, [
+            'choices' => [
+                'label1' => 'value1',
+                'label2' => 'value2',
+            ],
+            'expanded' => true,
+        ]);
+
+        $view = $form->createView();
+        $data = $vueForm->createData($form->createView($view));
+        $this->assertEquals('choice[choice]', $data['children'][0]['fullName']);
+        $this->assertEquals('choice[choice]', $data['children'][1]['fullName']);
     }
 }

--- a/src/Enhavo/Bundle/VueFormBundle/Tests/Form/Extension/RadioVueTypeExtensionTest.php
+++ b/src/Enhavo/Bundle/VueFormBundle/Tests/Form/Extension/RadioVueTypeExtensionTest.php
@@ -26,6 +26,6 @@ class RadioVueTypeExtensionTest extends TypeTestCase
         $data = $vueForm->createData($form->createView());
 
         $this->assertEquals('form-radio', $data['component']);
-        $this->assertEquals('FormRadio', $data['componentModel']);
+        $this->assertEquals('RadioForm', $data['componentModel']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| License       | MIT

Choice children, when choice has the option expanded, have different full names as other forms. In php, the `ChoiceType` will change the full name in `finishView`. So on the js site, we can't use the `updateFullName` in `ListForm`, because we assume that every full name of a form has the same build rules. So we have to delegate the rebuilding of the full name to the model, so it can overwrite its behaviour if needed.
