### PR TITLE
[UserBundle] Prevent SaveUserSubscriber triggering EntityManager flus…

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/EventListener/SaveUserSubscriber.php
+++ b/src/Enhavo/Bundle/UserBundle/EventListener/SaveUserSubscriber.php
@@ -26,7 +26,7 @@ class SaveUserSubscriber implements EventSubscriberInterface
     {
         $user = $event->getSubject();
         if ($user instanceof UserInterface) {
-            $this->userManager->update($user);
+            $this->userManager->update($user, false);
         }
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[UserBundle] Prevent SaveUserSubscriber triggering EntityManager flush before resource has been persisted, which causes errors if the user has connected entities
