### PR TITLE
fix: normalize navigation

### DIFF
--- a/src/Enhavo/Bundle/ApiBundle/Normalizer/AbstractDataNormalizer.php
+++ b/src/Enhavo/Bundle/ApiBundle/Normalizer/AbstractDataNormalizer.php
@@ -4,13 +4,15 @@ namespace Enhavo\Bundle\ApiBundle\Normalizer;
 
 abstract class AbstractDataNormalizer implements DataNormalizerInterface
 {
+    protected bool $stopped = false;
+
     protected function hasSerializationGroup(string|array $group, array $context): bool
     {
         if (empty($context['groups'])) {
             return false;
         }
 
-        $groups = $this->getSerializationGroups($context);
+        $groups = $this->getSerializationGroupsFromContext($context);
         if (is_array($group)) {
             foreach ($group as $singeGroup) {
                 if (in_array($singeGroup, $groups)) {
@@ -24,7 +26,7 @@ abstract class AbstractDataNormalizer implements DataNormalizerInterface
         return false;
     }
 
-    private function getSerializationGroups(array $context): array
+    private function getSerializationGroupsFromContext(array $context): array
     {
         if (is_array($context['groups'])) {
            return $context['groups'];
@@ -32,5 +34,20 @@ abstract class AbstractDataNormalizer implements DataNormalizerInterface
             return [$context['groups']];
         }
         return [];
+    }
+
+    public function getSerializationGroups(array $groups, array $context = []): array
+    {
+        return $groups;
+    }
+
+    public function isStopped(): bool
+    {
+        return $this->stopped;
+    }
+
+    protected function stop(): void
+    {
+        $this->stopped = true;
     }
 }

--- a/src/Enhavo/Bundle/ApiBundle/Normalizer/DataNormalizerInterface.php
+++ b/src/Enhavo/Bundle/ApiBundle/Normalizer/DataNormalizerInterface.php
@@ -9,4 +9,8 @@ interface DataNormalizerInterface
     public function buildData(Data $data, $object, string $format = null, array $context = []);
 
     public static function getSupportedTypes(): array;
+
+    public function getSerializationGroups(array $groups, array $context = []): array;
+
+    public function isStopped(): bool;
 }

--- a/src/Enhavo/Bundle/AppBundle/Normalizer/FormDataNormalizer.php
+++ b/src/Enhavo/Bundle/AppBundle/Normalizer/FormDataNormalizer.php
@@ -3,12 +3,12 @@
 namespace Enhavo\Bundle\AppBundle\Normalizer;
 
 use Enhavo\Bundle\ApiBundle\Data\Data;
-use Enhavo\Bundle\ApiBundle\Normalizer\DataNormalizerInterface;
+use Enhavo\Bundle\ApiBundle\Normalizer\AbstractDataNormalizer;
 use Enhavo\Bundle\VueFormBundle\Form\VueForm;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormView;
 
-class FormDataNormalizer implements DataNormalizerInterface
+class FormDataNormalizer extends AbstractDataNormalizer
 {
     public function __construct(
         private VueForm $vueForm,

--- a/src/Enhavo/Bundle/ContentBundle/Normalizer/ContentDataNormalizer.php
+++ b/src/Enhavo/Bundle/ContentBundle/Normalizer/ContentDataNormalizer.php
@@ -18,7 +18,7 @@ class ContentDataNormalizer extends AbstractDataNormalizer
 
     public function buildData(Data $data, $object, string $format = null, array $context = [])
     {
-        if (!$this->hasSerializationGroup('endpoint', $context)) {
+        if (!$this->hasSerializationGroup(['endpoint', 'endpoint.navigation'], $context)) {
             return;
         }
 

--- a/src/Enhavo/Bundle/ContentBundle/Resources/config/serialization/content.yaml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/config/serialization/content.yaml
@@ -1,7 +1,9 @@
 Enhavo\Bundle\ContentBundle\Entity\Content:
     attributes:
+        id:
+            groups: ['endpoint', 'endpoint.navigation']
         title:
-            groups: ['endpoint']
+            groups: ['endpoint', 'endpoint.navigation']
         metaDescription:
             groups: ['endpoint']
         pageTitle:

--- a/src/Enhavo/Bundle/NavigationBundle/Endpoint/NavigationEndpointExtension.php
+++ b/src/Enhavo/Bundle/NavigationBundle/Endpoint/NavigationEndpointExtension.php
@@ -25,7 +25,7 @@ class NavigationEndpointExtension extends AbstractEndpointTypeExtension
 
         $navigationData = [];
         foreach ($navigations as $navigation) {
-            $navigationData[$navigation->getCode()] = $this->normalize($navigation, null, ['groups' => ['endpoint']]);
+            $navigationData[$navigation->getCode()] = $this->normalize($navigation, null, ['groups' => ['endpoint.navigation']]);
         }
 
         $data->set('navigation', $navigationData);

--- a/src/Enhavo/Bundle/NavigationBundle/Normalizer/NavigationNodeNormalizer.php
+++ b/src/Enhavo/Bundle/NavigationBundle/Normalizer/NavigationNodeNormalizer.php
@@ -4,6 +4,8 @@ namespace Enhavo\Bundle\NavigationBundle\Normalizer;
 
 use Enhavo\Bundle\ApiBundle\Data\Data;
 use Enhavo\Bundle\ApiBundle\Normalizer\AbstractDataNormalizer;
+use Enhavo\Bundle\NavigationBundle\Entity\Content;
+use Enhavo\Bundle\NavigationBundle\Entity\Link;
 use Enhavo\Bundle\NavigationBundle\Model\NodeInterface;
 use Enhavo\Bundle\NavigationBundle\Navigation\NavigationManager;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
@@ -19,7 +21,7 @@ class NavigationNodeNormalizer extends AbstractDataNormalizer implements Normali
 
     public function buildData(Data $data, $object, string $format = null, array $context = [])
     {
-        if (!$this->hasSerializationGroup('endpoint', $context)) {
+        if (!$this->hasSerializationGroup('endpoint.navigation', $context)) {
             return;
         }
 

--- a/src/Enhavo/Bundle/NavigationBundle/Resources/config/serialization/navigation.yaml
+++ b/src/Enhavo/Bundle/NavigationBundle/Resources/config/serialization/navigation.yaml
@@ -1,40 +1,40 @@
 Enhavo\Bundle\NavigationBundle\Entity\Navigation:
     attributes:
         id:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         nodes:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
 
 Enhavo\Bundle\NavigationBundle\Entity\Node:
     attributes:
         id:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         name:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         label:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         children:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         subject:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
 
 Enhavo\Bundle\NavigationBundle\Entity\Submenu:
     attributes:
         id:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
 
 Enhavo\Bundle\NavigationBundle\Entity\Link:
     attributes:
         id:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         link:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         target:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
 
 Enhavo\Bundle\NavigationBundle\Entity\Content:
     attributes:
         id:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]
         content:
-            groups: [ 'endpoint' ]
+            groups: [ 'endpoint.navigation' ]


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Feature?     | yes
| Bug fix?     | yes
| New feature? | no
| License      | MIT

* Use `endpoint.navigation` group to avoid full normalization of navigation subjects 
* Add `getSerializationGroups` and `isStopped` method to data normalizer to get more control of normalization
* Add context option `prevent_data_normalizers` to prevent data normalizer for execution
