### PR TITLE
feat: load vue routes over provider sub system

### DIFF
--- a/config/packages/vue.yaml
+++ b/config/packages/vue.yaml
@@ -1,0 +1,29 @@
+enhavo_app:
+    vue:
+        route_providers:
+            theme:
+                type: file
+                path: assets/theme/routes.json
+                groups: ['theme']
+            page:
+                type: page
+                component: page
+                groups: ['theme']
+            article:
+                type: article
+                component: article
+                groups: ['theme']
+            template:
+                type: file
+                path: assets/theme/routes.json
+                prefix: /template
+                groups: ['template']
+
+when@template:
+    enhavo_app:
+        vue:
+            route_providers:
+                template:
+                    type: file
+                    path: assets/theme/routes.json
+                    groups: ['template']

--- a/config/routes/enhavo_app.yaml
+++ b/config/routes/enhavo_app.yaml
@@ -1,3 +1,7 @@
 enhavo_app_admin:
     resource: "@EnhavoAppBundle/Resources/config/routes/admin/*"
     prefix: /admin
+
+enhavo_app_api:
+    resource: "@EnhavoAppBundle/Resources/config/routes/api/*"
+    prefix: /api

--- a/data/routes/app.yaml
+++ b/data/routes/app.yaml
@@ -1,8 +1,10 @@
 template_hello:
-    path: /endpoint/world.{_format}
+    path: /world.{_format}
     defaults:
         _format: 'html'
         _endpoint:
             type: template
             load: [hello.yaml, hello2.php]
             template: 'theme/endpoint/hello.html.twig'
+            vue_routes_enabled: true
+            vue_routes_groups: ['template']

--- a/src/App/Kernel.php
+++ b/src/App/Kernel.php
@@ -2,7 +2,7 @@
 
 namespace App;
 
-use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Enhavo\Bundle\AppBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 class Kernel extends BaseKernel

--- a/src/Enhavo/Bundle/AppBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/AppBundle/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->getRootNode();
 
         $this->addViewerSectionSection($rootNode);
+        $this->addVueSectionSection($rootNode);
         $this->addMailSectionSection($rootNode);
         $this->addWebpackBuildSection($rootNode);
         $this->addFormThemesSection($rootNode);
@@ -57,6 +58,20 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('apps')
                     ->prototype('scalar')->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addVueSectionSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('vue')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->variableNode('route_providers')
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Enhavo/Bundle/AppBundle/DependencyInjection/EnhavoAppExtension.php
+++ b/src/Enhavo/Bundle/AppBundle/DependencyInjection/EnhavoAppExtension.php
@@ -42,6 +42,7 @@ class EnhavoAppExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('enhavo_app.locale_resolver', $config['locale_resolver']);
         $container->setParameter('enhavo_app.toolbar_widget.primary', $config['toolbar_widget']['primary']);
         $container->setParameter('enhavo_app.toolbar_widget.secondary', $config['toolbar_widget']['secondary']);
+        $container->setParameter('enhavo_app.vue.route_providers', $config['vue']['route_providers'] ?? []);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 

