### PR TITLE
feat: type extension

### DIFF
--- a/src/Enhavo/Component/Type/AbstractTypeExtension.php
+++ b/src/Enhavo/Component/Type/AbstractTypeExtension.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: gseidel
+ * Date: 2020-06-08
+ * Time: 10:56
+ */
+
+namespace Enhavo\Component\Type;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractTypeExtension implements TypeExtensionInterface
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+
+    }
+}

--- a/src/Enhavo/Component/Type/Exception/TypeNotValidException.php
+++ b/src/Enhavo/Component/Type/Exception/TypeNotValidException.php
@@ -8,6 +8,7 @@
 
 namespace Enhavo\Component\Type\Exception;
 
+use Enhavo\Component\Type\TypeExtensionInterface;
 use Enhavo\Component\Type\TypeInterface;
 
 class TypeNotValidException extends \InvalidArgumentException
@@ -15,6 +16,16 @@ class TypeNotValidException extends \InvalidArgumentException
     public static function invalidInterface($class)
     {
         return new self(sprintf('"%s" does not implement "%s"', $class, TypeInterface::class));
+    }
+
+    public static function invalidExtensionInterface($class)
+    {
+        return new self(sprintf('"%s" does not implement "%s"', $class, TypeExtensionInterface::class));
+    }
+
+    public static function extendedTypeNotExists(string $extensionClass, array $extendedTypes)
+    {
+        return new self(sprintf('Type "%s" does not exists for extension "%s"', join(',', $extendedTypes), $extensionClass));
     }
 
     public static function nameExists($name, $namespace, $class)

--- a/src/Enhavo/Component/Type/Factory.php
+++ b/src/Enhavo/Component/Type/Factory.php
@@ -39,7 +39,7 @@ class Factory implements FactoryInterface
         $type = $this->registry->getType($options['type']);
         $parents = $this->getParents($type);
         unset($options['type']);
-        $class = new $this->class($type, $parents, $options, $key);
+        $class = new $this->class($type, $parents, $options, $key, $this->getExtensions($type, $parents));
         return $class;
     }
 
@@ -55,5 +55,33 @@ class Factory implements FactoryInterface
         }
 
         return array_reverse($parents);
+    }
+
+    private function getExtensions(TypeInterface $type, array $parents): array
+    {
+        $extensions = [];
+
+        $checkTypes = [$type];
+        foreach ($parents as $parent) {
+            $checkTypes[] = $parent;
+        }
+
+        foreach ($checkTypes as $checkType) {
+            foreach ($this->registry->getExtensions($checkType) as $foundExtension) {
+                $exists = false;
+                foreach ($extensions as $extension) {
+                    if ($extension === $foundExtension) {
+                        $exists = true;
+                        break;
+                    }
+                }
+
+                if (!$exists) {
+                    $extensions[] = $foundExtension;
+                }
+            }
+        }
+
+        return $extensions;
     }
 }

