### PR TITLE
fix: remove doctrine mapping types

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/app/config.yaml
@@ -5,13 +5,6 @@ framework:
     session:
         cookie_lifetime: 25920000
 
-doctrine:
-    dbal:
-        mapping_types:
-            enum: string
-            json: string
-            json_array: string
-
 stof_doctrine_extensions:
     default_locale: "%locale%"
     orm:


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

* Remove mappig types, because `json` is already supported and `enum` and `json_array` is not used in enhavo at all. Let the project add them if needed
