### PR TITLE
fix: morph list form

### DIFF
--- a/assets/node_modules/@enhavo/form/form/model/ListForm.ts
+++ b/assets/node_modules/@enhavo/form/form/model/ListForm.ts
@@ -257,12 +257,10 @@ export class ListForm extends Form
         }
     }
 
-    public morphMerge(form: Form)
+    protected morphChildren(form: Form)
     {
-        super.morphMerge(form);
         let index = 0;
-        for (let child of this.children)
-        {
+        for (let child of this.children) {
             child.name = index.toString();
             index++;
         }

--- a/assets/node_modules/@enhavo/vue-form/model/Form.ts
+++ b/assets/node_modules/@enhavo/vue-form/model/Form.ts
@@ -297,22 +297,24 @@ export class Form
             }
             this.errors = form.errors;
         } else {
-            this.component = form.component;
-            this.label = form.label;
+            this.morphChildren(form);
+        }
+    }
 
-            for (let formChild of form.children) {
-                if (this.has(formChild.name)) {
-                    this.get(formChild.name).morphMerge(formChild);
-                } else {
-                    this.add(formChild);
-                }
+    protected morphChildren(form: Form)
+    {
+        for (let formChild of form.children) {
+            if (this.has(formChild.name)) {
+                this.get(formChild.name).morphMerge(formChild);
+            } else {
+                this.add(formChild);
             }
+        }
 
-            for (let child of this.children) {
-                if (!form.has(child.name)) {
-                    this.remove(child.name);
-                    child.destroy();
-                }
+        for (let child of this.children) {
+            if (!form.has(child.name)) {
+                this.remove(child.name);
+                child.destroy();
             }
         }
     }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | yes
| License      | MIT

* fix: keep children untouched on morph list, so added children between a submit and update form will not be deleted