--- a/src/Enhavo/Component/Type/RegistryExtension.php
+++ b/src/Enhavo/Component/Type/RegistryExtension.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: gseidel
+ * Date: 2020-06-08
+ * Time: 11:21
+ */
+
+namespace Enhavo\Component\Type;
+
+class RegistryExtension
+{
+    private ?TypeExtensionInterface $service = null;
+
+    public function __construct(
+        private string $id,
+        private string $class,
+        private array $extendedTypes,
+        private int $priority,
+    )
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getExtendedTypes(): array
+    {
+        return $this->extendedTypes;
+    }
+
+    /**
+     * @return TypeExtensionInterface|null
+     */
+    public function getService(): ?TypeExtensionInterface
+    {
+        return $this->service;
+    }
+
+    /**
+     * @param TypeExtensionInterface|null $service
+     */
+    public function setService(?TypeExtensionInterface $service): void
+    {
+        $this->service = $service;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/src/Enhavo/Component/Type/RegistryInterface.php
+++ b/src/Enhavo/Component/Type/RegistryInterface.php
@@ -11,5 +11,7 @@ namespace Enhavo\Component\Type;
 
 interface RegistryInterface
 {
-    public function getType(string $name);
+    public function getType(string $name): TypeInterface;
+
+    public function getExtensions(TypeInterface $type): array;
 }

--- a/src/Enhavo/Component/Type/Tests/FactoryTest.php
+++ b/src/Enhavo/Component/Type/Tests/FactoryTest.php
@@ -8,6 +8,7 @@
 
 namespace Enhavo\Component\Type\Tests;
 
+use Enhavo\Component\Type\AbstractTypeExtension;
 use Enhavo\Component\Type\AbstractType;
 use Enhavo\Component\Type\Exception\TypeCreateException;
 use Enhavo\Component\Type\Factory;
@@ -34,12 +35,16 @@ class FactoryTest extends TestCase
     {
         $testType = new FactoryTestType();
         $parentType = new FactoryParentType();
+        $parentExtensionType = new FactoryParentExtensionType();
         $rootType = new FactoryRootType();
+        $rootExtensionType = new FactoryRootExtensionType();
 
-        $dependencies =$this->createDependencies();
+        $dependencies = $this->createDependencies();
         $dependencies->registry->register('test', $testType);
         $dependencies->registry->register('parent', $parentType);
         $dependencies->registry->register('root', $rootType);
+        $dependencies->registry->registerExtension('parent', $parentExtensionType);
+        $dependencies->registry->registerExtension('root', $rootExtensionType);
         $factory = $this->createInstance($dependencies);
 
         /** @var ConcreteTest $typeContainer */
@@ -51,6 +56,7 @@ class FactoryTest extends TestCase
         $this->assertTrue($testType === $typeContainer->type);
         $this->assertEquals(['option' => 'value'], $typeContainer->options);
         $this->assertEquals([$rootType, $parentType], $typeContainer->parents);
+        $this->assertEquals([$rootExtensionType, $parentExtensionType], $typeContainer->extensions);
     }
 
     public function testMissingType()
@@ -86,17 +92,21 @@ class ConcreteTest
     /** @var array */
     public $options;
 
+    /** @var array */
+    public $extensions;
+
     /**
      * ConcreteTest constructor.
      * @param TypeInterface $type
      * @param TypeInterface[] $parents
      * @param array $options
      */
-    public function __construct(TypeInterface $type, array $parents, array $options)
+    public function __construct(TypeInterface $type, array $parents, array $options, $key = null, $extensions = [])
     {
         $this->type = $type;
         $this->parents = $parents;
         $this->options = $options;
+        $this->extensions = $extensions;
     }
 }
 
@@ -116,9 +126,25 @@ class FactoryParentType extends AbstractType
     }
 }
 
+class FactoryParentExtensionType extends AbstractTypeExtension
+{
+    public static function getExtendedTypes(): array
+    {
+        return [FactoryParentType::class];
+    }
+}
+
 class FactoryRootType extends AbstractType
 {
 
+}
+
+class FactoryRootExtensionType extends AbstractTypeExtension
+{
+    public static function getExtendedTypes(): array
+    {
+        return [FactoryRootType::class];
+    }
 }
 
 

--- a/src/Enhavo/Component/Type/Tests/Mock/RegistryMock.php
+++ b/src/Enhavo/Component/Type/Tests/Mock/RegistryMock.php
@@ -10,28 +10,48 @@ namespace Enhavo\Component\Type\Tests\Mock;
 
 use Enhavo\Component\Type\Exception\TypeNotFoundException;
 use Enhavo\Component\Type\RegistryInterface;
