### PR TITLE
Draft fix: inherit data with translation

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
@@ -83,7 +83,8 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
             'form_options' => $options,
             'form_type' => get_class($child->getConfig()->getType()->getInnerType()),
             'label' => $options['label'],
-            'translation_domain' => $options['translation_domain']
+            'translation_domain' => $options['translation_domain'],
+            'inherit_data' => $child->getConfig()->getInheritData(),
         ]);
     }
 }

--- a/src/Enhavo/Bundle/TranslationBundle/Form/Type/TranslationType.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/Type/TranslationType.php
@@ -10,7 +10,6 @@ namespace Enhavo\Bundle\TranslationBundle\Form\Type;
 
 use Enhavo\Bundle\TranslationBundle\Form\Transformer\TranslationValueTransformer;
 use Enhavo\Bundle\TranslationBundle\Translation\TranslationManager;
-use Enhavo\Bundle\TranslationBundle\Validator\Constraints\Translation;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -71,8 +70,7 @@ class TranslationType extends AbstractType
     {
         $resolver->setDefaults([
             'error_bubbling' => false,
-            'constraints' => [
-            ]
+            'constraints' => []
         ]);
 
         $resolver->setRequired([


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.12, 0.13
| Tickets      | Fix #1829
| License      | MIT

fix: inherit data with translation
