### PR TITLE
[Media(Libary)] Add webp + Fix no parameters on MediaLibrary select

### DIFF
--- a/assets/node_modules/@enhavo/media/type/MediaItem.ts
+++ b/assets/node_modules/@enhavo/media/type/MediaItem.ts
@@ -79,6 +79,15 @@ export default class MediaItem
         this.$element.find('[data-media-item-filename]').val(filename);
     }
 
+    setParameters(parameters:object): void  {
+        for (let key in parameters) {
+            let param = this.$element.find('[data-parameter-key="' + key + '"]');
+            if (param.length) {
+                param.val(parameters[key]);
+            }
+        }
+    }
+
     setId(id:number)
     {
         this.meta.id = id;
@@ -125,6 +134,7 @@ export default class MediaItem
             case 'image/jpg':
             case 'image/jpeg':
             case 'image/gif':
+            case 'image/webp':
                 mediaThumb.css('background-image', 'url('+this.getThumbUrl()+')');
                 break;
             case 'video/mpeg':

--- a/assets/node_modules/@enhavo/media/type/MediaItemMeta.ts
+++ b/assets/node_modules/@enhavo/media/type/MediaItemMeta.ts
@@ -13,5 +13,7 @@ export default class MediaItemMeta
 
     token: string;
 
-    order: number
+    order: number;
+
+    parameters: object
 }

--- a/assets/node_modules/@enhavo/media/type/MediaRow.ts
+++ b/assets/node_modules/@enhavo/media/type/MediaRow.ts
@@ -85,6 +85,7 @@ export default class MediaRow
         let item = new MediaItem(html, meta, this);
         item.setFilename(meta.filename);
         item.setId(meta.id);
+        item.setParameters(meta.parameters);
         this.items.push(item);
         this.$element.append(html);
         $(document).trigger('mediaAddItem', [item]);

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
     "ext-libxml": "*",
     "ext-zip": "*",
     "ext-zlib": "*",
+    "ext-gd": "*",
+    "ext-exif": "*",
     "behat/transliterator": "^1.5",
     "composer/package-versions-deprecated": "1.11.*",
     "doctrine/doctrine-migrations-bundle": "^3.1",

--- a/src/Enhavo/Bundle/MediaBundle/Filter/AbstractFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/AbstractFilter.php
@@ -64,6 +64,8 @@ abstract class AbstractFilter extends AbstractType implements FilterInterface
                 return 'png';
             case(IMAGETYPE_BMP):
                 return 'bmp';
+            case(IMAGETYPE_WEBP):
+                return 'webp';
         }
         return null;
     }
@@ -79,6 +81,8 @@ abstract class AbstractFilter extends AbstractType implements FilterInterface
                 return 'image/png';
             case('bmp'):
                 return 'image/bmp';
+            case('webp'):
+                return 'image/webp';
         }
         return null;
     }

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageFilter.php
@@ -12,13 +12,12 @@ use Enhavo\Bundle\MediaBundle\Content\ContentInterface;
 use Enhavo\Bundle\MediaBundle\Exception\FilterException;
 use Enhavo\Bundle\MediaBundle\Filter\AbstractFilter;
 use Enhavo\Bundle\MediaBundle\Model\FilterSetting;
-use Imagine\Exception\RuntimeException;
 use Imagine\Gd\Imagine;
-use Imagine\Imagick\Imagine as ImagickImagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\Palette\RGB;
 use Imagine\Image\Point;
+use Imagine\Imagick\Imagine as ImagickImagine;
 
 class ImageFilter extends AbstractFilter
 {
@@ -42,17 +41,20 @@ class ImageFilter extends AbstractFilter
             $options = $this->getSaveOptions($format, $setting);
             $options['animated'] = true;
             $resultImage->save($content->getFilePath(), $options);
+
         } elseif($format == 'bmp' && class_exists('Imagick') ) {
             $imagine = new ImagickImagine();
             $image = $imagine->load($content->getContent());
             $resultImage = $image->copy();
             $resultImage = $this->resize($resultImage, $setting);
             $resultImage->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
+
         } elseif(class_exists('Imagick') ) {
             $imagine = new ImagickImagine();
             $imagine = $imagine->load($content->getContent());
             $imagine = $this->resize($imagine, $setting);
             $imagine->save($content->getFilePath(), $this->getSaveOptions($format, $setting));
+
         } else {
             $imagine = new Imagine();
             $imagine = $imagine->load($content->getContent());

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/MimetypeFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/MimetypeFilter.php
@@ -24,7 +24,6 @@ class MimetypeFilter extends AbstractFilter
 
     public function apply($file, FilterSetting $setting)
     {
-        $content = $this->getContent($file);
         $mimeType = $file->getMimeType();
         $format = $setting->getSetting('format');
         $mimeTypes = $setting->getSetting('mimetypes', []);
@@ -32,7 +31,7 @@ class MimetypeFilter extends AbstractFilter
         foreach ($settings as $setting) {
             if (in_array($mimeType, $mimeTypes)) {
                 $format = $this->formatManager->getFilter($setting->getType());
-                $format->apply($content, $setting);
+                $format->apply($file, $setting);
             }
         }
     }

--- a/src/Enhavo/Bundle/MediaBundle/Form/Type/FileType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Form/Type/FileType.php
@@ -138,6 +138,14 @@ class FileType extends AbstractType
         }
     }
 
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        foreach ($view->children['parameters'] as $child) {
+            $child->vars['attr'] = $child->vars['attr'] ?: [];
+            $child->vars['attr']['data-parameter-key'] = $child->vars['name'];
+        }
+    }
+
     /**
      * @param OptionsResolver $resolver
      */

--- a/src/Enhavo/Bundle/MediaBundle/composer.json
+++ b/src/Enhavo/Bundle/MediaBundle/composer.json
@@ -19,7 +19,9 @@
     "spatie/image-optimizer": "^1.0",
     "imagine/imagine": "^1.2",
     "guzzlehttp/guzzle": "^6.5",
-    "symfony/mime": "^5.4"
+    "symfony/mime": "^5.4",
+    "ext-gd": "*",
+    "ext-exif": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5"

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Controller/FileController.php
@@ -5,6 +5,7 @@ namespace Enhavo\Bundle\MediaLibraryBundle\Controller;
 use Enhavo\Bundle\AppBundle\Controller\RequestConfiguration;
 use Enhavo\Bundle\AppBundle\Controller\ResourceController;
 use Enhavo\Bundle\MediaBundle\Controller\FileControllerTrait;
+use Enhavo\Bundle\MediaLibraryBundle\Entity\File;
 use Enhavo\Bundle\MediaLibraryBundle\Media\MediaLibraryManager;
 use Enhavo\Bundle\MediaLibraryBundle\Repository\FileRepository;
 use Enhavo\Bundle\MediaLibraryBundle\View\Type\MediaLibraryViewType;
@@ -144,6 +145,7 @@ class FileController extends ResourceController
     public function addAction(Request $request): JsonResponse
     {
         $id = $request->get('id');
+        /** @var File $file */
         $file = $this->getFileRepository()->find($id);
 
         return new JsonResponse([
@@ -151,6 +153,7 @@ class FileController extends ResourceController
             'filename' => $file->getFilename(),
             'mimeType' => $file->getMimeType(),
             'token' => $file->getToken(),
+            'parameters' => $file->getParameters(),
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc PR?       | no
| Backport      | 0.11 <!-- choose version where this PR should apply as well -->
| License       | MIT

a) It was not possible to set output format of ImageFilter to webp although it already is possible in imagick and gd
b) After selecting files in MediaLibrary, the parameters were not received and set in the newly generated FileParameters Form
