### PR TITLE
[AppBundle] Fix OutputStreamModal using non-proxy variable

### DIFF
--- a/assets/node_modules/@enhavo/app/modal/model/OutputStreamModal.ts
+++ b/assets/node_modules/@enhavo/app/modal/model/OutputStreamModal.ts
@@ -7,13 +7,15 @@ export default class OutputStreamModal extends AbstractModal
     public output: string = "";
     public done: boolean = false;
 
-    init() {
-        let modal = this;
+    init()
+    {
         fetch(this.url)
             .then(response => response.body)
             .then(body => {
                 const reader = body.getReader();
-                reader.read().then(function processText({ done, value }): any {
+                const processText = ({ done, value }) => {
+                    const modal = this.modalManager.modals[this.modalManager.modals.length-1];
+
                     if(value) {
                         modal.output += new TextDecoder("utf-8").decode(value);
                     }
@@ -22,7 +24,8 @@ export default class OutputStreamModal extends AbstractModal
                         modal.done = true;
                         return reader.read().then(processText);
                     }
-                })
+                }
+                reader.read().then(processText)
             });
     }
 }

--- a/assets/node_modules/@enhavo/app/modal/model/OutputStreamModal.ts
+++ b/assets/node_modules/@enhavo/app/modal/model/OutputStreamModal.ts
@@ -24,8 +24,8 @@ export default class OutputStreamModal extends AbstractModal
                         modal.done = true;
                         return reader.read().then(processText);
                     }
-                }
-                reader.read().then(processText)
+                };
+                reader.read().then(processText);
             });
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14
| License      | MIT

During outputstream read the modal should be updated on every iteration, but on every iteration the wrong object was written.
