### PR TITLE
[MediaLibraryBundle] Fixed ContentType-Filter using label instead of …

### DIFF
--- a/src/Enhavo/Bundle/MediaLibraryBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Controller/FileController.php
@@ -175,10 +175,10 @@ class FileController extends ResourceController
     {
         $terms = $this->getMediaLibraryManager()->getContentTypes();
         $contentTypes = [];
-        foreach ($terms as $term) {
+        foreach ($terms as $key => $term) {
             $contentTypes[] = [
-                'key' => $term,
-                'label' => ucfirst($term),
+                'key' => $key,
+                'label' => $term,
             ];
         }
         return $contentTypes;


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.11, 0.12, 0.13, 0.14
| License      | MIT

MediaLibrary: Fixed ContentType-Filter using label instead of key for filtering
