### PR TITLE
[UserBundle] Add possiblity to set from address for mails sent through user-bundle

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
@@ -431,6 +431,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('template')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('subject')->defaultValue('registration.mail.subject')->end()
+                ->scalarNode('from')->defaultValue(null)->end()
                 ->scalarNode('sender_name')->defaultValue(null)->end()
                 ->scalarNode('content_type')->defaultValue('text/plain')->end()
             ->end()


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.10
| License      | MIT

Cases:
If MultiTenancyBundle wants to change from address for each tenant.
If on registration we want another from address than on confirm.
