### PR TITLE
Fix autologin possible for disabled/unverified users

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Controller/ChangeEmailController.php
+++ b/src/Enhavo/Bundle/UserBundle/Controller/ChangeEmailController.php
@@ -146,9 +146,6 @@ class ChangeEmailController extends AbstractUserController
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
                 $this->userManager->changeEmail($user, $changeEmail->getEmail(), $configuration);
-                if ($configuration->isAutoLogin()) {
-                    $this->userManager->login($user);
-                }
 
                 $url = $this->generateUrl($configuration->getRedirectRoute());
 

--- a/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
@@ -165,8 +165,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('redirect_route')->defaultValue(null)->end()
                         ->scalarNode('confirmation_route')->isRequired()->cannotBeEmpty()->end()
                         ->append($this->addConfigMailNode())
-                        ->scalarNode('auto_login')->defaultValue(true)->end()
-                        ->scalarNode('auto_enabled')->defaultValue(true)->end()
+                        ->scalarNode('auto_login')->defaultValue(false)->end()
+                        ->scalarNode('auto_enabled')->defaultValue(false)->end()
                         ->scalarNode('auto_verified')->defaultValue(false)->end()
                         ->scalarNode('translation_domain')->defaultValue('EnhavoUserBundle')->end()
                         ->arrayNode('form')
@@ -252,7 +252,7 @@ class Configuration implements ConfigurationInterface
 
                 ->arrayNode('reset_password_confirm')
                     ->children()
-                        ->scalarNode('auto_login')->defaultValue(true)->end()
+                        ->scalarNode('auto_login')->defaultValue(false)->end()
                         ->scalarNode('template')->defaultValue('{{ area }}/user/reset-password/confirm.html.twig')->end()
                         ->scalarNode('redirect_route')->defaultValue(null)->end()
                         ->arrayNode('form')
@@ -314,6 +314,7 @@ class Configuration implements ConfigurationInterface
                                 ->variableNode('options')->defaultValue([])->end()
                             ->end()
                         ->end()
+                        ->scalarNode('auto_login')->defaultValue(false)->end()
                     ->end()
                 ->end()
 

--- a/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
@@ -314,7 +314,6 @@ class Configuration implements ConfigurationInterface
                                 ->variableNode('options')->defaultValue([])->end()
                             ->end()
                         ->end()
-                        ->scalarNode('auto_login')->defaultValue(true)->end()
                     ->end()
                 ->end()
 

--- a/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
@@ -165,8 +165,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('redirect_route')->defaultValue(null)->end()
                         ->scalarNode('confirmation_route')->isRequired()->cannotBeEmpty()->end()
                         ->append($this->addConfigMailNode())
-                        ->scalarNode('auto_login')->defaultValue(false)->end()
-                        ->scalarNode('auto_enabled')->defaultValue(false)->end()
+                        ->scalarNode('auto_login')->defaultValue(true)->end()
+                        ->scalarNode('auto_enabled')->defaultValue(true)->end()
                         ->scalarNode('auto_verified')->defaultValue(false)->end()
                         ->scalarNode('translation_domain')->defaultValue('EnhavoUserBundle')->end()
                         ->arrayNode('form')
@@ -252,7 +252,7 @@ class Configuration implements ConfigurationInterface
 
                 ->arrayNode('reset_password_confirm')
                     ->children()
-                        ->scalarNode('auto_login')->defaultValue(false)->end()
+                        ->scalarNode('auto_login')->defaultValue(true)->end()
                         ->scalarNode('template')->defaultValue('{{ area }}/user/reset-password/confirm.html.twig')->end()
                         ->scalarNode('redirect_route')->defaultValue(null)->end()
                         ->arrayNode('form')
@@ -314,7 +314,7 @@ class Configuration implements ConfigurationInterface
                                 ->variableNode('options')->defaultValue([])->end()
                             ->end()
                         ->end()
-                        ->scalarNode('auto_login')->defaultValue(false)->end()
+                        ->scalarNode('auto_login')->defaultValue(true)->end()
                     ->end()
                 ->end()
 

--- a/src/Enhavo/Bundle/UserBundle/EventListener/NotEnabledSubscriber.php
+++ b/src/Enhavo/Bundle/UserBundle/EventListener/NotEnabledSubscriber.php
@@ -16,6 +16,7 @@ class NotEnabledSubscriber implements EventSubscriberInterface
     {
         return [
             UserEvent::POST_AUTH => 'onPostAuth',
+            UserEvent::PRE_AUTH => 'onPostAuth',
         ];
     }
 

--- a/src/Enhavo/Bundle/UserBundle/EventListener/NotEnabledSubscriber.php
+++ b/src/Enhavo/Bundle/UserBundle/EventListener/NotEnabledSubscriber.php
@@ -15,12 +15,11 @@ class NotEnabledSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            UserEvent::POST_AUTH => 'onPostAuth',
-            UserEvent::PRE_AUTH => 'onPostAuth',
+            UserEvent::PRE_AUTH => 'onPreAuth',
         ];
     }
 
-    public function onPostAuth(UserEvent $userEvent): void
+    public function onPreAuth(UserEvent $userEvent): void
     {
         if (!$userEvent->getUser()->isEnabled()) {
             $exception = new NotEnabledException('Not enabled');

--- a/src/Enhavo/Bundle/UserBundle/EventListener/VerificationRequiredListenerSubscriber.php
+++ b/src/Enhavo/Bundle/UserBundle/EventListener/VerificationRequiredListenerSubscriber.php
@@ -31,6 +31,7 @@ class VerificationRequiredListenerSubscriber implements EventSubscriberInterface
     {
         return [
             UserEvent::POST_AUTH => 'onPostAuth',
+            UserEvent::PRE_AUTH => 'onPostAuth',
         ];
     }
 

--- a/src/Enhavo/Bundle/UserBundle/EventListener/VerificationRequiredListenerSubscriber.php
+++ b/src/Enhavo/Bundle/UserBundle/EventListener/VerificationRequiredListenerSubscriber.php
@@ -30,12 +30,11 @@ class VerificationRequiredListenerSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            UserEvent::POST_AUTH => 'onPostAuth',
-            UserEvent::PRE_AUTH => 'onPostAuth',
+            UserEvent::PRE_AUTH => 'onPreAuth',
         ];
     }
 
-    public function onPostAuth(UserEvent $event): void
+    public function onPreAuth(UserEvent $event): void
     {
         if ($this->isVerificationRequired($event->getUser())) {
             $exception = new VerificationRequiredException('Verification required');

--- a/src/Enhavo/Bundle/UserBundle/User/UserManager.php
+++ b/src/Enhavo/Bundle/UserBundle/User/UserManager.php
@@ -129,6 +129,8 @@ class UserManager
             $this->sessionStrategy->onAuthentication($request, $token);
         }
         $this->tokenStorage->setToken($token);
+
+        $this->userChecker->checkPostAuth($user);
     }
 
     public function logout(): void


### PR DESCRIPTION
Avoid user beeing logged in after changePassword and after changeEmail if not enabled or verified (depends on configuration).

Disable autologin, enabled and verified by default.

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | yes
| Backport     | 0.13
| License      | MIT

Users not beeing enabled, either because they did not confirm their account or were disabled by admin or another mechanism.
Could login via password reset if auto_login was enabled for password reset.
To avoid it the two listeners for NotEnabled and NotVerified are now also mounted onto the preAuth event to avoid this.
