### PR TITLE
fix: add route if no routes was set

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Extension/RouterEndpointExtensionType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Extension/RouterEndpointExtensionType.php
@@ -31,7 +31,7 @@ class RouterEndpointExtensionType extends AbstractEndpointTypeExtension
             $data->set('routes', $this->normalize($routesCollection, null, ['groups' => 'endpoint']));
         }
 
-        if (!$request->get('_format') || $request->get('_format') === 'html') {
+        if ($context->get('routes') && (!$request->get('_format') || $request->get('_format') === 'html')) {
             $this->twigRouter->addRouteCollection($context->get('routes'));
         }
     }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

fix add route to twig router if no routes was set
