### PR TITLE
[FormBundle] Allow copy paste base64 image into wysiwyg editor

### DIFF
--- a/assets/node_modules/@enhavo/form/package.json
+++ b/assets/node_modules/@enhavo/form/package.json
@@ -12,6 +12,7 @@
     "@enhavo/app": "https://github.com/enhavo/app-assets.git",
     "@sereneinserenade/tiptap-search-and-replace": "^0.1.1",
     "@tiptap/extension-color": "^2.9.1",
+    "@tiptap/extension-image": "^2.9.1",
     "@tiptap/extension-link": "^2.9.1",
     "@tiptap/extension-subscript": "^2.9.1",
     "@tiptap/extension-superscript": "^2.9.1",

--- a/assets/node_modules/@enhavo/form/wysiwyg/WysiwygConfig.ts
+++ b/assets/node_modules/@enhavo/form/wysiwyg/WysiwygConfig.ts
@@ -13,8 +13,8 @@ import {BackgroundColor} from "@enhavo/form/wysiwyg/tiptap-extensions/extension-
 import Color from "@tiptap/extension-color";
 import {CustomBulletList} from "@enhavo/form/wysiwyg/tiptap-extensions/extension-custom-bullet-list/custom-bullet-list";
 import {CustomOrderedList} from "@enhavo/form/wysiwyg/tiptap-extensions/extension-custom-ordered-list/custom-ordered-list";
+import Image from '@tiptap/extension-image';
 import Link from "@tiptap/extension-link";
-import Paragraph from "@tiptap/extension-paragraph";
 import SearchAndReplace from "@sereneinserenade/tiptap-search-and-replace";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
@@ -39,6 +39,10 @@ export class WysiwygConfig
                 Color,
                 CustomBulletList,
                 CustomOrderedList,
+                Image.configure({
+                    inline: true,
+                    allowBase64: true,
+                }),
                 Link.configure({
                     openOnClick: false,
                     autolink: true,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@sereneinserenade/tiptap-search-and-replace": "^0.1.1",
     "@symfony/stimulus-bridge": "^3.0.0",
     "@tiptap/extension-color": "^2.9.1",
+    "@tiptap/extension-image": "^2.9.1",
     "@tiptap/extension-link": "^2.9.1",
     "@tiptap/extension-subscript": "^2.9.1",
     "@tiptap/extension-superscript": "^2.9.1",


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

[FormBundle] Allow copy paste base64 image into wysiwyg editor
