### PR TITLE
Remove listAction from ProductController.

### DIFF
--- a/src/Enhavo/Bundle/ShopBundle/Controller/ProductController.php
+++ b/src/Enhavo/Bundle/ShopBundle/Controller/ProductController.php
@@ -30,13 +30,6 @@ class ProductController extends ResourceController
         ]);
     }
 
-    public function listAction(Request $request): Response
-    {
-        return $this->render($this->getTemplate('theme/shop/product/list.html.twig'), [
-
-        ]);
-    }
-
     private function getProductManager(): ProductManager
     {
         return $this->get('enhavo_shop.product_manager');


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| Backport     | 0.11
| License      | MIT

Removed listAction from the Product Controller because this function was overwriting an important function.
