### PR TITLE
[TranslationBundle] Fix wrong LocaleResolver used in DoctrineTranslationSubscriber

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/EventListener/DoctrineTranslationSubscriber.php
+++ b/src/Enhavo/Bundle/TranslationBundle/EventListener/DoctrineTranslationSubscriber.php
@@ -9,9 +9,9 @@ namespace Enhavo\Bundle\TranslationBundle\EventListener;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
-use Doctrine\Persistence\Proxy;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
-use Enhavo\Bundle\TranslationBundle\Locale\LocaleResolver;
+use Doctrine\Persistence\Proxy;
+use Enhavo\Bundle\AppBundle\Locale\LocaleResolverInterface;
 use Enhavo\Bundle\TranslationBundle\Translation\TranslationManager;
 use Enhavo\Component\Metadata\MetadataRepository;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
@@ -32,7 +32,7 @@ class DoctrineTranslationSubscriber implements EventSubscriber
     public function __construct(
         private AccessControl $accessControl,
         private MetadataRepository $metadataRepository,
-        private LocaleResolver $localeResolver,
+        private LocaleResolverInterface $localeResolver,
     )
     {
     }

--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/translator.yaml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/translator.yaml
@@ -17,7 +17,7 @@ services:
         arguments:
             - '@enhavo_translation.translation.access_control'
             - '@Enhavo\Component\Metadata\MetadataRepository[Translation]'
-            - '@Enhavo\Bundle\TranslationBundle\Locale\LocaleResolver'
+            - '@enhavo_app.locale_resolver'
         calls:
             - [setContainer, ['@service_container']]
         tags:


### PR DESCRIPTION

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14
| License      | MIT

DoctrineTranslationSubscriber was configured to always use the same LocaleResolver instead of using the one configured in AppBundle
