### PR TITLE
[AppBundle] Fixed incompatibility of OutputLoggers with current version of Monolog

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Output/AbstractOutputLogger.php
+++ b/src/Enhavo/Bundle/AppBundle/Output/AbstractOutputLogger.php
@@ -2,6 +2,7 @@
 
 namespace Enhavo\Bundle\AppBundle\Output;
 
+use Monolog\Level;
 use Monolog\Logger;
 
 abstract class AbstractOutputLogger implements OutputLoggerInterface
@@ -9,71 +10,71 @@ abstract class AbstractOutputLogger implements OutputLoggerInterface
     /**
      * {@inheritdoc}
      */
-    public function emergency($message, array $context = array())
+    public function emergency(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::EMERGENCY, $context);
+        $this->writeln($message, Level::Emergency, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function alert($message, array $context = array())
+    public function alert(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::ALERT, $context);
+        $this->writeln($message, Level::Alert, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function critical($message, array $context = array())
+    public function critical(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::CRITICAL, $context);
+        $this->writeln($message, Level::Critical, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function error($message, array $context = array())
+    public function error(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::ERROR, $context);
+        $this->writeln($message, Level::Error, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function warning($message, array $context = array())
+    public function warning(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::WARNING, $context);
+        $this->writeln($message, Level::Warning, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function notice($message, array $context = array())
+    public function notice(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::NOTICE, $context);
+        $this->writeln($message, Level::Notice, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function info($message, array $context = array())
+    public function info(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::INFO, $context);
+        $this->writeln($message, Level::Info, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function debug($message, array $context = array())
+    public function debug(string|\Stringable $message, array $context = array()): void
     {
-        $this->writeln($message, Logger::DEBUG, $context);
+        $this->writeln($message, Level::Debug, $context);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, string|\Stringable $message, array $context = array()): void
     {
         $level = Logger::toMonologLevel($level);
         $this->writeln($message, $level, $context);

--- a/src/Enhavo/Bundle/AppBundle/Output/ChainOutputLogger.php
+++ b/src/Enhavo/Bundle/AppBundle/Output/ChainOutputLogger.php
@@ -2,7 +2,7 @@
 
 namespace Enhavo\Bundle\AppBundle\Output;
 
-use Monolog\Logger;
+use Monolog\Level;
 
 class ChainOutputLogger implements OutputLoggerInterface
 {
@@ -22,7 +22,7 @@ class ChainOutputLogger implements OutputLoggerInterface
     /**
      * {@inheritdoc}
      */
-    public function writeln($message, $level = Logger::INFO, $context = array())
+    public function writeln($message, $level = Level::Info, $context = array())
     {
         foreach($this->outputLoggers as $logger) {
             $logger->writeln($message, $level, $context);
@@ -32,7 +32,7 @@ class ChainOutputLogger implements OutputLoggerInterface
     /**
      * {@inheritdoc}
      */
-    public function write($message, $level = Logger::INFO)
+    public function write($message, $level = Level::Info)
     {
         foreach($this->outputLoggers as $logger) {
             $logger->write($message, $level);

--- a/src/Enhavo/Bundle/AppBundle/Output/CliOutputLogger.php
+++ b/src/Enhavo/Bundle/AppBundle/Output/CliOutputLogger.php
@@ -2,7 +2,7 @@
 
 namespace Enhavo\Bundle\AppBundle\Output;
 
-use Monolog\Logger;
+use Monolog\Level;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -16,7 +16,7 @@ class CliOutputLogger extends AbstractOutputLogger
     /**
      * @var int
      */
-    private $verboseRequiredLevel = Logger::DEBUG;
+    private $verboseRequiredLevel = Level::Debug;
 
     /**
      * CliOutputLogger constructor.
@@ -55,7 +55,7 @@ class CliOutputLogger extends AbstractOutputLogger
     /**
      * {@inheritdoc}
      */
-    public function writeln($message, $level = Logger::INFO, $context = array())
+    public function writeln($message, $level = Level::Info, $context = array())
     {
         $type = $level <= $this->getVerboseRequiredLevel() ? OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_VERBOSE : OutputInterface::OUTPUT_NORMAL;
         $this->symfonyStyle->writeln($message, $type);
@@ -64,7 +64,7 @@ class CliOutputLogger extends AbstractOutputLogger
     /**
      * {@inheritdoc}
      */
-    public function write($message, $level = Logger::INFO)
+    public function write($message, $level = Level::Info)
     {
         $type = $level <= $this->getVerboseRequiredLevel() ? OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_VERBOSE : OutputInterface::OUTPUT_NORMAL;
         $this->symfonyStyle->write($message, false, $type);

--- a/src/Enhavo/Bundle/AppBundle/Output/LogOutputLogger.php
+++ b/src/Enhavo/Bundle/AppBundle/Output/LogOutputLogger.php
@@ -2,7 +2,7 @@
 
 namespace Enhavo\Bundle\AppBundle\Output;
 
-use Monolog\Logger;
+use Monolog\Level;
 use Psr\Log\LoggerInterface;
 
 class LogOutputLogger extends AbstractOutputLogger
@@ -34,7 +34,7 @@ class LogOutputLogger extends AbstractOutputLogger
     /**
      * {@inheritdoc}
      */
-    public function writeln($message, $level = Logger::INFO, $context = array())
+    public function writeln($message, $level = Level::Info, $context = array())
     {
         if ($this->lineBuffer !== '') {
             if ($this->lineBufferLogLevel !== $level) {
@@ -50,7 +50,7 @@ class LogOutputLogger extends AbstractOutputLogger
     /**
      * {@inheritdoc}
      */
-    public function write($message, $level = Logger::INFO)
+    public function write($message, $level = Level::Info)
     {
         if ($this->lineBuffer !== '' && $this->lineBufferLogLevel != $level) {
             $this->flushLineBuffer();

--- a/src/Enhavo/Bundle/AppBundle/Output/OutputLoggerInterface.php
+++ b/src/Enhavo/Bundle/AppBundle/Output/OutputLoggerInterface.php
@@ -2,7 +2,7 @@
 
 namespace Enhavo\Bundle\AppBundle\Output;
 
-use Monolog\Logger;
+use Monolog\Level;
 use Psr\Log\LoggerInterface;
 
 interface OutputLoggerInterface extends LoggerInterface
@@ -14,7 +14,7 @@ interface OutputLoggerInterface extends LoggerInterface
      * @param int $level The log level used, one of the constants from Monolog\Logger
      * @param array $context The log context as used in Monolog\LoggerInterface functions
      */
-    public function writeln($message, $level = Logger::INFO, $context = array());
+    public function writeln($message, $level = Level::Info, $context = array());
 
     /**
      * Write text to the output without a newline at the end
@@ -22,7 +22,7 @@ interface OutputLoggerInterface extends LoggerInterface
      * @param string $message The message to write
      * @param int $level The log level used, one of the constants from Monolog\Logger
      */
-    public function write($message, $level = Logger::INFO);
+    public function write($message, $level = Level::Info);
 
     /**
      * Create and display a progress bar. If the output does not support progress bars, nothing is done.


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | yes
| Backport     | 0.14
| License      | MIT

Fixed incompatibility of OutputLoggers with current version of Monolog
