### PR TITLE
fix: GuzzleMessageFactory error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
     "payum/offline": "^1.5",
     "payum/paypal-express-checkout-nvp": "^1.7",
     "payum/payum-bundle": "^2.3",
-    "php-http/guzzle6-adapter": "^1|^2",
     "ruflin/elastica": "^7.1",
     "sensio/framework-extra-bundle": "^5.1",
     "simshaun/recurr": "^2.2",

--- a/config/packages/enhavo_payment.yaml
+++ b/config/packages/enhavo_payment.yaml
@@ -1,0 +1,4 @@
+payum:
+    gateways:
+#        offline:
+#            factory: offline

--- a/src/Enhavo/Bundle/PaymentBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/PaymentBundle/Resources/config/app/config.yaml
@@ -11,8 +11,6 @@ payum:
             Enhavo\Bundle\PaymentBundle\Entity\GatewayConfig: { doctrine: orm }
 
     gateways:
-        offline:
-            factory: offline
 
 enhavo_app:
     template_paths:


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

When using `bin/console` we get an error:

```
You cannot use "Http\Message\MessageFactory\GuzzleMessageFactory" as the "php-http/message-factory" package is not installed. Try running "composer require php-http/message-factory". Note that this package is deprecated, use "psr/http-factory" instead
```

This occurs if we use payum. When the payum builder run with the offline factory it will instanciate `Http\Message\MessageFactory\GuzzleMessageFactory` be default (because this class is available), but there is no `Http\Message\MessageFactory` available and that's why the error trigger.

Only in `php-http/message-factory` I could found a `MessageFactory`, in `psr/http-factory` this class is vacant. I don't want to add a deprecated package, so we remove the offline factory for the moment to avoid this error.


