### PR TITLE
[FormBundle] Increase robustness of MediaType frontend style to preve…

### DIFF
--- a/assets/node_modules/@enhavo/media/assets/styles/_media.scss
+++ b/assets/node_modules/@enhavo/media/assets/styles/_media.scss
@@ -61,6 +61,7 @@
     .button-row {display:flex;gap:10px;}
   }
   .thumb {padding:5px;width:82px; height:82px; border-radius:6px;cursor: pointer;position:relative;background: variables.$grey1;
+    img { width: 100%; height: 100%; }
     .icon { position: absolute; z-index:2; font-size: 40px; line-height: 70px; color: #0090ba; left: 50%; transform: translateX(-50%) translateY(-50%); top:50%; }
     &:hover {
       .icons { display: block }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Increase robustness of MediaType frontend style to prevent graphic errors if preview thumb does not have expected size
