### PR TITLE
[BlockBundle] Enable Autowiring for Factories implementing BlockFactoryInterface

### DIFF
--- a/src/Enhavo/Bundle/BlockBundle/DependencyInjection/CompilerPass/BlockManagerCompilerPass.php
+++ b/src/Enhavo/Bundle/BlockBundle/DependencyInjection/CompilerPass/BlockManagerCompilerPass.php
@@ -21,6 +21,13 @@ class BlockManagerCompilerPass implements CompilerPassInterface
             }
         }
 
+        $factoryServices = $container->findTaggedServiceIds('enhavo_block.factory');
+        foreach ($factoryServices as $factoryId => $factoryTags) {
+            if (!isset($services[$factoryId])) {
+                $services[$factoryId] = new Reference($factoryId);
+            }
+        }
+
         $blockManager = $container->findDefinition(BlockManager::class);
         $blockManager->addMethodCall('setContainer', [ServiceLocatorTagPass::register($container, $services)]);
     }

--- a/src/Enhavo/Bundle/BlockBundle/EnhavoBlockBundle.php
+++ b/src/Enhavo/Bundle/BlockBundle/EnhavoBlockBundle.php
@@ -5,6 +5,7 @@ namespace Enhavo\Bundle\BlockBundle;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Enhavo\Bundle\BlockBundle\Block\Block;
 use Enhavo\Bundle\BlockBundle\DependencyInjection\CompilerPass\BlockManagerCompilerPass;
+use Enhavo\Bundle\BlockBundle\Factory\BlockFactoryInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Enhavo\Component\Type\TypeCompilerPass;
@@ -33,6 +34,10 @@ class EnhavoBlockBundle extends Bundle
         );
 
         $container->addCompilerPass(new BlockManagerCompilerPass());
+
+        $container->registerForAutoconfiguration(BlockFactoryInterface::class)
+            ->addTag('enhavo_block.factory')
+        ;
     }
 
     private function buildDoctrineBlockCompilerPass($configDir, $namespace, $enableParameter): DoctrineOrmMappingsPass

--- a/src/Enhavo/Bundle/BlockBundle/Factory/AbstractBlockFactory.php
+++ b/src/Enhavo/Bundle/BlockBundle/Factory/AbstractBlockFactory.php
@@ -9,19 +9,16 @@
 namespace Enhavo\Bundle\BlockBundle\Factory;
 
 use Enhavo\Bundle\BlockBundle\Model\BlockInterface;
-use Enhavo\Bundle\ResourceBundle\Factory\FactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-abstract class AbstractBlockFactory implements ContainerAwareInterface, FactoryInterface
+abstract class AbstractBlockFactory implements ContainerAwareInterface, BlockFactoryInterface
 {
     use ContainerAwareTrait;
 
-    protected $dataClass;
-
-    public function __construct($dataClass)
-    {
-        $this->dataClass = $dataClass;
+    public function __construct(
+        protected string $dataClass
+    ) {
     }
 
     public function createNew()

--- a/src/Enhavo/Bundle/BlockBundle/Factory/BlockFactoryInterface.php
+++ b/src/Enhavo/Bundle/BlockBundle/Factory/BlockFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @author blutze-media
+ * @since 2024-12-16
+ */
+
+namespace Enhavo\Bundle\BlockBundle\Factory;
+
+use Enhavo\Bundle\ResourceBundle\Factory\FactoryInterface;
+
+interface BlockFactoryInterface extends FactoryInterface
+{
+
+}


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | yes
| Tickets      | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License      | MIT

In Projects BlockFactories have to be overwritten and wired with certain services in some cases.
Until now BlockManager initiated BlockFactories mostly be new $className($modelName) because
Factory definitions were missing in the respective Container.
Now all BlockFactories implementing BlockFactoryInterface are inserted into the BlockManager's container, so that
it can use the service instead of instantiating a new Factory.
