### PR TITLE
[MediaBundle] Fix response on Range based Browser Request

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
@@ -161,6 +161,8 @@ class FileController extends ResourceController
                 $fileStream = fopen($file->getContent()->getFilePath(), 'r');
                 stream_copy_to_stream($fileStream, $outputStream);
             });
+            $response->headers->set('Content-Type', $file->getMimeType());
+
         } else {
             $response = new FileResponse($file);
         }

--- a/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
@@ -132,10 +132,11 @@ class FileController extends ResourceController
 
         $fileSize = filesize($file->getContent()->getFilePath());
         $length = $fileSize;
-        $start = 0;
-        $end = $length - 1;
 
         if ($rangeHeader) {
+            $start = 0;
+            $end = $length - 1;
+
             if (preg_match('/bytes=(\d*)-(\d*)/', $rangeHeader, $matches)) {
                 $start = ($matches[1] !== '') ? intval($matches[1]) : 0;
                 $end = ($matches[2] !== '') ? intval($matches[2]) : $end;
@@ -164,9 +165,7 @@ class FileController extends ResourceController
                 stream_copy_to_stream($fileStream, $outputStream);
             });
         } else {
-            $response = new Response();
-            $content = $file->getContent()->getContent();
-            $response->setContent($content);
+            $response = new Response($file->getContent()->getContent());
         }
         $response->headers->set('Content-Type', $file->getMimeType());
         $response->headers->set('Content-Length', $length);

--- a/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
@@ -127,7 +127,7 @@ class FileController extends ResourceController
         $path = $file->getContent()->getFilePath();
 
         if (!file_exists($path))  {
-            throw $this->createNotFoundException('File not exists, please refresh format');
+            $this->getMediaManager()->handleFileNotFound($file);
         }
 
         $fileSize = filesize($file->getContent()->getFilePath());

--- a/src/Enhavo/Bundle/MediaBundle/Http/FileRangeResponse.php
+++ b/src/Enhavo/Bundle/MediaBundle/Http/FileRangeResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Enhavo\Bundle\MediaBundle\Http;
+
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class FileRangeResponse extends Response
+{
+
+    public function __construct(FileInterface $file, int $length, int $start, int $end)
+    {
+        parent::__construct();
+        $this->setStatusCode(Response::HTTP_PARTIAL_CONTENT);
+        $this->setFile($file, $length, $start, $end);
+    }
+
+    public function setFile(FileInterface $file, int $length, int $start, int $end): void
+    {
+        $handle = fopen($file->getContent()->getFilePath(), 'rb');
+        // Seek to the starting position and read the specified length
+        fseek($handle, $start);
+        $content = fread($handle, $length);
+        fclose($handle);
+
+        $this->setContent($content);
+        $this->headers->set('Content-Range', sprintf('bytes %d-%d/%d', $start, $end, $length));
+        $this->headers->set('Accept-Ranges', '0-' . $length);
+        $this->headers->set('Content-Length', $length);
+        $this->headers->set('Content-Type', $file->getMimeType());
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Http/FileResponse.php
+++ b/src/Enhavo/Bundle/MediaBundle/Http/FileResponse.php
@@ -16,10 +16,17 @@ class FileResponse extends Response
         $this->setFile($file, $disposition);
     }
 
-    public function setFile(FileInterface $file, $disposition = self::DISPOSITION_INLINE)
+    public function setFile(FileInterface $file, $disposition = self::DISPOSITION_INLINE): void
     {
         $this->setContent($file->getContent()->getContent());
         $this->headers->set('Content-Type', $file->getMimeType());
-        $this->headers->set('Content-Disposition', sprintf('%s; filename="%s"', $disposition, $file->getFilename()));
+
+        if ($disposition === self::DISPOSITION_ATTACHMENT) {
+            $this->headers->set('Content-Disposition', sprintf('%s; filename="%s"', $disposition, $file->getFilename()));
+        } else {
+            $this->headers->set('Content-Disposition', sprintf('%s', $disposition));
+        }
+        $this->headers->set('Content-Length', filesize($file->getContent()->getFilePath()));
+        $this->headers->set('Content-Type', $file->getMimeType());
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.13
| License      | MIT

If browsers send a request containing a Range header, Controller must react with 206 and certain headers as expected.
