### PR TITLE
[FormBundle] Enable errors on compound type forms after morph; show t…

### DIFF
--- a/assets/node_modules/@enhavo/app/components/resource/ResourceInput.vue
+++ b/assets/node_modules/@enhavo/app/components/resource/ResourceInput.vue
@@ -16,6 +16,9 @@
 
             <div class="form-container" v-if="manager.tabs">
                 <form-form v-if="manager.form" :form="manager.form">
+                    <div class="form-errors-global">
+                        <form-errors :form="manager.form"></form-errors>
+                    </div>
                     <template v-for="tab of manager.tabs">
                         <component v-show="tab.active" :tab="tab" :form="manager.form" :is="tab.component"></component>
                     </template>

--- a/assets/node_modules/@enhavo/form/assets/styles/module/_form.scss
+++ b/assets/node_modules/@enhavo/form/assets/styles/module/_form.scss
@@ -27,12 +27,6 @@
         .choice-input-with-label {display:flex;gap:6px;}
     }
 
-    .form-error-list {color:variables.$color4;list-style:square;padding-left:20px;font-size:0.875rem;
-      &:not(:first-child) {margin-top:2px;}
-      &:not(:last-child) {margin-bottom:2px;}
-      li {padding-left:0;}
-    }
-
     .html-tag-widget { position:relative;
         .flex-container {display:flex;width:100%;
             .html-tag-widget-choice {margin-left:2px;width:120px;flex:0 0 auto;}
@@ -49,4 +43,16 @@
             .help-text {position:absolute;top:-3px;left:calc(100% + 1px);min-width:280px;padding:6px;box-shadow:1px 1px 3px rgba(#000,0.16);border-radius:3px;background:rgba(#fff,0.95);display:none;z-index:2;line-height:1.25em;}
         }
     }
+}
+
+.form-row, .form-errors-global {
+  .form-error-list {color: variables.$color4;list-style:square;padding-left:20px;font-size:0.875rem;
+    &:not(:first-child) {margin-top:2px;}
+    &:not(:last-child) {margin-bottom:2px;}
+    li {padding-left:0;}
+  }
+}
+
+.form-errors-global {
+  .form-error-list { margin: 15px; padding: 15px; }
 }

--- a/assets/node_modules/@enhavo/vue-form/model/Form.ts
+++ b/assets/node_modules/@enhavo/vue-form/model/Form.ts
@@ -290,12 +290,12 @@ export class Form
         this.component = form.component;
         this.label = form.label;
         this.disabled = form.disabled;
+        this.errors = form.errors;
 
         if (!this.compound) {
             if (this.morphStartValue == this.value) {
                 this.value = form.value;
             }
-            this.errors = form.errors;
         } else {
             this.morphChildren(form);
         }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[FormBundle] Enable errors on compound type forms after morph; show top level form errors
