### PR TITLE
[MediaBundle] Allow CreateDummyFileNotFoundHandler to write the dummy…

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/EventListener/DoctrineContentSubscriber.php
+++ b/src/Enhavo/Bundle/MediaBundle/EventListener/DoctrineContentSubscriber.php
@@ -26,6 +26,7 @@ class DoctrineContentSubscriber implements EventSubscriber
     public function __construct(
         private readonly StorageInterface $storage,
         private readonly FileNotFoundHandlerInterface $handler,
+        private readonly array $fileNotFoundHandlerParameters,
     ) {}
 
     public function getSubscribedEvents(): array
@@ -45,7 +46,7 @@ class DoctrineContentSubscriber implements EventSubscriber
             try {
                 $object->setContent($this->storage->saveContent($object));
             } catch (FileNotFoundException $exception) {
-                $this->handler->handleSave($object, $this->storage, $exception);
+                $this->handler->handleSave($object, $this->storage, $exception, $this->fileNotFoundHandlerParameters);
             }
         }
     }
@@ -57,7 +58,7 @@ class DoctrineContentSubscriber implements EventSubscriber
             try {
                 $object->setContent($this->storage->saveContent($object));
             } catch (FileNotFoundException $exception) {
-                $this->handler->handleSave($object, $this->storage, $exception);
+                $this->handler->handleSave($object, $this->storage, $exception, $this->fileNotFoundHandlerParameters);
             }
         }
     }
@@ -69,7 +70,7 @@ class DoctrineContentSubscriber implements EventSubscriber
             try {
                 $object->setContent($this->storage->getContent($object));
             } catch (FileNotFoundException $exception) {
-                $this->handler->handleLoad($object, $this->storage, $exception);
+                $this->handler->handleLoad($object, $this->storage, $exception, $this->fileNotFoundHandlerParameters);
             }
         }
     }
@@ -81,7 +82,7 @@ class DoctrineContentSubscriber implements EventSubscriber
             try {
                 $this->storage->deleteContent($object);
             } catch (FileNotFoundException $exception) {
-                $this->handler->handleDelete($object, $this->storage, $exception);
+                $this->handler->handleDelete($object, $this->storage, $exception, $this->fileNotFoundHandlerParameters);
             }
         }
     }

--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/ExceptionFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/ExceptionFileNotFoundHandler.php
@@ -15,17 +15,17 @@ class ExceptionFileNotFoundHandler implements FileNotFoundHandlerInterface
         // do nothing
     }
 
