### PR TITLE
fix: move template file endpoint to media-bundle

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Type/TemplateEndpointType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Type/TemplateEndpointType.php
@@ -20,17 +20,6 @@ class TemplateEndpointType extends AbstractEndpointType
 
     public function handleRequest($options, Request $request, Data $data, Context $context)
     {
-        if ($options['media_routes']) {
-            $data->set('routes', [
-                'enhavo_media_file_show' => [
-                    'path' => '/template/file/show/{id}',
-                ],
-                'enhavo_media_file_format' => [
-                    'path' => '/template/file/format/{id}/{format}',
-                ],
-            ]);
-        }
-
         if (is_array($options['load'])) {
             foreach ($options['load'] as $file) {
                 $this->loader->merge($data, $this->loader->load($file), $options['recursive'], $options['depth']);
@@ -57,7 +46,6 @@ class TemplateEndpointType extends AbstractEndpointType
             'recursive' => false,
             'depth' => null,
             'description' => null,
-            'media_routes' => true,
         ]);
     }
 

--- a/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
@@ -119,14 +119,6 @@ services:
         tags:
             - { name: enhavo_api.endpoint }
 
-    Enhavo\Bundle\AppBundle\Endpoint\Type\TemplateFileEndpointType:
-        arguments:
-            - '%kernel.project_dir%/data/media'
-            - '@enhavo_media_library.factory.file'
-            - '@filesystem'
-        tags:
-            - { name: enhavo_api.endpoint }
-
     Enhavo\Bundle\AppBundle\Endpoint\Extension\RouterEndpointExtensionType:
         arguments:
             - '@Enhavo\Bundle\AppBundle\Twig\TwigRouter'

--- a/src/Enhavo/Bundle/MediaBundle/Endpoint/Extension/MediaRoutesEndpointExtensionType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Endpoint/Extension/MediaRoutesEndpointExtensionType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Enhavo\Bundle\MediaBundle\Endpoint\Extension;
+
+use Enhavo\Bundle\ApiBundle\Data\Data;
+use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointTypeExtension;
+use Enhavo\Bundle\ApiBundle\Endpoint\Context;
+use Enhavo\Bundle\AppBundle\Endpoint\Type\TemplateEndpointType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MediaRoutesEndpointExtensionType extends AbstractEndpointTypeExtension
+{
+    public function handleRequest($options, Request $request, Data $data, Context $context)
+    {
+        if ($options['media_routes']) {
+            $data->set('routes', [
+                'enhavo_media_file_show' => [
+                    'path' => '/template/file/show/{id}',
+                ],
+                'enhavo_media_file_format' => [
+                    'path' => '/template/file/format/{id}/{format}',
+                ],
+            ]);
+        }
+    }
+
+    public static function getExtendedTypes(): array
+    {
+        return [TemplateEndpointType::class];
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'media_routes' => true,
+        ]);
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Endpoint/Type/TemplateFileEndpointType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Endpoint/Type/TemplateFileEndpointType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enhavo\Bundle\AppBundle\Endpoint\Type;
+namespace Enhavo\Bundle\MediaBundle\Endpoint\Type;
 
 use Enhavo\Bundle\ApiBundle\Data\Data;
 use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointType;

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
@@ -195,3 +195,18 @@ services:
             - '%enhavo_media.upload_validation.clamav%'
         tags:
             - { name: validator.constraint_validator }
+
+    Enhavo\Bundle\MediaBundle\Endpoint\Type\TemplateFileEndpointType:
+        arguments:
+            - '%kernel.project_dir%/data/media'
+            - '@enhavo_media.factory.file'
+            - '@filesystem'
+        tags:
+            - { name: enhavo_api.endpoint }
+
+    Enhavo\Bundle\MediaBundle\Endpoint\Extension\MediaRoutesEndpointExtensionType:
+        calls:
+            - [setContainer, ['@Psr\Container\ContainerInterface']]
+        tags:
+            - { name: enhavo_api.endpoint_extension }
+            - { name: container.service_subscriber }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| License      | MIT

* Move template file endpoint to media-bundle, because the app-bundle shouldn't have a dependency to media-bundle
