### PR TITLE
fix: normalize content id and title

### DIFF
--- a/src/Enhavo/Bundle/ContentBundle/Resources/config/serialization/content.yaml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/config/serialization/content.yaml
@@ -1,9 +1,9 @@
 Enhavo\Bundle\ContentBundle\Entity\Content:
     attributes:
         id:
-            groups: ['endpoint', 'endpoint.navigation']
+            groups: ['endpoint', 'endpoint.navigation', 'endpoint.block']
         title:
-            groups: ['endpoint', 'endpoint.navigation']
+            groups: ['endpoint', 'endpoint.navigation', 'endpoint.block']
         metaDescription:
             groups: ['endpoint']
         pageTitle:


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

* Fix normalize content id and title for blocks
