### PR TITLE
[RoutingBundle] Always set route's static prefix to empty string if prefix is falseish

### DIFF
--- a/src/Enhavo/Bundle/RoutingBundle/Entity/Route.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Entity/Route.php
@@ -51,6 +51,9 @@ class Route extends BaseRouteModel implements RouteInterface, ResourceInterface
 
         if ($prefix) {
             $this->setStaticPrefix($prefix);
+
+        } else {
+            $this->setStaticPrefix('');
         }
 
         if ($variablePattern) {

--- a/src/Enhavo/Bundle/RoutingBundle/Tests/Route/RouteTest.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Tests/Route/RouteTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Route;
+
+use Enhavo\Bundle\RoutingBundle\Entity\Route;
+use Enhavo\Bundle\RoutingBundle\Tests\Mock\RouteContentMock;
+use PHPUnit\Framework\TestCase;
+
+class RouteTest extends TestCase
+{
+    private function createResource()
+    {
+        $resource = new RouteContentMock();
+        $resource->setRoute(new Route());
+        $resource->setTitle('this is a title');
+        $resource->setSubTitle('My subtitle');
+        return $resource;
+    }
+
+    public function testResetPath()
+    {
+        $resource = $this->createResource();
+        $resource->getRoute()->setPath('/exists');
+        $this->assertEquals('/exists', $resource->getRoute()->getStaticPrefix());
+        $resource->getRoute()->setPath(null);
+        $this->assertEquals('', $resource->getRoute()->getStaticPrefix());
+    }
+
+}

--- a/src/Enhavo/Bundle/RoutingBundle/Tests/Route/RouteTest.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Tests/Route/RouteTest.php
@@ -3,27 +3,17 @@
 namespace Route;
 
 use Enhavo\Bundle\RoutingBundle\Entity\Route;
-use Enhavo\Bundle\RoutingBundle\Tests\Mock\RouteContentMock;
 use PHPUnit\Framework\TestCase;
 
 class RouteTest extends TestCase
 {
-    private function createResource()
-    {
-        $resource = new RouteContentMock();
-        $resource->setRoute(new Route());
-        $resource->setTitle('this is a title');
-        $resource->setSubTitle('My subtitle');
-        return $resource;
-    }
-
     public function testResetPath()
     {
-        $resource = $this->createResource();
-        $resource->getRoute()->setPath('/exists');
-        $this->assertEquals('/exists', $resource->getRoute()->getStaticPrefix());
-        $resource->getRoute()->setPath(null);
-        $this->assertEquals('', $resource->getRoute()->getStaticPrefix());
+        $route = new Route();
+        $route->setPath('/exists');
+        $this->assertEquals('/exists', $route->getStaticPrefix());
+        $route->setPath(null);
+        $this->assertEquals('', $route->getStaticPrefix());
     }
 
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14
| License      | MIT

When URL in eg. Page was set to empty via HTML form no static prefix was set at all so that the old static prefix was preserved instead of creating a new prefix via given AutoGenerator(s).
