### PR TITLE
[FormBundle] Remove option 'tags' from auto complete select2 options …

### DIFF
--- a/assets/node_modules/@enhavo/form/components/FormAutoComplete.vue
+++ b/assets/node_modules/@enhavo/form/components/FormAutoComplete.vue
@@ -136,7 +136,6 @@ function buildConfig()
             },
             cache: true,
         },
-        tags: props.form.multiple,
         placeholder: props.form.placeholder,
         allowClear: props.form.placeholder != null,
     };


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[FormBundle] Remove option 'tags' from auto complete select2 options to prevent entering random data
