### PR TITLE
feat: error endpoint type

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Type/ErrorEndpointType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Type/ErrorEndpointType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Enhavo\Bundle\AppBundle\Endpoint\Type;
+
+use Enhavo\Bundle\ApiBundle\Data\Data;
+use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointType;
+use Enhavo\Bundle\ApiBundle\Endpoint\Context;
+use Enhavo\Bundle\AppBundle\Template\TemplateResolver;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
+
+class ErrorEndpointType extends AbstractEndpointType
+{
+    public function __construct(
+        private readonly TemplateResolver $templateResolver,
+        private readonly Environment $twigEnvironment,
+    )
+    {
+    }
+
+    public function handleRequest($options, Request $request, Data $data, Context $context): void
+    {
+        $data['status_code'] = $options['status_code'];
+        $data['status_text'] = $options['status_text'];
+
+        $template = $this->templateResolver->resolve(sprintf('theme/error/%s.html.twig', $options['status_code']));
+        if ($this->twigEnvironment->getLoader()->exists($template)) {
+            $context->set('template', $template);
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'template' => 'theme/error/default.html.twig',
+            'exception' => null,
+            'status_code' => null,
+            'status_text' => null,
+        ]);
+    }
+
+    public static function getParentType(): ?string
+    {
+        return AreaEndpointType::class;
+    }
+}

--- a/src/Enhavo/Bundle/AppBundle/Resources/config/services/endpoint.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/services/endpoint.yaml
@@ -166,3 +166,13 @@ services:
         tags:
             - { name: enhavo_api.endpoint }
             - { name: container.service_subscriber }
+
+    Enhavo\Bundle\AppBundle\Endpoint\Type\ErrorEndpointType:
+        arguments:
+            - '@Enhavo\Bundle\AppBundle\Template\TemplateResolverInterface'
+            - '@twig'
+        calls:
+            - [ setContainer, [ '@Psr\Container\ContainerInterface' ] ]
+        tags:
+            - { name: enhavo_api.endpoint }
+            - { name: container.service_subscriber }

--- a/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/services/services.yaml
@@ -39,10 +39,6 @@ services:
             - '%twig.default_path%'
             - '%kernel.project_dir%/assets/theme'
 
-    Enhavo\Bundle\AppBundle\Controller\ArgumentResolver:
-        arguments:
-            - '@argument_metadata_factory'
-
     Enhavo\Bundle\AppBundle\Security\ExceptionListener:
         tags:
             - { name: kernel.event_listener, event: kernel.exception, priority: 300 }
@@ -51,11 +47,9 @@ services:
         class: Enhavo\Bundle\AppBundle\ErrorRenderer\EnhavoErrorRenderer
         decorates: twig.error_renderer.html
         arguments:
-            - '@twig'
-            - '%kernel.project_dir%'
-            - '@Enhavo\Bundle\AppBundle\Template\TemplateResolverInterface'
-            - '@enhavo.error_handler.html.inner'
+            - '@Enhavo\Component\Type\FactoryInterface[Endpoint]'
             - '@request_stack'
+            - '@enhavo.error_handler.html.inner'
             - '%kernel.debug%'
 
     Enhavo\Bundle\AppBundle\Mailer\MailerManager:


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Add `ErrorEndpointType` and use it for error rendering to access view data on error pages
