### PR TITLE
fix: content in api docs

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -9,7 +9,3 @@ app:
 endpoint:
     resource: ../src/App/Endpoint
     type: endpoint
-
-app_controller:
-    resource: ../src/App/Controller
-    type: annotation

--- a/src/Enhavo/Bundle/ApiBundle/Documentation/Model/Content.php
+++ b/src/Enhavo/Bundle/ApiBundle/Documentation/Model/Content.php
@@ -20,12 +20,6 @@ class Content
         return new Schema($this->content['schema'], $this);
     }
 
-    public function example($data): self
-    {
-        $this->content['examples'] = $data;
-        return $this;
-    }
-
     public function end()
     {
         return $this->parent;

--- a/src/Enhavo/Bundle/ApiBundle/Documentation/Model/Response.php
+++ b/src/Enhavo/Bundle/ApiBundle/Documentation/Model/Response.php
@@ -19,11 +19,15 @@ class Response
 
     public function content($mimeType = 'application/json'): Content
     {
-        if (!array_key_exists($mimeType, $this->response)) {
-            $this->response[$mimeType] = [];
+        if (!array_key_exists('content', $this->response)) {
+            $this->response['content'] = [];
         }
 
-        return new Content($this->response[$mimeType], $this);
+        if (!array_key_exists($mimeType, $this->response['content'])) {
+            $this->response['content'][$mimeType] = [];
+        }
+
+        return new Content($this->response['content'][$mimeType], $this);
     }
 
     public function end(): Method

--- a/src/Enhavo/Bundle/ApiBundle/Tests/Documentation/DocumentationTest.php
+++ b/src/Enhavo/Bundle/ApiBundle/Tests/Documentation/DocumentationTest.php
@@ -41,9 +41,6 @@ class DocumentationTest extends TestCase
                                     ->end()
                                 ->end()
                             ->end()
-                            ->example([
-                                'test' => 'hello'
-                            ])
                         ->end()
                     ->end()
                 ->end()
@@ -69,10 +66,7 @@ class DocumentationTest extends TestCase
                     ]
                 ]
             ],
-            'examples' => [
-                'test' => 'hello'
-            ]
-        ], $output['paths']['/test/url']['post']['responses'][200]['application/json']);
+        ], $output['paths']['/test/url']['post']['responses'][200]['content']['application/json']);
     }
 
     public function testInfo()


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

* fix showing content object in api docs
* remove examples
