### PR TITLE
[UserBundle] Fixed error in User FormType caused by Doctrine short al…

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Form/Type/UserType.php
+++ b/src/Enhavo/Bundle/UserBundle/Form/Type/UserType.php
@@ -24,9 +24,15 @@ class UserType extends AbstractResourceType
      */
     private $authorizationChecker;
 
-    public function __construct(string $dataClass, AuthorizationCheckerInterface $authorizationChecker, array $validationGroups = [])
+    /**
+     * @var string
+     */
+    private $groupDataClass;
+
+    public function __construct(string $dataClass, string $groupDataClass, AuthorizationCheckerInterface $authorizationChecker, array $validationGroups = [])
     {
         parent::__construct($dataClass, $validationGroups);
+        $this->groupDataClass = $groupDataClass;
         $this->authorizationChecker = $authorizationChecker;
     }
 
@@ -79,7 +85,7 @@ class UserType extends AbstractResourceType
         }
 
         $builder->add('groups', EntityType::class, array(
-            'class' => 'EnhavoUserBundle:Group',
+            'class' => $this->groupDataClass,
             'choice_label' => 'name',
             'multiple' => true,
             'expanded' => true,

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/services/form.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/services/form.yaml
@@ -16,6 +16,7 @@ services:
     Enhavo\Bundle\UserBundle\Form\Type\UserType:
         arguments:
             - '%enhavo_user.model.user.class%'
+            - '%enhavo_user.model.group.class%'
             - '@security.authorization_checker'
             - [default]
         tags:


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[UserBundle] Fixed error in User FormType caused by Doctrine short alias naming that is no longer supported in newer Doctrine versions