--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Extension/VueRouteEndpointExtensionType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Extension/VueRouteEndpointExtensionType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Endpoint\Extension;
+
+use Enhavo\Bundle\ApiBundle\Data\Data;
+use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointTypeExtension;
+use Enhavo\Bundle\ApiBundle\Endpoint\Context;
+use Enhavo\Bundle\AppBundle\Endpoint\Type\AreaEndpointType;
+use Enhavo\Bundle\AppBundle\Endpoint\Type\TemplateEndpointType;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class VueRouteEndpointExtensionType extends AbstractEndpointTypeExtension
+{
+    public function __construct(
+        private readonly VueRouteProviderInterface $provider,
+    )
+    {
+    }
+
+    public function handleRequest($options, Request $request, Data $data, Context $context)
+    {
+        if ($options['vue_routes_enabled']) {
+            $routes = $this->provider->getRoutes($options['vue_routes_groups']);
+            $context->set('vue_routes', $routes);
+            if (count($routes) > 0) {
+                $data['vue_routes'] = $this->normalize($routes);
+            }
+        }
+    }
+
+    public static function getExtendedTypes(): array
+    {
+        return [TemplateEndpointType::class, AreaEndpointType::class];
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'vue_routes_groups' => null,
+            'vue_routes_enabled' => false,
+        ]);
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Type/VueRoutesEndpointType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Type/VueRoutesEndpointType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Endpoint\Type;
+
+use Enhavo\Bundle\ApiBundle\Data\Data;
+use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointType;
+use Enhavo\Bundle\ApiBundle\Endpoint\Context;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class VueRoutesEndpointType extends AbstractEndpointType
+{
+    public function __construct(
+        private readonly VueRouteProviderInterface $provider,
+    )
+    {
+    }
+
+    public function handleRequest($options, Request $request, Data $data, Context $context): void
+    {
+        if ($request->query->has('path')) {
+            $path = $request->get('path');
+            $route = $this->provider->getRoute($path, $options['groups']);
+            if ($route === null) {
+                $data->set('vue_routes', []);
+            } else {
+                $data->set('vue_routes', $this->normalize([$route]));
+            }
+        } else {
+            $routes = $this->provider->getRoutes($options['groups']);
+            $data->set('vue_routes', $this->normalize($routes));
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'groups' => null,
+        ]);
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/EnhavoAppBundle.php
+++ b/src/Enhavo/Bundle/AppBundle/EnhavoAppBundle.php
@@ -17,10 +17,12 @@ use Enhavo\Bundle\AppBundle\Type\TypeCompilerPass;
 use Enhavo\Bundle\AppBundle\View\View;
 use Enhavo\Bundle\AppBundle\View\ViewFactoryAwareInterface;
 use Enhavo\Bundle\AppBundle\View\ViewTypeInterface;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\RouteProvider;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderTypeInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class EnhavoAppBundle extends Bundle
 {
@@ -52,6 +54,10 @@ class EnhavoAppBundle extends Bundle
 
         $container->addCompilerPass(
             new \Enhavo\Component\Type\TypeCompilerPass('View', 'enhavo_app.view', View::class)
+        );
+
+        $container->addCompilerPass(
+            new \Enhavo\Component\Type\TypeCompilerPass('VueRouteProvider', 'enhavo_app.vue_route_provider', RouteProvider::class)
         );
 
         $container->addCompilerPass(
@@ -96,6 +102,10 @@ class EnhavoAppBundle extends Bundle
 
         $container->registerForAutoconfiguration(ViewTypeInterface::class)
             ->addTag('enhavo_app.view')
+        ;
+
+        $container->registerForAutoconfiguration(VueRouteProviderTypeInterface::class)
+            ->addTag('enhavo_app.vue_route_provider')
         ;
 
         $container->registerForAutoconfiguration(RouteCollectorInterface::class)

--- a/src/Enhavo/Bundle/AppBundle/Kernel/MicroKernelTrait.php
+++ b/src/Enhavo/Bundle/AppBundle/Kernel/MicroKernelTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait as BaseMicroKernelTrait;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+trait MicroKernelTrait
+{
+    use BaseMicroKernelTrait {
+        configureRoutes as baseConfigureRoutes;
+    }
+
+    private function configureRoutes(RoutingConfigurator $routes): void
+    {
+        // load only template routes in template environment
+        if ($this->environment === 'template') {
+            $configDir = $this->getConfigDir();
+            $routes->import($configDir.'/{routes}/template/*.{php,yaml}');
+        } else {
+            $this->baseConfigureRoutes($routes);
+        }
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Resources/config/routes/api/vue-routes.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/routes/api/vue-routes.yaml
@@ -1,0 +1,9 @@
+enhavo_app_api_vue_routes:
+    path: /vue-routes
+    methods: [GET]
+    defaults:
+        _describe: true
+        _format: json
+        _endpoint:
+            type: Enhavo\Bundle\AppBundle\Endpoint\Type\VueRoutesEndpointType
+            groups: theme

--- a/src/Enhavo/Bundle/AppBundle/Resources/config/services/endpoint.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/services/endpoint.yaml
@@ -31,6 +31,15 @@ services:
             - { name: enhavo_api.endpoint }
             - { name: container.service_subscriber }
 
+    Enhavo\Bundle\AppBundle\Endpoint\Type\VueRoutesEndpointType:
+        arguments:
+            - '@Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderInterface'
+        calls:
+            - [ setContainer, [ '@Psr\Container\ContainerInterface' ] ]
+        tags:
+            - { name: enhavo_api.endpoint }
+            - { name: container.service_subscriber }
+
     enhavo_app.endpoint.expression_language:
         class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
 
@@ -56,3 +65,12 @@ services:
             - '@Enhavo\Bundle\AppBundle\Endpoint\Template\ExpressionLanguage\LoremIpsumGenerator'
         tags:
             - { name: enhavo_app.endpoint.expression_language }
+
+    Enhavo\Bundle\AppBundle\Endpoint\Extension\VueRouteEndpointExtensionType:
+        arguments:
+            - '@Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderInterface'
+        calls:
+            - [ setContainer, [ '@Psr\Container\ContainerInterface' ] ]
+        tags:
+            - { name: enhavo_api.endpoint_extension }
+            - { name: container.service_subscriber }

--- a/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
@@ -131,8 +131,22 @@ services:
         alias: enhavo_app.route_collector
 
 
-    Enhavo\Bundle\AppBundle\Routing\Loader\VueRouterLoader:
+    Enhavo\Bundle\AppBundle\Routing\Loader\VueRouterRouteLoader:
         arguments:
             - '@file_locator'
         tags:
             - { name: routing.loader }
+
+    Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderInterface:
+        alias: Enhavo\Bundle\AppBundle\Vue\RouteProvider\ChainVueRouteProvider
+
+    Enhavo\Bundle\AppBundle\Vue\RouteProvider\ChainVueRouteProvider:
+        arguments:
+            - '%enhavo_app.vue.route_providers%'
+            - '@Enhavo\Component\Type\FactoryInterface[VueRouteProvider]'
+
+    Enhavo\Bundle\AppBundle\Vue\RouteProvider\FileVueRouteProviderType:
+        arguments:
+            - '%kernel.project_dir%'
+        tags:
+            - { name: 'enhavo_app.vue_route_provider' }

--- a/src/Enhavo/Bundle/AppBundle/Routing/Loader/VueRouterRouteLoader.php
+++ b/src/Enhavo/Bundle/AppBundle/Routing/Loader/VueRouterRouteLoader.php
@@ -8,7 +8,7 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Yaml\Yaml;
 
-class VueRouterLoader extends FileLoader
+class VueRouterRouteLoader extends FileLoader
 {
     public function load(mixed $resource, string $type = null): RouteCollection
     {
@@ -37,7 +37,7 @@ class VueRouterLoader extends FileLoader
             return json_decode(file_get_contents($resource->getResource()), true);
         }
 
-        throw new \Exception(sprintf('VueRouterLoader can only read yaml or json formats. Trying to read "%s"', $resource->getResource()));
+        throw new \Exception(sprintf('VueRouterRouteLoader can only read yaml or json formats. Trying to read "%s"', $resource->getResource()));
     }
 
     private function getRoutes(mixed $content): array

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/AbstractVueRouteProviderType.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/AbstractVueRouteProviderType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+use Enhavo\Component\Type\AbstractType;
+
+abstract class AbstractVueRouteProviderType extends AbstractType implements VueRouteProviderTypeInterface
+{
+    public function getRoutes($options, array|string|null $groups = null): array
+    {
+        return $this->parent->getRoutes($options, $groups);
+    }
+
+    public function getRoute($options, $path, array|string|null $groups = null): ?VueRoute
+    {
+        return $this->parent->getRoute($options, $groups);
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/ChainVueRouteProvider.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/ChainVueRouteProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+use Enhavo\Component\Type\FactoryInterface;
+
+class ChainVueRouteProvider implements VueRouteProviderInterface
+{
+    /** @var RouteProvider[] */
+    private ?array $providers = null;
+
+    public function __construct(
+        private array $config,
+        private FactoryInterface $factory,
+    )
+    {
+    }
+
+    public function getRoutes(array|string|null $groups = null): array
+    {
+        $this->init();
+
+        $routes = [];
+
+        foreach ($this->providers as $provider) {
+            foreach ($provider->getRoutes($groups) as $route) {
+                $routes[] = $route;
+            }
+        }
+
+        return $routes;
+    }
+
+    public function getRoute($path, array|string|null $groups = null): ?VueRoute
+    {
+        $this->init();
+
+        foreach ($this->providers as $provider) {
+            $route = $provider->getRoute($path, $groups);
+            if ($route !== null) {
+                return $route;
+            }
+        }
+
+        return null;
+    }
+
+    private function init(): void
+    {
+        if ($this->providers !== null) {
+            return;
+        }
+
+        $this->providers = [];
+        foreach ($this->config as $providerConfig) {
+            $this->providers[] = $this->factory->create($providerConfig);
+        }
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/FileVueRouteProviderType.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/FileVueRouteProviderType.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+use Enhavo\Component\Type\AbstractType;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Yaml\Yaml;
+
+class FileVueRouteProviderType extends AbstractType implements VueRouteProviderTypeInterface
+{
+    use GroupHelperTrait;
+
+    /** @var VueRoute[] */
+    private ?array $routes = null;
+
+    public function __construct(
+        private string $basePath,
+    )
+    {
+    }
+
+    public function getRoutes($options, array|string|null $groups = null): array
+    {
+        if (!$this->isGroupSelected($options, $groups)) {
+            return [];
+        }
+
+        $this->load($options);
+
+        return $this->routes;
+    }
+
+    public function getRoute($options, $path, array|string|null $groups = null): ?VueRoute
+    {
+        if (!$this->isGroupSelected($options, $groups)) {
+            return null;
+        }
+
+        $this->load($options);
+        return $this->search($path, $this->routes);
+    }
+
+    /**
+     * @param VueRoute[] $routes
+     */
+    private function search(string $path, array $routes): ?VueRoute
+    {
+        foreach ($routes as $route) {
+            if ($route->getPath() === $path) {
+                return $route;
+            }
+
+            if (count($route->getChildren()) > 0) {
+                return $this->search($path, $route->getChildren());
+            }
+        }
+
+        return null;
+    }
+
+    private function load($options): void
+    {
+        if ($this->routes !== null) {
+            return;
+        }
+
+        $resource = new FileResource(Path::join($this->basePath, $options['path']));
+        $content = $this->getContent($resource);
+        if (is_string($options['prefix'])) {
+            $content = $this->prefixRoutes($content, $options['prefix']);
+        }
+
+        $this->routes = [];
+        foreach ($content as $routeContent) {
+            $this->routes[] = new VueRoute($routeContent);
+        }
+    }
+
+    private function getContent(FileResource $resource)
+    {
+        $ext = pathinfo($resource->getResource(), PATHINFO_EXTENSION);
+
+        if ($ext === 'yaml') {
+            return Yaml::parseFile($resource->getResource());
+        } elseif ($ext === 'json') {
+            return json_decode(file_get_contents($resource->getResource()), true);
+        }
+
+        throw new \Exception(sprintf('VueRouterContentLoader can only read yaml or json formats. Trying to read "%s"', $resource->getResource()));
+    }
+
+    private function prefixRoutes($routes, $prefix)
+    {
+        foreach ($routes as $key => $route) {
+            if (isset($route['path'])) {
+                $routes[$key]['path'] = Path::join($prefix, $route['path']);
+            }
+
+            if (isset($route['children'])) {
+                $routes[$key]['children'] = $this->prefixRoutes($route['children'], $prefix);
+            }
+        }
+
+        return $routes;
+    }
+
+    public static function getName(): ?string
+    {
+        return 'file';
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'prefix' => null,
+            'groups' => null,
+        ]);
+
+        $resolver->setRequired(['path']);
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/GroupHelperTrait.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/GroupHelperTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+trait GroupHelperTrait
+{
+    public function isGroupSelected($options, $group): bool
+    {
+        if ($options['groups'] === null && $group === null) {
+            return true;
+        }
+
+        $groups = match (gettype($options['groups'])) {
+            'array' => $options['groups'],
+            'string' => [$options['groups']],
+            default => [],
+        };
+
+        $targetGroups = match (gettype($group)) {
+            'array' => $group,
+            'string' => [$group],
+            default => [],
+        };
+
+        foreach ($targetGroups as $targetGroup) {
+            if (in_array($targetGroup, $groups)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/RouteProvider.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/RouteProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+use Enhavo\Component\Type\AbstractContainerType;
+
+class RouteProvider extends AbstractContainerType
+{
+    /** @var VueRouteProviderTypeInterface */
+    protected $type;
+
+    /** @var VueRouteProviderTypeInterface[] */
+    protected $parents;
+
+    public function getRoutes(null|string|array $groups = null): array
+    {
+        return $this->type->getRoutes($this->options, $groups);
+    }
+
+    public function getRoute($path, null|string|array $groups = null): ?VueRoute
+    {
+        return $this->type->getRoute($this->options, $path, $groups);
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/VueRoute.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/VueRoute.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+class VueRoute
+{
+    /** @var VueRoute[]  */
+    private array $children = [];
+    private ?string $name;
+    private ?string $path;
+    private string|array|null $meta;
+    private ?string $component;
+
+    public function __construct(?array $data = null)
+    {
+        $this->name = $data['name'] ?? null;
+        $this->path = $data['path'] ?? null;
+        $this->meta = $data['meta'] ?? null;
+        $this->component = $data['component'] ?? null;
+
+        if (isset($data['children'])) {
+            foreach ($data['children'] as $child) {
+                $this->children[] = new self($child);
+            }
+        }
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->path;
+    }
+
+    public function setPath(?string $path): void
+    {
+        $this->path = $path;
+    }
+
+    public function getMeta(): string|array|null
+    {
+        return $this->meta;
+    }
+
+    public function setMeta(string|array|null $meta): void
+    {
+        $this->meta = $meta;
+    }
+
+    public function addChildren(VueRoute $child)
+    {
+        $this->children[] = $child;
+    }
+
+    public function removeChildren(VueRoute $child)
+    {
+        if (false !== $key = array_search($child, $this->children, true)) {
+            array_splice($this->children, $key, 1);
+        }
+    }
+
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function getComponent(): ?string
+    {
+        return $this->component;
+    }
+
+    public function setComponent(?string $component): void
+    {
+        $this->component = $component;
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/VueRouteProviderInterface.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/VueRouteProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+interface VueRouteProviderInterface
+{
+    public function getRoutes(null|string|array $groups = null): array;
+
+    public function getRoute($path, null|string|array $groups = null): ?VueRoute;
+}

--- a/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/VueRouteProviderTypeInterface.php
+++ b/src/Enhavo/Bundle/AppBundle/Vue/RouteProvider/VueRouteProviderTypeInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Vue\RouteProvider;
+
+use Enhavo\Component\Type\TypeInterface;
+
+interface VueRouteProviderTypeInterface extends TypeInterface
+{
+    public function getRoutes($options, null|string|array $groups = null): array;
+
+    public function getRoute($options, $path, null|string|array $groups = null): ?VueRoute;
+}

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/services.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/services.yaml
@@ -72,3 +72,7 @@ services:
             - '@enhavo_article.repository.article'
         tags:
             - { name: enhavo.provider, alias: article.total }
+
+    Enhavo\Bundle\ArticleBundle\Vue\ArticleVueRouteProviderType:
+        tags:
+            - { name: enhavo_app.vue_route_provider }

--- a/src/Enhavo/Bundle/ArticleBundle/Vue/ArticleVueRouteProviderType.php
+++ b/src/Enhavo/Bundle/ArticleBundle/Vue/ArticleVueRouteProviderType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Enhavo\Bundle\ArticleBundle\Vue;
+
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\AbstractVueRouteProviderType;
+use Enhavo\Bundle\RoutingBundle\Vue\RoutingVueRouteProviderType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ArticleVueRouteProviderType extends AbstractVueRouteProviderType
+{
+    public static function getName(): ?string
+    {
+        return 'article';
+    }
+
+    public static function getParentType(): ?string
+    {
+        return RoutingVueRouteProviderType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'resource_key' => 'enhavo_article.article',
+            'meta_name' => 'article',
+        ]);
+    }
+}

--- a/src/Enhavo/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Enhavo/Bundle/PageBundle/Controller/PageController.php
@@ -17,6 +17,8 @@ class PageController extends ResourceController
             'resource' => $contentDocument,
             'preview' => $preview,
             'area' => 'theme',
+            'vue_routes_enabled' => true,
+            'vue_routes_groups' => ['theme'],
         ]);
     }
 }

--- a/src/Enhavo/Bundle/PageBundle/Endpoint/PageEndpointType.php
+++ b/src/Enhavo/Bundle/PageBundle/Endpoint/PageEndpointType.php
@@ -69,6 +69,8 @@ class PageEndpointType extends AbstractEndpointType
             'preview' => false,
             'template' => '{{ area }}/resource/page/show.html.twig',
             'resource' => null,
+            'vue_routes_enabled' => true,
+            'vue_routes_groups' => ['theme'],
         ]);
     }
 }

--- a/src/Enhavo/Bundle/PageBundle/Resources/config/services.yaml
+++ b/src/Enhavo/Bundle/PageBundle/Resources/config/services.yaml
@@ -69,3 +69,7 @@ services:
             - '@enhavo_routing.router'
         tags:
             - { name: enhavo_app.route_collector }
+
+    Enhavo\Bundle\PageBundle\Vue\PageVueRouteProviderType:
+        tags:
+            - { name: enhavo_app.vue_route_provider }

--- a/src/Enhavo/Bundle/PageBundle/Vue/PageVueRouteProviderType.php
+++ b/src/Enhavo/Bundle/PageBundle/Vue/PageVueRouteProviderType.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Enhavo\Bundle\PageBundle\Vue;
+
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\AbstractVueRouteProviderType;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRoute;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderTypeInterface;
+use Enhavo\Bundle\RoutingBundle\Vue\RoutingVueRouteProviderType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PageVueRouteProviderType extends AbstractVueRouteProviderType implements VueRouteProviderTypeInterface
+{
+    public static function getName(): ?string
+    {
+        return 'page';
+    }
+
+    public static function getParentType(): ?string
+    {
+        return RoutingVueRouteProviderType::class;
+    }
+
+    public function getRoutes($options, array|string|null $groups = null): array
+    {
+        return $this->parent->getRoutes($options, $groups);
+    }
+
+    public function getRoute($options, $path, array|string|null $groups = null): ?VueRoute
+    {
+        return $this->parent->getRoute($options, $groups);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'resource_key' => 'enhavo_page.page',
+            'meta_name' => 'page',
+        ]);
+    }
+}

--- a/src/Enhavo/Bundle/RoutingBundle/Resources/config/services/general.yaml
+++ b/src/Enhavo/Bundle/RoutingBundle/Resources/config/services/general.yaml
@@ -25,3 +25,9 @@ services:
     Enhavo\Bundle\RoutingBundle\Twig\SlugifyExtension:
         tags:
             - { name: twig.extension }
+
+    Enhavo\Bundle\RoutingBundle\Vue\RoutingVueRouteProviderType:
+        arguments:
+            - '@enhavo_routing.repository.route'
+        tags:
+            - { name: enhavo_app.vue_route_provider }

--- a/src/Enhavo/Bundle/RoutingBundle/Vue/RoutingVueRouteProviderType.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Vue/RoutingVueRouteProviderType.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Enhavo\Bundle\RoutingBundle\Vue;
+
+use Doctrine\ORM\AbstractQuery;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\GroupHelperTrait;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRoute;
+use Enhavo\Bundle\AppBundle\Vue\RouteProvider\VueRouteProviderTypeInterface;
+use Enhavo\Bundle\RoutingBundle\Repository\RouteRepository;
+use Enhavo\Component\Type\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RoutingVueRouteProviderType extends AbstractType implements VueRouteProviderTypeInterface
+{
+    use GroupHelperTrait;
+
+    public function __construct(
+        private readonly RouteRepository $routeRepository,
+    )
+    {
+    }
+
+    public function getRoutes($options, array|string|null $groups = null): array
+    {
+        if (!$this->isGroupSelected($options, $groups)) {
+            return [];
+        }
+
+        $routes = $this->routeRepository->createQueryBuilder('r')
+            ->where('r.contentClass = :contentClass')
+            ->setParameter('contentClass', $options['resource_key'])
+            ->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY);
+
+        $vueRoutes = [];
+        foreach ($routes as $route) {
+            $vueRoutes[] = $this->createVueRoute($route, $options);
+        }
+        return $vueRoutes;
+    }
+
+    public function getRoute($options, $path, array|string|null $groups = null): ?VueRoute
+    {
+        if (!$this->isGroupSelected($options, $groups)) {
+            return null;
+        }
+
+        $routes = $this->routeRepository->createQueryBuilder('r')
+            ->where('r.contentClass = :contentClass')
+            ->andWhere('r.staticPrefix = :staticPrefix')
+            ->setParameter('contentClass', $options['resource_key'])
+            ->setParameter('staticPrefix', $path)
+            ->setMaxResults(1)
+            ->getQuery()->getResult(AbstractQuery::HYDRATE_ARRAY);
+
+        if (count($routes) > 0) {
+            return $this->createVueRoute($routes[0], $options);
+        }
+
+        return null;
+    }
+
+    private function createVueRoute(array $route, $options): VueRoute
+    {
+        return new VueRoute([
+            'path' => $route['staticPrefix'],
+            'component' => $options['component'],
+            'meta' => [
+                'name' => $options['meta_name'],
+                'id' => $route['contentId'],
+            ]
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'groups' => null,
+        ]);
+
+        $resolver->setRequired(['component', 'resource_key', 'meta_name']);
+    }
+}


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

* Add vue router provider subsystem with type config
* Add providers for file, routing, page and article
* Use groups to define which vue routes getting loaded
* Add endpoint extension to provide routes automatically over options
* Provide vue-routes api
* Add kernel to load only template routes in template env