+use Enhavo\Component\Type\TypeInterface;
 
 class RegistryMock implements RegistryInterface
 {
     private $types = [];
+    private $extensions = [];
 
     public function register($name, $type)
     {
         return $this->types[$name] = $type;
     }
 
-    public function getType(string $name)
+    public function registerExtension($name, $extension)
+    {
+        return $this->extensions[$name] = $extension;
+    }
+
+    public function getType(string $name): TypeInterface
     {
         if (isset($this->types[$name])) {
             return $this->types[$name];
         }
 
         foreach ($this->types as $type) {
-            if(get_class($type) === $name) {
+            if (get_class($type) === $name) {
                 return $type;
             }
         }
 
         throw TypeNotFoundException::notFound($name, 'Test', array_keys($this->types));
+    }
+
+    public function getExtensions(TypeInterface $type): array
+    {
+        foreach ($this->types as $name => $foundType) {
+            if ($foundType === $type) {
+                if (isset($this->extensions[$name])) {
+                    return [$this->extensions[$name]];
+                }
+            }
+        }
+
+        return [];
     }
 }

--- a/src/Enhavo/Component/Type/Tests/TypeExtensionCompilerPassTest.php
+++ b/src/Enhavo/Component/Type/Tests/TypeExtensionCompilerPassTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: gseidel
+ * Date: 2020-06-08
+ * Time: 14:49
+ */
+
+namespace Enhavo\Component\Type\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Enhavo\Component\Type\TypeExtensionCompilerPass;
+
+class TypeExtensionCompilerPassTest extends TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->addDefinitions([
+            'Enhavo\Component\Type\RegistryInterface[Test]' => $this->createTypeDefinition('Enhavo\Component\Type\Registry'),
+            'extensionTypeOne' => $this->createTypeDefinition('ExtensionClassTypeOne', 'test.tag'),
+            'extensionTypeTwo' => $this->createTypeDefinition('ExtensionClassTypeTwo', 'test.tag')
+        ]);
+
+        $pass = new TypeExtensionCompilerPass('Test', 'test.tag', 'ConcreteTypeClass');
+
+        $pass->process($container);
+
+        $registryDefinition = $container->getDefinition('Enhavo\Component\Type\RegistryInterface[Test]');
+
+        $this->assertCount(2, $registryDefinition->getMethodCalls());
+        $this->assertEquals('registerExtension', $registryDefinition->getMethodCalls()[0][0]);
+        $this->assertEquals('ExtensionClassTypeOne', $registryDefinition->getMethodCalls()[0][1][0]);
+        $this->assertEquals('extensionTypeOne', $registryDefinition->getMethodCalls()[0][1][1]);
+    }
+
+    private function createTypeDefinition($class, $tag = null)
+    {
+        $definition = new Definition();
+        $definition->setClass($class);
+        if ($tag) {
+            $definition->addTag($tag);
+        }
+        return $definition;
+    }
+}

--- a/src/Enhavo/Component/Type/TypeExtensionCompilerPass.php
+++ b/src/Enhavo/Component/Type/TypeExtensionCompilerPass.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * AbstractCollectorPass.php
+ *
+ * @since 29/05/16
+ * @author gseidel
+ */
+
+namespace Enhavo\Component\Type;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class TypeExtensionCompilerPass implements CompilerPassInterface
+{
+    public function __construct(
+        private string $namespace,
+        private string $tagName
+    )
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $registryDefinitionId = sprintf('%s[%s]', RegistryInterface::class, $this->namespace);
+        $registryDefinition = $container->getDefinition($registryDefinitionId);
+
+
+        $taggedServices = $container->findTaggedServiceIds($this->tagName);
+
+        foreach ($taggedServices as $id => $tagAttributes) {
+            $priority = 10;
+            foreach ($tagAttributes as $tagAttribute) {
+                if (isset($tagAttribute['priority'])) {
+                    $priority = $tagAttribute['priority'];
+                    break;
+                }
+            }
+
+            $tagServiceDefinition = $container->getDefinition($id);
+            $tagServiceDefinition->setPublic(true);
+            $registryDefinition->addMethodCall(
+                'registerExtension',
+                array($tagServiceDefinition->getClass() ?: $id, $id, $priority)
+            );
+        }
+    }
+}

--- a/src/Enhavo/Component/Type/TypeExtensionInterface.php
+++ b/src/Enhavo/Component/Type/TypeExtensionInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * TypeInterface.php
+ *
+ * @since 29/05/16
+ * @author gseidel
+ */
+
+namespace Enhavo\Component\Type;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+interface TypeExtensionInterface
+{
+    public static function getExtendedTypes(): array;
+
+    public function configureOptions(OptionsResolver $resolver);
+}


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Allow to extends type via `TypeExtensionCompilerPass`. With this compiler you are able to add extensions to the registry. The factory will pass all needed extensions to the container class to apply if neccessary.
