### PR TITLE
[SearchBundle] Fixed bug in DatabaseSearchEngine where results with i…

### DIFF
--- a/src/Enhavo/Bundle/SearchBundle/Repository/IndexRepository.php
+++ b/src/Enhavo/Bundle/SearchBundle/Repository/IndexRepository.php
@@ -41,18 +41,19 @@ class IndexRepository extends EntityRepository
     {
         $query = $this->createQueryBuilder('i');
         $query->select(
-            'min(d.contentId) AS id',
-            'min(d.contentClass) AS class',
+            'd.contentId AS id',
+            'd.contentClass AS class',
             'sum(i.score * t.count) AS calculated_score',
             'min(f.value) AS value',
-            'min(f.key) AS key'
+            'min(f.key) AS key',
+            'd.id AS dataset_id'
         );
 
         $query->innerJoin(Total::class, 't', 'WITH', 'i.word = t.word');
         $query->innerJoin(DataSet::class, 'd', 'WITH', 'i.dataSet = d');
         $query->leftJoin('d.filters', 'f');
 
-        $query->groupBy('d.contentId');
+        $query->groupBy('d.id');
 
         $i = 0;
         foreach($filter->getWords() as  $word) {


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14, 0.13, 0.12, 0.11, 0.10, 0.9, 0.8, 0.7, 0.6, 0.5
| License      | MIT

Fixed bug in DatabaseSearchEngine where results with identical contentId but different class got merged together