-    public function handleSave(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception): void
+    public function handleSave(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {
         throw new FileNotFoundException($exception->getMessage(), $exception->getCode(), $exception);
     }
 
-    public function handleLoad(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception): void
+    public function handleLoad(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {
         throw new FileNotFoundException($exception->getMessage(), $exception->getCode(), $exception);
     }
 
-    public function handleDelete(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception): void
+    public function handleDelete(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {
         throw new FileNotFoundException($exception->getMessage(), $exception->getCode(), $exception);
     }

--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/FileNotFoundHandlerInterface.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/FileNotFoundHandlerInterface.php
@@ -9,8 +9,7 @@ use Enhavo\Bundle\MediaBundle\Storage\StorageInterface;
 
 interface FileNotFoundHandlerInterface
 {
-    public function setParameters(array $parameters);
-    public function handleSave(FileInterface|FormatInterface $file, StorageInterface $storage, FileNotFoundException $exception): void;
-    public function handleLoad(FileInterface|FormatInterface $file, StorageInterface $storage, FileNotFoundException $exception): void;
-    public function handleDelete(FileInterface|FormatInterface $file, StorageInterface $storage, FileNotFoundException $exception): void;
+    public function handleSave(FileInterface|FormatInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void;
+    public function handleLoad(FileInterface|FormatInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void;
+    public function handleDelete(FileInterface|FormatInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void;
 }

--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/RemoteFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/RemoteFileNotFoundHandler.php
@@ -13,27 +13,21 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class RemoteFileNotFoundHandler implements FileNotFoundHandlerInterface
 {
-    private $parameters = [];
-    const SERVER_URL_PARAMETER = 'server_url';
+    const PARAMETER_SERVER_URL = 'server_url';
 
     public function __construct(
         private UrlGeneratorInterface $urlGenerator,
         private HttpClientInterface $client,
     ) {}
 
-    public function setParameters(array $parameters)
-    {
-        $this->parameters = $parameters;
-    }
-
-    public function handleSave(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception): void
+    public function handleSave(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {
         // do nothing
     }
 
-    public function handleLoad(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception): void
+    public function handleLoad(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {
-        $url = $this->getRemoteServerUrl($this->parameters) . $this->urlGenerator->generate($file);
+        $url = $this->getRemoteServerUrl($parameters) . $this->urlGenerator->generate($file);
 
         $response = $this->client->request('GET', $url);
         if($response->getStatusCode() != 200) {
@@ -44,7 +38,7 @@ class RemoteFileNotFoundHandler implements FileNotFoundHandlerInterface
         $storage->saveContent($file);
     }
 
-    public function handleDelete(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception): void
+    public function handleDelete(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {
         // do nothing
     }
@@ -56,9 +50,9 @@ class RemoteFileNotFoundHandler implements FileNotFoundHandlerInterface
 
     private function getRemoteServerUrl($parameters)
     {
-        if (!isset($parameters[self::SERVER_URL_PARAMETER])) {
-            throw new \Exception(sprintf('FileNotFound Strategy of type "%s" requires parameter "%s"', $this->getType(), self::SERVER_URL_PARAMETER));
+        if (!isset($parameters[self::PARAMETER_SERVER_URL])) {
+            throw new \Exception(sprintf('FileNotFoundHandler of type "%s" requires parameter "%s"', self::class, self::PARAMETER_SERVER_URL));
         }
-        return $parameters[self::SERVER_URL_PARAMETER];
+        return $parameters[self::PARAMETER_SERVER_URL];
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
@@ -7,3 +7,6 @@ services:
             - '@http_client'
 
     Enhavo\Bundle\MediaBundle\FileNotFound\CreateDummyFileNotFoundHandler:
+        arguments:
+            - '@filesystem'
+            - '%kernel.project_dir%/var/media/dummy'

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
@@ -77,6 +77,7 @@ services:
         arguments:
             - '@Enhavo\Bundle\MediaBundle\Storage\StorageInterface'
             - '@Enhavo\Bundle\MediaBundle\FileNotFound\FileNotFoundHandlerInterface'
+            - '%enhavo_media.file_not_found.parameters%'
         tags:
             - { name: doctrine.event_listener, event: postLoad, method: postLoad }
             - { name: doctrine.event_listener, event: postUpdate, method: postUpdate }

--- a/src/Enhavo/Bundle/MediaBundle/Tests/FileNotFound/RemoteFileNotFoundHandlerTest.php
+++ b/src/Enhavo/Bundle/MediaBundle/Tests/FileNotFound/RemoteFileNotFoundHandlerTest.php
@@ -62,10 +62,9 @@ class RemoteFileNotFoundHandlerTest extends TestCase
         $instance = $this->createInstance($dependencies);
         $file = new File();
 
-        $instance->setParameters([
-            RemoteFileNotFoundHandler::SERVER_URL_PARAMETER => 'http://127.0.0.1:1234'
+        $instance->handleLoad($file, $dependencies->storage, $dependencies->exception, [
+            RemoteFileNotFoundHandler::PARAMETER_SERVER_URL => 'http://127.0.0.1:1234'
         ]);
-        $instance->handleLoad($file, $dependencies->storage, $dependencies->exception);
 
         $this->assertEquals("File could not be found.", $file->getContent()->getContent());
     }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | no
| BC-Break?    | no
| License      | MIT

[MediaBundle] Allow CreateDummyFileNotFoundHandler to write the dummy file to var/media directory to avoid rebuilding the same dummy file every request