### PR TITLE
[FormBundle] AutoCompleteEntityType: Prevent exception in ViewTransfo…

### DIFF
--- a/src/Enhavo/Bundle/FormBundle/Form/Type/AutoCompleteEntityType.php
+++ b/src/Enhavo/Bundle/FormBundle/Form/Type/AutoCompleteEntityType.php
@@ -41,6 +41,9 @@ class AutoCompleteEntityType extends AbstractType
                     }
                     $data = [];
                     foreach($collection as $entry) {
+                        if ($entry === null) {
+                            continue;
+                        }
                         if (!method_exists($entry, 'getId')) {
                             throw new \Exception('class need to be an entity with getId function');
                         }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[FormBundle] AutoCompleteEntityType: Prevent exception in ViewTransformer if data has null entries
