### PR TITLE
fix: file type if no parameters type is set

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Form/Type/FileType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Form/Type/FileType.php
@@ -140,9 +140,11 @@ class FileType extends AbstractType
 
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
-        foreach ($view->children['parameters'] as $child) {
-            $child->vars['attr'] = $child->vars['attr'] ?: [];
-            $child->vars['attr']['data-parameter-key'] = $child->vars['name'];
+        if (isset($view->children['parameters'])) {
+            foreach ($view->children['parameters'] as $child) {
+                $child->vars['attr'] = $child->vars['attr'] ?: [];
+                $child->vars['attr']['data-parameter-key'] = $child->vars['name'];
+            }
         }
     }
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.12
| License      | MIT

* Fix `FileType`: If no parameters type is set, we should't get any errors
