### PR TITLE
[MediaLibrary] Fixed missing argument to FileFactory service definition

### DIFF
--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/services.yml
@@ -82,3 +82,4 @@ services:
         arguments:
             - '%enhavo_media_library.model.file.class%'
             - '@enhavo_media.provider'
+            - '@http_client'


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14 0.13
| License      | MIT

Fixed missing argument to FileFactory service definition in MediaLibraryBundle
