### PR TITLE
[MediaBundle] fix wrongly configured header

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
@@ -145,11 +145,6 @@ class FileController extends ResourceController
             if (preg_match('/bytes=(\d*)-(\d*)/', $rangeHeader, $matches)) {
                 $start = ($matches[1] !== '') ? intval($matches[1]) : 0;
                 $end = ($matches[2] !== '') ? intval($matches[2]) : $end;
-
-                // Adjust if range is beyond the file size
-                if ($end >= $fileSize) {
-                    $end = $fileSize - 1;
-                }
             }
 
             $response = new FileRangeResponse($file, $start, $end);

--- a/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
+++ b/src/Enhavo/Bundle/MediaBundle/Controller/FileController.php
@@ -150,10 +150,9 @@ class FileController extends ResourceController
                 if ($end >= $fileSize) {
                     $end = $fileSize - 1;
                 }
-                $length = $end - $start + 1;
             }
 
-            $response = new FileRangeResponse($file, $length, $start, $end);
+            $response = new FileRangeResponse($file, $start, $end);
 
         } else if (!$this->getStreamingDisabled() && $this->getStreamingThreshold() < $fileSize) {
             $response = new StreamedResponse(function () use ($file) {

--- a/src/Enhavo/Bundle/MediaBundle/Http/FileRangeResponse.php
+++ b/src/Enhavo/Bundle/MediaBundle/Http/FileRangeResponse.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @author blutze-media
+ * @since 2024-05-15
+ */
 
 namespace Enhavo\Bundle\MediaBundle\Http;
 
@@ -8,23 +12,27 @@ use Symfony\Component\HttpFoundation\Response;
 class FileRangeResponse extends Response
 {
 
-    public function __construct(FileInterface $file, int $length, int $start, int $end)
+    public function __construct(FileInterface $file, int $start, int $end)
     {
         parent::__construct();
         $this->setStatusCode(Response::HTTP_PARTIAL_CONTENT);
-        $this->setFile($file, $length, $start, $end);
+        $this->setFile($file, $start, $end);
     }
 
-    public function setFile(FileInterface $file, int $length, int $start, int $end): void
+    public function setFile(FileInterface $file, int $start, int $end): void
     {
-        $handle = fopen($file->getContent()->getFilePath(), 'rb');
+        $path = $file->getContent()->getFilePath();
+        $size = filesize($path);
+        $length = $end - $start + 1;
+
+        $handle = fopen($path, 'rb');
         // Seek to the starting position and read the specified length
         fseek($handle, $start);
         $content = fread($handle, $length);
         fclose($handle);
 
         $this->setContent($content);
-        $this->headers->set('Content-Range', sprintf('bytes %d-%d/%d', $start, $end, $length));
+        $this->headers->set('Content-Range', sprintf('bytes %d-%d/%d', $start, $end, $size));
         $this->headers->set('Accept-Ranges', '0-' . $length);
         $this->headers->set('Content-Length', $length);
         $this->headers->set('Content-Type', $file->getMimeType());

--- a/src/Enhavo/Bundle/MediaBundle/Http/FileRangeResponse.php
+++ b/src/Enhavo/Bundle/MediaBundle/Http/FileRangeResponse.php
@@ -23,6 +23,11 @@ class FileRangeResponse extends Response
     {
         $path = $file->getContent()->getFilePath();
         $size = filesize($path);
+
+        // Adjust if range is beyond the file size
+        if ($end >= $size) {
+            $end = $size - 1;
+        }
         $length = $end - $start + 1;
 
         $handle = fopen($path, 'rb');


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no

fix wrongly configured Content-Range header that did not set size but range length as divisor.
Remove length attribute that also can be calculated in FileRangeResponse.