### PR TITLE
[ContentBundle] re-add canonicalUrl to database

### DIFF
--- a/migrations/Version20240619042720.php
+++ b/migrations/Version20240619042720.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240619042720 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE article_article ADD canonicalUrl VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE calendar_appointment ADD canonicalUrl VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE page_page ADD canonicalUrl VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE article_article DROP canonicalUrl');
+        $this->addSql('ALTER TABLE calendar_appointment DROP canonicalUrl');
+        $this->addSql('ALTER TABLE page_page DROP canonicalUrl');
+    }
+}

--- a/src/Enhavo/Bundle/ContentBundle/Resources/config/doctrine/Content.orm.xml
+++ b/src/Enhavo/Bundle/ContentBundle/Resources/config/doctrine/Content.orm.xml
@@ -7,6 +7,7 @@
 
         <field name="title" length="255" nullable="true" />
         <field name="slug" length="255" nullable="true" />
+        <field name="canonicalUrl" length="255" nullable="true" />
         <field name="metaDescription" type="text" nullable="true" />
         <field name="pageTitle" type="text" nullable="true" />
         <field name="public" type="boolean" nullable="true" />


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.10
| License      | MIT

During a former refactoring, the Database field definition for canonicalUrl in Content entity got lost. Now it is back again.
