### PR TITLE
Removed ThemeBundle from static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
                     composer validate --strict src/Enhavo/Bundle/SliderBundle/composer.json
                     composer validate --strict src/Enhavo/Bundle/TaxonomyBundle/composer.json
                     composer validate --strict src/Enhavo/Bundle/TemplateBundle/composer.json
-                    composer validate --strict src/Enhavo/Bundle/ThemeBundle/composer.json
                     composer validate --strict src/Enhavo/Bundle/TranslationBundle/composer.json
                     composer validate --strict src/Enhavo/Bundle/UserBundle/composer.json
                     composer validate --strict src/Enhavo/Bundle/VueFormBundle/composer.json


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Removed ThemeBundle from static checks because the bundle no longer exists