### PR TITLE
[TranslationBundle] Fix unnecessary throw of Exception

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translation/TranslationManagerTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translation/TranslationManagerTest.php
@@ -264,8 +264,9 @@ class TranslationManagerTest extends TestCase
         $manager->detach($entity);
         $this->assertEquals('name-de.old', $entity->getName());
 
-        $this->expectException(TranslationException::class);
+        // after second detach nothing should happen
         $manager->detach($entity);
+        $this->assertEquals('name-de.old', $entity->getName());
     }
 
     public function testTranslateSlug()

--- a/src/Enhavo/Bundle/TranslationBundle/Translation/TranslationManager.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translation/TranslationManager.php
@@ -202,7 +202,7 @@ class TranslationManager
         $this->checkEntity($object);
 
         if (!$this->isTranslated($object)) {
-            throw new TranslationException('Entity was not translated. You can only detach already translated objects');
+            return;
         }
 
         $locale = $this->getTranslatedLocale($object);


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

As suggested by gseidel, just return instead of throwing exception whilst detaching untranslated objects
