### PR TITLE
fix: document write preview

### DIFF
--- a/assets/node_modules/@enhavo/app/action/model/AutoSaveAction.ts
+++ b/assets/node_modules/@enhavo/app/action/model/AutoSaveAction.ts
@@ -4,6 +4,7 @@ import {UiManager} from "@enhavo/app/ui/UiManager";
 import {FlashMessenger, FlashMessage} from "@enhavo/app/flash-message/FlashMessenger";
 import {Translator} from "@enhavo/app/translation/Translator";
 import {FormEventDispatcher} from "@enhavo/vue-form/form/FormEventDispatcher";
+import {FrameManager} from "@enhavo/app/frame/FrameManager";
 
 export class AutoSaveAction extends AbstractAction
 {
@@ -20,6 +21,7 @@ export class AutoSaveAction extends AbstractAction
         private readonly resourceInputManager: ResourceInputManager,
         private readonly translator: Translator,
         private readonly formEventDispatcher: FormEventDispatcher,
+        private readonly frameManager: FrameManager,
     ) {
         super();
     }
@@ -46,6 +48,10 @@ export class AutoSaveAction extends AbstractAction
                 this.addTimout();
             }
         });
+
+        this.frameManager.on('input_changed', () => {
+            this.removeTimeout()
+        });
     }
 
     private addTimout()
@@ -54,8 +60,13 @@ export class AutoSaveAction extends AbstractAction
 
         this.timeoutId = window.setTimeout(async () => {
             if (this.on) {
-                await this.resourceInputManager.save(this.url, true);
-                this.flashMessenger.addMessage(new FlashMessage(this.translator.trans('enhavo_app.auto_save', {}, 'javascript'), FlashMessage.SUCCESS));
+                let success = await this.resourceInputManager.save(this.url, true);
+
+                if (success) {
+                    this.flashMessenger.addMessage(new FlashMessage(this.translator.trans('enhavo_app.auto_save', {}, 'javascript'), FlashMessage.SUCCESS));
+                } else {
+                    this.flashMessenger.error(this.translator.trans('enhavo_app.save.message.not_valid', {}, 'javascript'));
+                }
             }
         }, this.timeout * 1000);
     }

--- a/assets/node_modules/@enhavo/app/manager/ResourcePreviewManager.ts
+++ b/assets/node_modules/@enhavo/app/manager/ResourcePreviewManager.ts
@@ -1,4 +1,3 @@
-import {Router} from "@enhavo/app/routing/Router";
 import {ActionManager} from "@enhavo/app/action/ActionManager";
 import {ActionInterface} from "@enhavo/app/action/ActionInterface";
 import {FrameManager} from "@enhavo/app/frame/FrameManager";
@@ -73,11 +72,8 @@ export class ResourcePreviewManager
             if ((event as PreviewData).target == this.frameManager.getId()) {
                 this.previewData = (event as PreviewData).data;
                 if (this.iframe) {
-                    this.iframe.contentWindow.document.open();
-                    this.iframe.contentWindow.document.write(this.previewData);
-                    this.iframe.contentWindow.document.close();
+                    this.iframe.contentWindow.document.querySelector('html').innerHTML = this.previewData
                 }
-
                 event.resolve();
             }
         })

--- a/assets/node_modules/@enhavo/app/services/admin/action.yaml
+++ b/assets/node_modules/@enhavo/app/services/admin/action.yaml
@@ -130,6 +130,7 @@ services:
             - '@enhavo/app/manager/ResourceInputManager'
             - '@enhavo/app/translation/Translator'
             - '@enhavo/vue-form/form/FormEventDispatcher'
+            - '@enhavo/app/frame/FrameManager'
         tags:
             - { name: 'enhavo_app.action', class: 'AutoSaveAction' }
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,8 +34,8 @@ security:
             custom_authenticators:
                 - Enhavo\Bundle\UserBundle\Security\Authentication\FormLoginAuthenticator
             logout:
