### PR TITLE
[SearchBundle] Fixed pagination error on higher pagination pages when…

### DIFF
--- a/src/Enhavo/Bundle/SearchBundle/Controller/SearchController.php
+++ b/src/Enhavo/Bundle/SearchBundle/Controller/SearchController.php
@@ -52,8 +52,8 @@ class SearchController extends AbstractController
 
         $pagination = $this->searchEngine->searchPaginated($filter);
 
-        $pagination->setCurrentPage($page);
         $pagination->setMaxPerPage($configuration->getMaxPerPage());
+        $pagination->setCurrentPage($page);
 
         $results = $this->resultConverter->convert($pagination, $term);
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.12, 0.11, 0.10
| License      | MIT

Fixed pagination error on higher pagination pages when using less items per page than default
