### PR TITLE
fix: media library form file parameters

### DIFF
--- a/src/Enhavo/Bundle/MediaLibraryBundle/Form/Type/FileType.php
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Form/Type/FileType.php
@@ -21,14 +21,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FileType extends AbstractType
 {
-
     public function __construct(
         private MediaLibraryManager $mediaLibraryManager,
         private UrlGeneratorInterface $urlGenerator,
+        private array $formConfiguration,
     )
     {
     }
-
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -52,7 +51,7 @@ class FileType extends AbstractType
                 'edit_route' => 'enhavo_media_library_tag_update',
                 'view_key' => 'media_library_tags'
             ])
-            ->add('parameters', FileParametersType::class)
+            ->add('parameters', $this->formConfiguration['parameters_type'])
         ;
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA,  function(FormEvent $event) {

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
@@ -72,6 +72,7 @@ services:
         arguments:
             - '@Enhavo\Bundle\MediaLibraryBundle\Media\MediaLibraryManager'
             - '@enhavo_media.media.public_url_generator'
+            - '%enhavo_media.form%'
         tags:
             - { name: form.type }
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| License      | MIT

* Fix media library form file parameters, so it load same as in media bundle
