### PR TITLE
[NewsletterBundle] CleverReach Enhancements

### DIFF
--- a/src/Enhavo/Bundle/NewsletterBundle/Client/CleverReachClient.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Client/CleverReachClient.php
@@ -9,6 +9,7 @@
 namespace Enhavo\Bundle\NewsletterBundle\Client;
 
 use Enhavo\Bundle\NewsletterBundle\Event\StorageEvent;
+use Enhavo\Bundle\NewsletterBundle\Exception\ActivateException;
 use Enhavo\Bundle\NewsletterBundle\Exception\InsertException;
 use Enhavo\Bundle\NewsletterBundle\Exception\NotFoundException;
 use Enhavo\Bundle\NewsletterBundle\Exception\RemoveException;
@@ -93,6 +94,23 @@ class CleverReachClient
         if (!isset($response['id'])) {
             throw new InsertException(
                 sprintf('Insertion into group "%s" failed.', $groupId)
+            );
+        }
+    }
+
+
+    /**
+     * @param SubscriberInterface $subscriber
+     * @param $groupId
+     * @throws ActivateException
+     */
+    public function activateSubscriber(SubscriberInterface $subscriber, $groupId)
+    {
+        $response = $this->getApiManager()->activateSubscriber($subscriber->getEmail(), intval($groupId));
+
+        if (true !== $response) {
+            throw new ActivateException(
+                sprintf('Activation in group "%s" failed.', $groupId)
             );
         }
     }

--- a/src/Enhavo/Bundle/NewsletterBundle/Exception/ActivateException.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Exception/ActivateException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Enhavo\Bundle\NewsletterBundle\Exception;
+
+
+class ActivateException extends \Exception
+{
+
+}

--- a/src/Enhavo/Bundle/NewsletterBundle/Exception/UpdateException.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Exception/UpdateException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: m
+ * Date: 08.12.16
+ * Time: 14:43
+ */
+
+namespace Enhavo\Bundle\NewsletterBundle\Exception;
+
+
+class UpdateException extends \Exception
+{
+
+}

--- a/src/Enhavo/Bundle/NewsletterBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/NewsletterBundle/Resources/config/services/services.yaml
@@ -2,7 +2,7 @@ services:
     Enhavo\Bundle\NewsletterBundle\Client\CleverReachClient:
         arguments:
             - '@event_dispatcher'
-            - 'Enhavo\Component\CleverReach\Http\GuzzleAdapter'
+            - 'Enhavo\Component\CleverReach\Http\SymfonyAdapter'
 
     Enhavo\Bundle\NewsletterBundle\Client\MailChimpClient:
         arguments:

--- a/src/Enhavo/Bundle/NewsletterBundle/Storage/Type/CleverReachStorageType.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Storage/Type/CleverReachStorageType.php
@@ -8,6 +8,7 @@ namespace Enhavo\Bundle\NewsletterBundle\Storage\Type;
 
 use Enhavo\Bundle\NewsletterBundle\Client\CleverReachClient;
 use Enhavo\Bundle\NewsletterBundle\Entity\Group;
+use Enhavo\Bundle\NewsletterBundle\Exception\ActivateException;
 use Enhavo\Bundle\NewsletterBundle\Exception\InsertException;
 use Enhavo\Bundle\NewsletterBundle\Exception\NoGroupException;
 use Enhavo\Bundle\NewsletterBundle\Model\CleverReachGroup;
