### PR TITLE
[AppBundle] Fixed error in SyliusCompilerPass if sylius/locale is not…

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/DependencyInjection/Compiler/SyliusCompilerPass.php
+++ b/src/Enhavo/Bundle/AppBundle/DependencyInjection/Compiler/SyliusCompilerPass.php
@@ -86,7 +86,7 @@ class SyliusCompilerPass implements CompilerPassInterface
     private function overwriteLocalProvider(ContainerBuilder $container)
     {
         if ($container->getParameter('kernel.environment') === 'template' &&
-            $container->getDefinition('sylius.locale_provider'))
+            $container->hasDefinition('sylius.locale_provider'))
         {
             $definition = $container->getDefinition('sylius.locale_provider');
             $definition->setClass(TemplateModeSyliusLocaleProvider::class);


### PR DESCRIPTION

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14
| License      | MIT

Fixed error in SyliusCompilerPass if sylius/locale is not included