### PR TITLE
[UserBundle] Fix RegistrationConfirmEndpoint asking for AutoLogin but  setting can't be influenced within project

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/UserBundle/DependencyInjection/Configuration.php
@@ -127,6 +127,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('template')->defaultValue('{{ area }}/user/registration/confirm.html.twig')->end()
                         ->scalarNode('auto_enabled')->defaultValue(true)->end()
+                        ->scalarNode('auto_login')->defaultValue(true)->end()
                         ->append($this->addConfigMailNode())
                         ->scalarNode('translation_domain')->defaultValue(null)->end()
                         ->scalarNode('redirect_route')->defaultValue(null)->end()


### PR DESCRIPTION

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.13
| License      | MIT

The configuration setting for auto_login was missing for registration confirm, although it was checked within the endpoint/controller.
