### PR TITLE
[MultiTenancyBundle] Fix call on null error exception if Resolver is used from Command

### DIFF
--- a/src/Enhavo/Bundle/MultiTenancyBundle/Resolver/SessionResolver.php
+++ b/src/Enhavo/Bundle/MultiTenancyBundle/Resolver/SessionResolver.php
@@ -32,23 +32,24 @@ class SessionResolver implements ResolverInterface
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        if ($this->routePrefixOnly !== null && $this->routePrefixOnly !== '') {
-            $path = $request->getPathInfo();
-            if (strpos($path, $this->routePrefixOnly) !== 0) {
+        if ($request) {
+            if ($this->routePrefixOnly !== null && $this->routePrefixOnly !== '') {
+                $path = $request->getPathInfo();
+                if (strpos($path, $this->routePrefixOnly) !== 0) {
+                    return null;
+                }
+            }
+            $session = $request->getSession();
+            if (!$session->has($this->sessionKey)) {
                 return null;
             }
-        }
 
-        if(!$request->getSession()->has($this->sessionKey)) {
-            return null;
-        }
+            $tenantKey = $session->get($this->sessionKey);
 
-        $tenantKey = $request->getSession()->get($this->sessionKey);
-
-        foreach ($this->provider->getTenants() as $tenant) {
-            $keys[] = $tenant->getKey();
-            if ($tenant->getKey() === $tenantKey) {
-                return $tenant;
+            foreach ($this->provider->getTenants() as $tenant) {
+                if ($tenant->getKey() === $tenantKey) {
+                    return $tenant;
+                }
             }
         }
 

--- a/src/Enhavo/Bundle/MultiTenancyBundle/Tests/Resolver/SessionResolverTest.php
+++ b/src/Enhavo/Bundle/MultiTenancyBundle/Tests/Resolver/SessionResolverTest.php
@@ -100,6 +100,19 @@ class SessionResolverTest extends TestCase
         $this->assertNull($resolver->getTenant());
     }
 
+    public function testRequestMissing()
+    {
+        $dependencies = $this->createDependencies();
+        $dependencies->requestStack = $this->createMock(RequestStack::class);
+        $dependencies->requestStack->expects($this->once())->method('getCurrentRequest')->willReturn(null);
+        $dependencies->request->expects($this->never())->method('getPathInfo');
+        $dependencies->request->expects($this->never())->method('getSession');
+
+        $resolver = $this->createInstance($dependencies);
+
+        $this->assertNull($resolver->getTenant());
+    }
+
 }
 
 class SessionResolverTestDependencies

--- a/src/Enhavo/Bundle/MultiTenancyBundle/Tests/Resolver/SessionResolverTest.php
+++ b/src/Enhavo/Bundle/MultiTenancyBundle/Tests/Resolver/SessionResolverTest.php
@@ -105,8 +105,6 @@ class SessionResolverTest extends TestCase
         $dependencies = $this->createDependencies();
         $dependencies->requestStack = $this->createMock(RequestStack::class);
         $dependencies->requestStack->expects($this->once())->method('getCurrentRequest')->willReturn(null);
-        $dependencies->request->expects($this->never())->method('getPathInfo');
-        $dependencies->request->expects($this->never())->method('getSession');
 
         $resolver = $this->createInstance($dependencies);
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.10
| Tickets      | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License      | MIT

If e.g. TenantManager->getTenant was called from a CLI Command during resolver->getTenant no Request is provided in SessionResolver.
Instead of throwing an Error due to a call on a null object, return null and see if any of the remaining resolvers can resolve the tenant and finally return null if none was found.
