### PR TITLE
[RoutingBundle] Allow contentClass to be set to null as defined in doctrine annotation

### DIFF
--- a/src/Enhavo/Bundle/RoutingBundle/Entity/Route.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Entity/Route.php
@@ -22,7 +22,7 @@ class Route extends BaseRouteModel implements RouteInterface, ResourceInterface
         return $this->contentClass;
     }
 
-    public function setContentClass(string $contentClass): void
+    public function setContentClass(?string $contentClass): void
     {
         $this->contentClass = $contentClass;
     }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14

In case one route exists with a contentId that does not exist anymore, doctrine-extension-bundle's ReferenceSubscriber is meant to also set contentclass to NULL.
In case contentClass may not be set to NULL, it is not even possible to remove the unassigned route via entityManager->remove due to error within ReferenceSubscriber.
