### PR TITLE
[RoutingBundle] change order of transliteration and urlization to make it even work with arabic characters

### DIFF
--- a/src/Enhavo/Bundle/RoutingBundle/Slugifier/Slugifier.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Slugifier/Slugifier.php
@@ -13,8 +13,8 @@ class Slugifier implements SlugifierInterface
     public static function slugify($content, $separator = '-')
     {
         $urlizer = new Urlizer();
-        $content = $urlizer->urlize($content, $separator);
         $content  = $urlizer->transliterate($content, $separator);
+        $content = $urlizer->urlize($content, $separator);
         return $content;
     }
 }


### PR DESCRIPTION
…

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14
| License      | MIT

slugifier cut off all arabic characters by slugifing first and then transliterating, switching orders helped.
