### PR TITLE
fix: translation help message, twig routing on json requests, duplica…

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Extension/RouterEndpointExtensionType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Extension/RouterEndpointExtensionType.php
@@ -31,7 +31,7 @@ class RouterEndpointExtensionType extends AbstractEndpointTypeExtension
             $data->set('routes', $this->normalize($routesCollection, null, ['groups' => 'endpoint']));
         }
 
-        if ($context->get('routes') && (!$request->get('_format') || $request->get('_format') === 'html')) {
+        if ($context->get('routes')) {
             $this->twigRouter->addRouteCollection($context->get('routes'));
         }
     }

--- a/src/Enhavo/Bundle/BlockBundle/Factory/NodeFactory.php
+++ b/src/Enhavo/Bundle/BlockBundle/Factory/NodeFactory.php
@@ -43,8 +43,10 @@ class NodeFactory
             $node->setBlock($this->blockFactory->duplicate($original->getBlock()));
         }
         foreach($original->getChildren() as $child) {
-            $newChild = $this->duplicate($child);
-            $node->addChild($newChild);
+            if ($child->getType() !== NodeInterface::TYPE_LIST) {
+                $newChild = $this->duplicate($child);
+                $node->addChild($newChild);
+            }
         }
         return $node;
     }

--- a/src/Enhavo/Bundle/TranslationBundle/Form/Type/TranslationType.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/Type/TranslationType.php
@@ -63,6 +63,9 @@ class TranslationType extends AbstractType
             }
         }
 
+        $help = $form->get($this->translationManager->getDefaultLocale())->getConfig()->getOption('help');
+        $view->vars['help'] = $help;
+
         $view->vars['errors'] = new FormErrorIterator($errors->getForm(), $newErrors);
         $view->vars['translation_locales'] = $this->translationManager->getLocales();
     }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.14
| License      | MIT

* fix: help message for translated forms
* fix: twig routing on json requests (needed for html in json)
* fix: duplicate block node with type list

