### PR TITLE
fix: duplicate on proxy classes

### DIFF
--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/DuplicateFactory.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/DuplicateFactory.php
@@ -34,13 +34,15 @@ class DuplicateFactory
             }
         }
 
-        $target = $target ?? new (get_class($source));
-
+        $sourceClass = get_class($source);
         if ($source instanceof Proxy) {
+            $sourceClass = get_parent_class($source);
             if (!$source->__isInitialized()) {
                 $source->__load();
             }
         }
+
+        $target = $target ?? new ($sourceClass);
 
         foreach ($metadataList as $class => $metadata) {
             $reflection = new \ReflectionClass($class);


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

* fix: duplicate on proxy classes, we have to call new on the parent class if it is a proxy
