### PR TITLE
[ShopBundle] Fixed missing association between Coupons and their Prom…

### DIFF
--- a/src/Enhavo/Bundle/ShopBundle/Repository/PromotionCouponRepository.php
+++ b/src/Enhavo/Bundle/ShopBundle/Repository/PromotionCouponRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Enhavo\Bundle\ShopBundle\Repository;
+
+class PromotionCouponRepository extends \Sylius\Bundle\PromotionBundle\Doctrine\ORM\PromotionCouponRepository
+{
+    public function findByPromotionId($promotionId)
+    {
+        $queryBuilder = $this->createQueryBuilder('promotionCoupon');
+        $queryBuilder
+            ->andWhere('promotionCoupon.promotion = :promotionId')
+            ->setParameter('promotionId', $promotionId);
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+}

--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/app/config.yaml
@@ -66,6 +66,7 @@ sylius_promotion:
             classes:
                 controller: Enhavo\Bundle\ShopBundle\Controller\PromotionCouponController
                 form: Enhavo\Bundle\ShopBundle\Form\Type\PromotionCouponType
+                repository: Enhavo\Bundle\ShopBundle\Repository\PromotionCouponRepository
 
 sylius_payment:
     resources:

--- a/src/Enhavo/Bundle/ShopBundle/Resources/config/routes/admin/promotion_coupon.yaml
+++ b/src/Enhavo/Bundle/ShopBundle/Resources/config/routes/admin/promotion_coupon.yaml
@@ -29,6 +29,10 @@ sylius_promotion_coupon_create:
         _controller: sylius.controller.promotion_coupon:createAction
         _sylius:
             redirect: sylius_promotion_coupon_update
+            factory:
+                method: createForPromotion
+                arguments:
+                    - expr:notFoundOnNull(service('sylius.repository.promotion').find($promotionId))
             viewer:
 
 sylius_promotion_coupon_update:
@@ -49,6 +53,10 @@ sylius_promotion_coupon_table:
     defaults:
         _controller: sylius.controller.promotion_coupon:tableAction
         _sylius:
+            repository:
+                method: findByPromotionId
+                arguments:
+                    - $promotionId
             viewer:
                 columns:
                     code:


### PR DESCRIPTION
…otions if created via Create-Action (backport 0.11)

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[ShopBundle] Fixed missing association between Coupons and their Promotions if created via Create-Action (backport 0.11)
