### PR TITLE
feat: make the condition resolver available in a static routes

### DIFF
--- a/src/App/Controller/PersonController.php
+++ b/src/App/Controller/PersonController.php
@@ -10,20 +10,14 @@ namespace App\Controller;
 
 use App\Form\Type\PersonType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @package App\Controller
- * @Route("/person")
- */
+#[Route('/person')]
 class PersonController extends AbstractController
 {
-    /**
-     * @Route("/", name="app_theme_person_index")
-     */
+    #[Route('/', name: 'app_theme_person_index', condition: 'context.getResolver()')]
     public function indexAction(Request $request)
     {
         $form = $this->createForm(PersonType::class);

--- a/src/Enhavo/Bundle/RoutingBundle/DependencyInjection/Compiler/ConditionResolverPass.php
+++ b/src/Enhavo/Bundle/RoutingBundle/DependencyInjection/Compiler/ConditionResolverPass.php
@@ -18,10 +18,12 @@ class ConditionResolverPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $conditionResolver = $container->getParameter('enhavo_routing.condition_resolver');
-        if($conditionResolver) {
+        if ($conditionResolver) {
             $definition = $container->getDefinition('cmf_routing.final_matcher');
             $definition->setClass(ConditionUrlMatcher::class);
             $definition->addArgument(new Reference($conditionResolver));
+
+            $container->setAlias('enhavo_routing.condition_resolver', $conditionResolver);
         }
     }
 }

--- a/src/Enhavo/Bundle/RoutingBundle/Request/RequestContext.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Request/RequestContext.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Enhavo\Bundle\RoutingBundle\Request;
+
+use Enhavo\Bundle\RoutingBundle\Condition\ConditionResolverInterface;
+
+/**
+ * We want to use the resolver in static routes. Unlike in cmf routing, the static routes getting compiled to php
+ * for faster execution. So it is hard to inject further variables to the condition language expression. Thus, we abuse
+ * the request context to inject our condition resolver to make it available in any static routing condition expression.
+ */
+class RequestContext extends \Symfony\Component\Routing\RequestContext
+{
+    private ?ConditionResolverInterface $resolver;
+
+    public function resolve()
+    {
+        return $this->resolver->resolve();
+    }
+
+    public function getResolver(): ?ConditionResolverInterface
+    {
+        return $this->resolver;
+    }
+
+    public function setResolver(?ConditionResolverInterface $resolver): void
+    {
+        $this->resolver = $resolver;
+    }
+}

--- a/src/Enhavo/Bundle/RoutingBundle/Resources/config/services/general.yaml
+++ b/src/Enhavo/Bundle/RoutingBundle/Resources/config/services/general.yaml
@@ -25,3 +25,9 @@ services:
     Enhavo\Bundle\RoutingBundle\Twig\SlugifyExtension:
         tags:
             - { name: twig.extension }
+
+    Enhavo\Bundle\RoutingBundle\Request\RequestContext:
+        decorates: router.request_context
+        class: Enhavo\Bundle\RoutingBundle\Request\RequestContext
+        calls:
+            - ['setResolver', ['@enhavo_routing.condition_resolver']]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Doc PR?       | no
| Backport      | 0.10, 0.11, 0.12
| License       | MIT

* Make the condition resolver available in a static routes over the request context