-                path: enhavo_user_theme_security_logout
-                target: enhavo_user_theme_security_login
+                path: enhavo_user_theme_logout
+                target: enhavo_user_theme_login
 
     access_control:
         - { path: ^/admin/login$, role: PUBLIC_ACCESS }

--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Type/PreviewEndpointType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Type/PreviewEndpointType.php
@@ -35,7 +35,7 @@ class PreviewEndpointType extends AbstractEndpointType
 
         $resource = $input->getResource() ?? $input->createResource();
 
-        $form = $input->getForm($resource);
+        $form = $input->createForm($resource);
         if ($form) {
             $form->setData($resource);
             $form->handleRequest($request);

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/routes/admin_api/article.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/routes/admin_api/article.yaml
@@ -62,7 +62,7 @@ enhavo_article_admin_api_article_duplicate:
             input: enhavo_article.article
 
 enhavo_article_admin_api_article_preview:
-    path: /article/preview/{id}
+    path: /article/preview
     methods: [GET, POST]
     defaults:
         _expose: admin_api

--- a/src/Enhavo/Bundle/CommentBundle/Resources/config/routes/admin_api/comment.yaml
+++ b/src/Enhavo/Bundle/CommentBundle/Resources/config/routes/admin_api/comment.yaml
@@ -61,7 +61,7 @@ enhavo_comment_admin_api_comment_batch:
             grid: enhavo_comment.comment
 
 enhavo_comment_admin_api_preview:
-    path: /comment/preview/{id}
+    path: /comment/preview
     methods: [GET, POST]
     defaults:
         _expose: admin_api

--- a/src/Enhavo/Bundle/NewsletterBundle/Endpoint/NewsletterTestEndpointType.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Endpoint/NewsletterTestEndpointType.php
@@ -39,7 +39,7 @@ class NewsletterTestEndpointType extends AbstractEndpointType
 
         $input = $this->inputFactory->create($options['input']);
 
-        $form = $input->getForm();
+        $form = $input->createForm();
         $form->setData($newsletter);
 
         $submittedFormData = [];

--- a/src/Enhavo/Bundle/PageBundle/Resources/config/routes/admin_api/page.yaml
+++ b/src/Enhavo/Bundle/PageBundle/Resources/config/routes/admin_api/page.yaml
@@ -62,7 +62,7 @@ enhavo_page_admin_api_page_duplicate:
             input: enhavo_page.page
 
 enhavo_page_admin_api_preview:
-    path: /page/preview/{id}
+    path: /page/preview
     methods: [GET, POST]
     defaults:
         _expose: admin_api

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/PropertyDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/PropertyDuplicateType.php
@@ -16,8 +16,12 @@ class PropertyDuplicateType extends AbstractDuplicateType
         }
 
         $value = $sourceValue->getValue();
-        if (!is_null($value) && !is_scalar($value)) {
-            throw new \InvalidArgumentException(sprintf('Duplicate type property only accept scalar values but "%s" given', gettype($value)));
+        if (!is_null($value) && !(is_scalar($value) || is_array($value))) {
+            throw new \InvalidArgumentException(sprintf('Duplicate type property only accept scalar or array values but "%s" given for property "%s" on class "%s"',
+                gettype($value),
+                $sourceValue->getPropertyName(),
+                get_class($sourceValue->getParent()
+            )));
         }
 
         $targetValue->setValue($value);

--- a/templates/theme/base.html.twig
+++ b/templates/theme/base.html.twig
@@ -8,8 +8,8 @@
     {% endif %}
 
     {% if app.user %}
-        <a href="{{ path('enhavo_user_theme_security_logout') }}">Logout</a>
+        <a href="{{ path('enhavo_user_theme_logout') }}">Logout</a>
     {% else %}
-        <a href="{{ path('enhavo_user_theme_security_login') }}">Login</a>
+        <a href="{{ path('enhavo_user_theme_login') }}">Login</a>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

* fix: replace `document.write` in preview as it is deprecated and won't work for long strings (tested in chrome)
* fix: auto save interval stop if normal save was triggered
* fix: property duplicate type accepts also array
* fix: login paths
