### PR TITLE
chore: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,10 @@
-| Q             | A
-| ------------- | ---
-| Bug fix?      | yes/no
-| New feature?  | yes/no
-| Doc PR?       | yes/no
-| Backport      | 0.9 <!-- choose version where this PR should apply as well -->
-| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
-| License       | MIT
+| Q            | A
+|--------------| ---
+| Bug fix?     | yes/no
+| New feature? | yes/no
+| BC-Break?    | yes/no
+| Backport     | 0.9 <!-- choose version where this PR should apply as well -->
+| Tickets      | Fix #... <!-- prefix each issue number with "Fix #", if any -->
+| License      | MIT
 
-<!--
-Replace this notice by a short README for your feature/bugfix/docs. This will help people
-understand your PR.
--->
+<!-- Replace this notice by a short README to help people to understand your PR. -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| License       | MIT

Update PR Template to track BC-Break instead of Doc PR
