### PR TITLE
fix: merge grid and input config with missing classes

### DIFF
--- a/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/GridConfigurationMerger.php
+++ b/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/GridConfigurationMerger.php
@@ -6,6 +6,12 @@ use Enhavo\Bundle\ResourceBundle\Grid\Grid;
 
 class GridConfigurationMerger extends AbstractConfigurationMerger
 {
+    public function __construct(
+        protected string $defaultClass = Grid::class,
+    )
+    {
+    }
+
     public function performMerge(array $configs): array
     {
         $grids = [];
@@ -27,7 +33,7 @@ class GridConfigurationMerger extends AbstractConfigurationMerger
         $cachedConfigs = [];
         foreach ($grids as $name => $gridConfigs) {
             try {
-                $newGridConfig[$name] = $this->mergeConfigs($gridConfigs, $grids, $name, $cachedConfigs, Grid::class);
+                $newGridConfig[$name] = $this->mergeConfigs($gridConfigs, $grids, $name, $cachedConfigs, $this->defaultClass);
             } catch (\Exception $exception) {
                 throw new \Exception(sprintf('Error merging grid configs: %s', $exception->getMessage()), 0, $exception);
             }

--- a/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/GridConfigurationMerger.php
+++ b/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/GridConfigurationMerger.php
@@ -2,6 +2,8 @@
 
 namespace Enhavo\Bundle\ResourceBundle\DependencyInjection\Merge;
 
+use Enhavo\Bundle\ResourceBundle\Grid\Grid;
+
 class GridConfigurationMerger extends AbstractConfigurationMerger
 {
     public function performMerge(array $configs): array
@@ -25,7 +27,7 @@ class GridConfigurationMerger extends AbstractConfigurationMerger
         $cachedConfigs = [];
         foreach ($grids as $name => $gridConfigs) {
             try {
-                $newGridConfig[$name] = $this->mergeConfigs($gridConfigs, $grids, $name, $cachedConfigs);
+                $newGridConfig[$name] = $this->mergeConfigs($gridConfigs, $grids, $name, $cachedConfigs, Grid::class);
             } catch (\Exception $exception) {
                 throw new \Exception(sprintf('Error merging grid configs: %s', $exception->getMessage()), 0, $exception);
             }

--- a/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/InputConfigurationMerger.php
+++ b/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/InputConfigurationMerger.php
@@ -6,6 +6,12 @@ use Enhavo\Bundle\ResourceBundle\Input\Input;
 
 class InputConfigurationMerger extends AbstractConfigurationMerger
 {
+    public function __construct(
+        protected string $defaultClass = Input::class,
+    )
+    {
+    }
+
     public function performMerge(array $configs): array
     {
         $inputs = [];
@@ -27,7 +33,7 @@ class InputConfigurationMerger extends AbstractConfigurationMerger
         $cachedConfigs = [];
         foreach ($inputs as $name => $inputConfigs) {
             try {
-                $newInputConfig[$name] = $this->mergeConfigs($inputConfigs, $inputs, $name, $cachedConfigs, Input::class);
+                $newInputConfig[$name] = $this->mergeConfigs($inputConfigs, $inputs, $name, $cachedConfigs, $this->defaultClass);
             } catch (\Exception $exception) {
                 throw new \Exception(sprintf('Error merging input configs: %s', $exception->getMessage()), 0, $exception);
             }

--- a/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/InputConfigurationMerger.php
+++ b/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Merge/InputConfigurationMerger.php
@@ -2,6 +2,8 @@
 
 namespace Enhavo\Bundle\ResourceBundle\DependencyInjection\Merge;
 
+use Enhavo\Bundle\ResourceBundle\Input\Input;
+
 class InputConfigurationMerger extends AbstractConfigurationMerger
 {
     public function performMerge(array $configs): array
@@ -25,7 +27,7 @@ class InputConfigurationMerger extends AbstractConfigurationMerger
         $cachedConfigs = [];
         foreach ($inputs as $name => $inputConfigs) {
             try {
-                $newInputConfig[$name] = $this->mergeConfigs($inputConfigs, $inputs, $name, $cachedConfigs);
+                $newInputConfig[$name] = $this->mergeConfigs($inputConfigs, $inputs, $name, $cachedConfigs, Input::class);
             } catch (\Exception $exception) {
                 throw new \Exception(sprintf('Error merging input configs: %s', $exception->getMessage()), 0, $exception);
             }

--- a/src/Enhavo/Bundle/ResourceBundle/Exception/GridException.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Exception/GridException.php
@@ -16,7 +16,11 @@ class GridException extends \Exception
     {
         return new self(sprintf('Grid configuration with key "%s" does not exist!', $key));
     }
-
+    public static function configurationClassMissing($key): self
+    {
+        return new self(sprintf('Grid configuration with key "%s" does not provide a class option!', $key));
+    }
+    
     public static function notImplementGridInterface($class): self
     {
         return new self(sprintf('The class "%s" doesn\'t implement interface %s!', get_class($class), GridInterface::class));

--- a/src/Enhavo/Bundle/ResourceBundle/Exception/InputException.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Exception/InputException.php
@@ -16,6 +16,11 @@ class InputException extends \Exception
         return new self(sprintf('Input configuration with key "%s" does not exist!', $key));
     }
 
+    public static function configurationClassMissing($key): self
+    {
+        return new self(sprintf('Input configuration with key "%s" does not provide a class option!', $key));
+    }
+
     public static function notImplementInputInterface($class): self
     {
         return new self(sprintf('The class "%s" doesn\'t implement interface %s!', get_class($class), InputInterface::class));

--- a/src/Enhavo/Bundle/ResourceBundle/Grid/GridFactory.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Grid/GridFactory.php
@@ -13,7 +13,6 @@ class GridFactory
 
     public function __construct(
         private readonly array $configurations,
-        private readonly string $defaultClass = Grid::class,
     )
     {
     }
@@ -30,12 +29,13 @@ class GridFactory
         }
 
         $configuration = $this->configurations[$key];
-
-        $class = $this->defaultClass;
-        if (isset($configuration['class'])) {
-            $class = $configuration['class'];
-            unset($configuration['class']);
+        
+        if (!isset($configuration['class'])) {
+            throw GridException::configurationClassMissing($key);
         }
+
+        $class = $configuration['class'];
+        unset($configuration['class']);
 
         if (isset($configuration['priority'])) {
             unset($configuration['priority']);

--- a/src/Enhavo/Bundle/ResourceBundle/Input/InputFactory.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Input/InputFactory.php
@@ -13,7 +13,6 @@ class InputFactory
 
     public function __construct(
         private array $configurations,
-        private string $defaultClass = Input::class,
     )
     {
     }
@@ -30,13 +29,14 @@ class InputFactory
         }
 
         $configuration = $this->configurations[$key];
-
-        $class = $this->defaultClass;
-        if (isset($configuration['class'])) {
-            $class = $configuration['class'];
-            unset($configuration['class']);
+        
+        if (!isset($configuration['class'])) {
+            throw InputException::configurationClassMissing($key);
         }
 
+        $class = $configuration['class'];
+        unset($configuration['class']);
+        
         if ($this->container->has($class)) {
             $input = clone $this->container->get($class);
         } else {

--- a/src/Enhavo/Bundle/ResourceBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -12,7 +12,7 @@ class ConfigurationTest extends TestCase
 {
     private function process(Configuration $configuration, array $configs)
     {
-        $gridConfigurationMerger = new GridConfigurationMerger();
+        $gridConfigurationMerger = new GridConfigurationMerger(Grid::class);
         $configs = $gridConfigurationMerger->performMerge($configs);
 
         $processor = new Processor();

--- a/src/Enhavo/Bundle/ResourceBundle/Tests/DependencyInjection/Merge/GridConfigurationMergerTest.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Tests/DependencyInjection/Merge/GridConfigurationMergerTest.php
@@ -103,6 +103,76 @@ class GridConfigurationMergerTest extends TestCase
         $this->assertEquals('id', $columnKeys[0]);
         $this->assertEquals('title', $columnKeys[1]);
     }
+
+    public function testMergeGridWithSameName()
+    {
+        $dependencies = $this->createDependencies();
+        $instance = $this->createInstance($dependencies);
+
+        $configBase = [
+            'grids' => [
+                'base' => [
+                    'class' => Grid::class,
+                    'columns' => [
+                        'id' => [
+                            'label' => 'id',
+                        ],
+                    ],
+                    'resource' => 'base'
+                ],
+            ]
+        ];
+
+        $configExtend = [
+            'grids' => [
+                'base' => [
+                    'columns' => [
+                        'name' => [
+                            'label' => 'name',
+                        ],
+                    ],
+                ],
+            ]
+        ];
+
+        $configs = $instance->performMerge([$configBase, $configExtend]);
+        $config = array_pop($configs);
+
+        $columnKeys = array_keys($config['grids']['base']['columns']);
+        $this->assertEquals('id', $columnKeys[0]);
+        $this->assertEquals('name', $columnKeys[1]);
+
+        $this->assertArrayHasKey('resource', $config['grids']['base']);
+
+        // reverse order
+        $configs = $instance->performMerge([$configExtend, $configBase]);
+        $config = array_pop($configs);
+
+        $columnKeys = array_keys($config['grids']['base']['columns']);
+        $this->assertEquals('id', $columnKeys[1]);
+        $this->assertEquals('name', $columnKeys[0]);
+
+        $this->assertArrayHasKey('resource', $config['grids']['base']);
+    }
+
+    public function testSetDefaultClass()
+    {
+        $dependencies = $this->createDependencies();
+        $instance = $this->createInstance($dependencies);
+
+        $configBase = [
+            'grids' => [
+                'base' => [
+                    'resource' => 'base'
+                ],
+            ]
+        ];
+
+        $configs = $instance->performMerge([$configBase]);
+        $config = array_pop($configs);
+
+        $this->assertEquals(Grid::class, $config['grids']['base']['class']);
+    }
 }
 
 class GridConfigurationMergerDependencies


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

* fix: merge grid and input config with missing classes, by adding default class while merging
