### PR TITLE
[TranslationBundle] Avoid AccessControl to set access to true per default

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/EventListener/AccessControl.php
+++ b/src/Enhavo/Bundle/TranslationBundle/EventListener/AccessControl.php
@@ -51,18 +51,19 @@ class AccessControl
         $this->accessControl = $accessControl;
     }
 
-    public function isAccess()
+    public function isAccess(): bool
     {
         if ($this->access !== null) {
             return $this->access;
         }
 
-        $this->access = true;
         $request = $this->requestStack->getMainRequest();
         if ($request === null) {
-            return false;
+            $this->access = false;
+            return $this->access;
         }
 
+        $this->access = true;
         $path = $request->getPathInfo();
         foreach ($this->accessControl as $regex) {
             if (!preg_match($regex, $path)) {

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/AccessControlTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/AccessControlTest.php
@@ -20,7 +20,6 @@ class AccessControlTest extends TestCase
         $dependencies->requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $dependencies->request = $this->getMockBuilder(Request::class)->getMock();
         $dependencies->request->attributes = $this->getMockBuilder(ParameterBag::class)->getMock();
-        $dependencies->requestStack->method('getMainRequest')->willReturn($dependencies->request);
         $dependencies->localeResolver = $this->getMockBuilder(LocaleResolverInterface::class)->getMock();
 
         return $dependencies;
@@ -53,7 +52,7 @@ class AccessControlTest extends TestCase
         $dependencies = $this->createDependencies();
         $control = $this->createInstance($dependencies);
 
-        $dependencies->requestStack->expects($this->exactly(1))->method('getMainRequest')->willReturn($dependencies->request);
+        $dependencies->requestStack->expects($this->once())->method('getMainRequest')->willReturn($dependencies->request);
         $dependencies->request->expects($this->once())->method('getPathInfo')->willReturn('/my/page/10');
 
         $this->assertTrue($control->isAccess());
@@ -86,6 +85,17 @@ class AccessControlTest extends TestCase
 
         $this->assertEquals('_locale', $control->getLocale());
         $this->assertNotEquals('__locale', $control->getLocale());
+    }
+
+    public function testIsAccessFalseNoMainRequestTwice()
+    {
+        $dependencies = $this->createDependencies();
+        $control = $this->createInstance($dependencies);
+
+        $dependencies->requestStack->expects($this->once())->method('getMainRequest')->willReturn(null);
+
+        $this->assertFalse($control->isAccess());
+        $this->assertFalse($control->isAccess());
     }
 }
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.12
| Tickets      | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License      | MIT

AccessControl is designed to only allow access if RequestStack has a main request.
If called twice, on the second call a cached value is returned to avoid unnecessary computation.
Before the fix, access cache value was set to **true** before clarification if the call came with a Request.
