### PR TITLE
fix: normalize term name

### DIFF
--- a/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/serialization.yaml
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/serialization.yaml
@@ -3,7 +3,7 @@ Enhavo\Bundle\TaxonomyBundle\Entity\Term:
         id:
             groups: ['form']
         name:
-            groups: ['form']
+            groups: ['form', 'endpoint.block']
         children:
             groups: ['form']
         parent:


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | no
| BC-Break?    | no
| License      | MIT

Fix normalize term name for blocks