@@ -37,9 +38,9 @@ class CleverReachStorageType extends AbstractStorageType
     /**
      * @param SubscriberInterface $subscriber
      * @param array $options
-     * @return mixed|void
+     * @return void
      * @throws NoGroupException
-     * @throws InsertException
+     * @throws InsertException|ActivateException
      */
     public function saveSubscriber(SubscriberInterface $subscriber, array $options)
     {
@@ -49,6 +50,7 @@ class CleverReachStorageType extends AbstractStorageType
 
         foreach ($groups as $group) {
             if ($this->client->exists($subscriber->getEmail(), $group)) {
+                $this->client->activateSubscriber($subscriber, $group);
                 continue;
             }
             $this->client->saveSubscriber($subscriber, $group);

--- a/src/Enhavo/Bundle/NewsletterBundle/Tests/Storage/CleverReachTypeStorageTest.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Tests/Storage/CleverReachTypeStorageTest.php
@@ -66,7 +66,7 @@ class CleverReachTypeStorageTest extends TestCase
         $dependencies->apiManager->expects($this->exactly(2))->method('getSubscriber')->willReturn(['id' => 1]);
         $dependencies->apiManager->expects($this->never())->method('createSubscriber')->willReturn([]);
         $dependencies->apiManager->expects($this->exactly(2))->method('updateSubscriber')->willReturn(['id' => 1]);
-        $dependencies->apiManager->expects($this->exactly(2))->method('activateSubscriber');
+        $dependencies->apiManager->expects($this->exactly(2))->method('activateSubscriber')->willReturn(true);
         $dependencies->subscriber->method('getEmail')->willReturn('to@enhavo.com');
 
         $instance->saveSubscriber($dependencies->subscriber);

--- a/src/Enhavo/Bundle/NewsletterBundle/Tests/Storage/CleverReachTypeStorageTest.php
+++ b/src/Enhavo/Bundle/NewsletterBundle/Tests/Storage/CleverReachTypeStorageTest.php
@@ -65,6 +65,8 @@ class CleverReachTypeStorageTest extends TestCase
         ]);
         $dependencies->apiManager->expects($this->exactly(2))->method('getSubscriber')->willReturn(['id' => 1]);
         $dependencies->apiManager->expects($this->never())->method('createSubscriber')->willReturn([]);
+        $dependencies->apiManager->expects($this->exactly(2))->method('updateSubscriber')->willReturn(['id' => 1]);
+        $dependencies->apiManager->expects($this->exactly(2))->method('activateSubscriber');
         $dependencies->subscriber->method('getEmail')->willReturn('to@enhavo.com');
 
         $instance->saveSubscriber($dependencies->subscriber);

--- a/src/Enhavo/Component/CleverReach/ApiManager.php
+++ b/src/Enhavo/Component/CleverReach/ApiManager.php
@@ -62,8 +62,6 @@ class ApiManager implements ApiManagerInterface
         array $globalAttributes = [],
         array $tags = [],
     ) {
-        $now = time();
-
         return $this->adapter->action(
             'put',
             "/v3/groups.json/{$groupId}/receivers/{$email}",

--- a/src/Enhavo/Component/CleverReach/ApiManager.php
+++ b/src/Enhavo/Component/CleverReach/ApiManager.php
@@ -47,6 +47,16 @@ class ApiManager implements ApiManagerInterface
     }
 
     /**
+     * @param $email
+     * @param int $groupId
+     * @return mixed
+     */
+    public function activateSubscriber($email, int $groupId)
+    {
+        return $this->adapter->action('put', "/v3/groups.json/{$groupId}/receivers/{$email}/activate");
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getSubscriber(string $email, int $groupId = null)

--- a/src/Enhavo/Component/CleverReach/ApiManager.php
+++ b/src/Enhavo/Component/CleverReach/ApiManager.php
@@ -46,6 +46,35 @@ class ApiManager implements ApiManagerInterface
         );
     }
 
+
+    /**
+     * @param string $email
+     * @param int $groupId
+     * @param array $attributes
+     * @param array $globalAttributes
+     * @param array $tags
+     * @return mixed
+     */
+    public function updateSubscriber(
+        string $email,
+        int $groupId,
+        array $attributes = [],
+        array $globalAttributes = [],
+        array $tags = [],
+    ) {
+        $now = time();
+
+        return $this->adapter->action(
+            'put',
+            "/v3/groups.json/{$groupId}/receivers/{$email}",
+            [
+                'attributes' => $attributes,
+                'global_attributes' => $globalAttributes,
+                'tags' => $tags,
+            ]
+        );
+    }
+
     /**
      * @param $email
      * @param int $groupId


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | yes
| License      | MIT

Until now already existing subscribers could not be updated nor reactivated via enhavo newsletter subscription mecahnism.
From now if they subscribe again, they can update their data as well as reactivate their subscription via clicking on a freshly supplied confirmation link.
