### PR TITLE
Draft: VimeoProvider to use current URLs

### DIFF
--- a/src/Enhavo/Bundle/ContentBundle/Video/VimeoProvider.php
+++ b/src/Enhavo/Bundle/ContentBundle/Video/VimeoProvider.php
@@ -26,21 +26,21 @@ class VimeoProvider implements ProviderInterface
         if (!empty($this->apiKey)) {
             $options = array('http' => array(
                 'method'  => 'GET',
-                'header' => sprintf('Authorization: Bearer %s'. $this->apiKey)
+                'header' => sprintf('Authorization: Bearer %s', $this->apiKey)
             ));
             $context  = stream_context_create($options);
-            $data = json_decode(file_get_contents(sprintf("https://api.vimeo.com/%s", $videoId),false, $context));
+            $data = json_decode(file_get_contents(sprintf("https://api.vimeo.com/videos/%s", $videoId),false, $context));
         } else {
-            $data = json_decode(file_get_contents(sprintf("https://vimeo.com/api/v2/video/%s.json", $videoId),false));
+            $data = json_decode(file_get_contents(sprintf("https://vimeo.com/api/oembed.json?url=%s", $url),false));
         }
 
         return new Video(
             self::PROVIDER_NAME,
-            $data[0]->title,
-            str_replace(array("<br>", "<br/>", "<br />"), NULL, $data[0]->description),
-            $data[0]->thumbnail_large,
-            sprintf("https://vimeo.com/%s", $data[0]->id),
-            sprintf("https://player.vimeo.com/video/%s", $data[0]->id),
+            $data->title,
+            str_replace(array("<br>", "<br/>", "<br />"), '', $data->description),
+            $data->thumbnail_url,
+            sprintf("https://vimeo.com/%s", $data->video_id),
+            sprintf("https://player.vimeo.com/video/%s", $data->video_id),
         );
     }
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.11
| License      | MIT

Vimeo's V2 API is deprecated.
