### PR TITLE
[FormBundle] Fix big modals being cut off if wysiwyg fields are too s…

### DIFF
--- a/assets/node_modules/@enhavo/form/assets/styles/module/_wysiwyg.scss
+++ b/assets/node_modules/@enhavo/form/assets/styles/module/_wysiwyg.scss
@@ -350,7 +350,7 @@ $menuColor: variables.$grey6;
       max-height: $maxHeight;
       overflow-y: scroll;
 
-      &.source-code-open {
+      &.modal-open {
         min-height: ($minHeightSourceCodeEditor + 100px);
       }
 

--- a/assets/node_modules/@enhavo/form/form/model/WysiwygForm.ts
+++ b/assets/node_modules/@enhavo/form/form/model/WysiwygForm.ts
@@ -157,6 +157,7 @@ export class WysiwygForm extends Form
 
     openModal(component: string, options: object = {}): Promise<object>
     {
+        this.addCssClass('modal-open');
         this.modal = new WysiwygModalConfiguration(component, options);
         return new Promise<object>((resolve, reject) => {
             this.modal.getPromise()
@@ -167,6 +168,9 @@ export class WysiwygForm extends Form
                 .catch(() => {
                     reject();
                     this.modal = null;
+                })
+                .finally(() => {
+                    this.removeCssClass('modal-open');
                 })
             ;
         });

--- a/assets/node_modules/@enhavo/form/wysiwyg/WysiwygSourceCodeButton.ts
+++ b/assets/node_modules/@enhavo/form/wysiwyg/WysiwygSourceCodeButton.ts
@@ -13,7 +13,6 @@ export class WysiwygSourceCodeButton extends WysiwygMenuButton
 
     click: (event: Event, form: WysiwygForm) => void =
         (event: Event, form: WysiwygForm) => {
-            form.addCssClass('source-code-open');
             form.openModal('form-wysiwyg-modal-source-code', {
                     code: WysiwygSourceCodeButton.addWhitespace(form.editor.getHTML()),
                 })
@@ -24,9 +23,6 @@ export class WysiwygSourceCodeButton extends WysiwygMenuButton
                 })
                 .catch(() => {
                     // Cancelled
-                })
-                .finally(() => {
-                    form.removeCssClass('source-code-open');
                 })
             ;
         };


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[FormBundle] Fix big modals being cut off if wysiwyg fields are too small
