### PR TITLE
feat: add error handling for fetch

### DIFF
--- a/assets/node_modules/@enhavo/app/client/Client.ts
+++ b/assets/node_modules/@enhavo/app/client/Client.ts
@@ -1,0 +1,107 @@
+import {ClientInterface, ErrorHandlerInterface, Options, ErrorContextInterface, Transport} from "@enhavo/app/client/ClientInterface"
+
+export class Client implements ClientInterface
+{
+    private errorHandler: ErrorHandler[] = [];
+
+    lastRequest: {
+        input: RequestInfo | URL,
+        init?: RequestInit,
+    } = {input: null, init: null};
+
+    fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Transport>
+    {
+        this.lastRequest.input = input;
+        this.lastRequest.init = init;
+
+        return new Promise(async (resolve, reject) => {
+            try {
+                const response = await fetch(input, init);
+                resolve(new Transport(response));
+            } catch (e) {
+                resolve(new Transport(null, e));
+            }
+        });
+    }
+
+    on(code: number, callback: () => Promise<void>): ErrorContextInterface
+    {
+        return new ErrorContext(this.errorHandler, this);
+    }
+
+    handleError(transport: Transport, options: Options = {}): Promise<void>
+    {
+        for (let errorhandler of this.errorHandler) {
+            if (errorhandler.errorHandler.supports(transport, options, this)) {
+                return errorhandler.errorHandler.handleError(transport, options, this);
+            }
+        }
+
+        throw 'Client: No error handler can handle this error';
+    }
+
+    addErrorHandler(errorHandler: ErrorHandlerInterface, priority: number = 0): ClientInterface
+    {
+        this.errorHandler.push(new ErrorHandler(errorHandler, priority));
+
+        this.errorHandler.sort(function (a, b) {
+            return b.priority - a.priority;
+        });
+
+        return this;
+    }
+}
+
+class ErrorHandler
+{
+    constructor(
+        public errorHandler: ErrorHandlerInterface,
+        public priority: number,
+    ) {
+    }
+}
+
+class OnErrorHandler
+{
+    constructor(
+        public code: number,
+        public callback: () => Promise<void>,
+    ) {
+    }
+}
+
+class ErrorContext implements ErrorContextInterface
+{
+    private onErrorhandler: OnErrorHandler[] = [];
+
+    constructor(
+        private errorHandler: ErrorHandler[],
+        private client: ClientInterface,
+    ) {
+    }
+
+    on(code: number, callback: () => Promise<void>): ErrorContextInterface
+    {
+        this.onErrorhandler.push(new OnErrorHandler(code, callback));
+        return this;
+    }
+
+    handleError(transport: Transport, options: Options): Promise<void>
+    {
+        for (let onErrorhandler of this.onErrorhandler) {
+            if (transport.response?.status === onErrorhandler.code) {
+                return onErrorhandler.callback();
+            }
+        }
+
+
+        for (let errorhandler of this.errorHandler) {
+            if (errorhandler.errorHandler.supports(transport, options, this)) {
+                return errorhandler.errorHandler.handleError(transport, options, this);
+            }
+        }
+
+        throw 'Client: No error handler can handle this error';
+    }
+}
+

--- a/assets/node_modules/@enhavo/app/client/ClientInterface.ts
+++ b/assets/node_modules/@enhavo/app/client/ClientInterface.ts
@@ -1,0 +1,47 @@
+
+export interface ErrorContextInterface
+{
+    on(code: number, callback: () => Promise<void>): ErrorContextInterface;
+    handleError(transport: Transport, options?: Options): Promise<void>;
+}
+
+
+export interface ClientInterface extends ErrorContextInterface
+{
+    lastRequest: {
+        input: RequestInfo | URL,
+        init?: RequestInit,
+    }
+
+    fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Transport>;
+
+    repeat(): Promise<Transport>;
+
+    addErrorHandler(errorHandler: ErrorHandlerInterface, priority?: number): ClientInterface;
+}
+
+export type Options = {
+    terminate?: boolean;
+    repeatable?: boolean;
+    confirm?: boolean;
+    validation?: boolean;
+}
+
+export interface ErrorHandlerInterface
+{
+    handleError(transport: Transport, options: Options, client: ClientInterface): Promise<void>;
+
+    supports(transport: Transport, options: Options, client: ClientInterface): boolean;
+}
+
+export class Transport
+{
+    public readonly ok: boolean;
+
+    constructor(
+        public readonly response: Response = null,
+        public readonly error: Error = null,
+    ) {
+        this.ok = response !== null;
+    }
+}

--- a/assets/node_modules/@enhavo/app/client/DefaultErrorHandler.ts
+++ b/assets/node_modules/@enhavo/app/client/DefaultErrorHandler.ts
@@ -1,0 +1,47 @@
+import {ClientInterface, ErrorHandlerInterface, Options, Transport} from "@enhavo/app/client/ClientInterface"
+import {FlashMessenger} from "@enhavo/app/flash-message/FlashMessenger";
+import {UiManager} from "@enhavo/app/ui/UiManager";
+import {FrameManager} from "@enhavo/app/frame/FrameManager";
+import {Translator} from "@enhavo/app/translation/Translator";
+
+export class DefaultErrorHandler implements ErrorHandlerInterface
+{
+    constructor(
+        private uiManager: UiManager,
+        private flashMessenger: FlashMessenger,
+        private frameManager: FrameManager,
+        private translator: Translator,
+    ) {
+    }
+
+    handleError(transport: Transport, options: Options, client: ClientInterface): Promise<void>
+    {
+        if (!transport.ok) {
+            console.error(transport.error);
+        }
+
+        return new Promise((resolve, reject) => {
+            if (options.confirm) {
+                this.uiManager.alert({
+                    message: this.translator.trans('enhavo_app.error', {}, 'javascript')
+                }).then(() => {
+                    if (options.terminate) {
+                        this.frameManager.close(true);
+                    }
+                    resolve();
+                });
+            } else {
+                this.flashMessenger.error(this.translator.trans('enhavo_app.error', {}, 'javascript'));
+                if (options.terminate) {
+                    this.frameManager.close(true);
+                }
+                resolve();
+            }
+        })
+    }
+
+    supports(transport: Transport, options: Options, client: ClientInterface): boolean
+    {
+        return true;
+    }
+}

--- a/assets/node_modules/@enhavo/app/client/ValidationErrorHandler.ts
+++ b/assets/node_modules/@enhavo/app/client/ValidationErrorHandler.ts
@@ -1,0 +1,25 @@
+import {ClientInterface, ErrorHandlerInterface, Options, Transport} from "@enhavo/app/client/ClientInterface"
+import {FlashMessenger} from "@enhavo/app/flash-message/FlashMessenger";
+import {Translator} from "@enhavo/app/translation/Translator";
+
+export class ValidationErrorHandler implements ErrorHandlerInterface
+{
+    constructor(
+        private flashMessenger: FlashMessenger,
+        private translator: Translator,
+    ) {
+    }
+
+    handleError(transport: Transport, options: Options, client: ClientInterface): Promise<void>
+    {
+        return new Promise((resolve, reject) => {
+            this.flashMessenger.error(this.translator.trans('enhavo_app.save.message.not_valid', {}, 'javascript'));
+            resolve();
+        })
+    }
+
+    supports(transport: Transport, options: Options, client: ClientInterface): boolean
+    {
+        return transport.ok && transport.response.status === 400 && options.validation;
+    }
+}

--- a/assets/node_modules/@enhavo/app/compiler-pass/client-error-handler-register.js
+++ b/assets/node_modules/@enhavo/app/compiler-pass/client-error-handler-register.js
@@ -1,0 +1,21 @@
+import Argument from "@enhavo/dependency-injection/container/Argument.js"
+import Call from "@enhavo/dependency-injection/container/Call.js"
+
+export default function(builder, options, context)
+{
+    let client = builder.getDefinition('@enhavo/app/client/Client');
+
+    let visitors = builder.getDefinitionsByTagName('enhavo_app.client_error_handler');
+    for (let definition of visitors) {
+
+        let priority = definition.getTag('enhavo_app.client_error_handler').getParameter('priority');
+        if (!priority) {
+            priority = 0;
+        }
+
+        client.addCall(new Call('addErrorHandler', [
+            new Argument(definition.getName()),
+            new Argument(priority, 'number'),
+        ]));
+    }
+};

--- a/assets/node_modules/@enhavo/app/frame/FrameManager.ts
+++ b/assets/node_modules/@enhavo/app/frame/FrameManager.ts
@@ -10,6 +10,7 @@ import {
     FrameUpdate,
     FrameSave,
     FrameArrange,
+    FrameUnload,
 } from "@enhavo/app/frame/FrameStackSubscriber";
 import {Frame} from "@enhavo/app/frame/Frame";
 import {FrameAdded, FrameUpdated} from "@enhavo/app/frame/FrameStack";
@@ -120,6 +121,11 @@ export class FrameManager
     public loaded()
     {
         this.eventDispatcher.dispatch(new FrameLoaded(window.name));
+    }
+
+    public async unload(): Promise<Frame>
+    {
+        return await this.eventDispatcher.request(new FrameUnload(window.name)) as Frame;
     }
 
     public async addFrame(options: object): Promise<Frame>

--- a/assets/node_modules/@enhavo/app/frame/FrameStackSubscriber.ts
+++ b/assets/node_modules/@enhavo/app/frame/FrameStackSubscriber.ts
@@ -24,6 +24,7 @@ export class FrameStackSubscriber
             this.addFrameAddListener();
             this.addFrameGetListener();
             this.addFrameLoadedListener();
+            this.addFrameUnloadListener();
             this.addFrameLabelListener();
             this.addFrameUpdateListener();
             this.addFrameClearListener();
@@ -62,6 +63,19 @@ export class FrameStackSubscriber
             if (frame) {
                 frame.loaded = true;
             }
+        });
+    }
+
+    private addFrameUnloadListener()
+    {
+        this.dispatcher.on('frame_unload', (event: Event) => {
+            const frame = this.frameStack.getFrame((event as FrameLoaded).id);
+
+            if (frame) {
+                frame.loaded = false;
+            }
+
+            event.resolve();
         });
     }
 
@@ -150,6 +164,16 @@ export class FrameLoaded extends Event
     )
     {
         super('frame_loaded');
+    }
+}
+
+export class FrameUnload extends Event
+{
+    constructor(
+        public id: string,
+    )
+    {
+        super('frame_unload');
     }
 }
 

--- a/assets/node_modules/@enhavo/app/services/admin/action.yaml
+++ b/assets/node_modules/@enhavo/app/services/admin/action.yaml
@@ -117,6 +117,7 @@ services:
             - '@enhavo/app/manager/ResourceInputManager'
             - '@enhavo/app/flash-message/FlashMessenger'
             - '@enhavo/app/translation/Translator'
+            - '@enhavo/app/client/Client'
         tags:
             - { name: 'enhavo_app.action', class: 'SaveAction' }
 
@@ -130,6 +131,7 @@ services:
             - '@enhavo/app/translation/Translator'
             - '@enhavo/vue-form/form/FormEventDispatcher'
             - '@enhavo/app/frame/FrameManager'
+            - '@enhavo/app/client/Client'
         tags:
             - { name: 'enhavo_app.action', class: 'AutoSaveAction' }
 

--- a/assets/node_modules/@enhavo/app/services/admin/client.yaml
+++ b/assets/node_modules/@enhavo/app/services/admin/client.yaml
@@ -1,0 +1,21 @@
+services:
+    '@enhavo/app/client/Client':
+        import: Client
+
+    '@enhavo/app/client/DefaultErrorHandler':
+        import: DefaultErrorHandler
+        arguments:
+            - '@enhavo/app/ui/UiManager'
+            - '@enhavo/app/flash-message/FlashMessenger'
+            - '@enhavo/app/frame/FrameManager'
+            - '@enhavo/app/translation/Translator'
+        tags:
+            - { name: enhavo_app.client_error_handler, priority: -10 }
+
+    '@enhavo/app/client/ValidationErrorHandler':
+        import: ValidationErrorHandler
+        arguments:
+            - '@enhavo/app/flash-message/FlashMessenger'
+            - '@enhavo/app/translation/Translator'
+        tags:
+            - { name: enhavo_app.client_error_handler, priority: 10 }

--- a/assets/node_modules/@enhavo/app/services/admin/manager.yaml
+++ b/assets/node_modules/@enhavo/app/services/admin/manager.yaml
@@ -24,6 +24,7 @@ services:
             - '@enhavo/app/batch/BatchManager'
             - '@enhavo/app/collection/CollectionFactory'
             - '@enhavo/app/ui/UiManager'
+            - '@enhavo/app/client/Client'
         tags:
             - { name: vue.service, service: 'resourceIndexManager', reactive: true }
 
@@ -36,6 +37,7 @@ services:
             - '@enhavo/app/frame/FrameManager'
             - '@enhavo/app/vue/VueRouterFactory'
             - '@enhavo/app/ui/UiManager'
+            - '@enhavo/app/client/Client'
         tags:
             - { name: vue.service, service: 'resourceInputManager', reactive: true }
 

--- a/assets/node_modules/@enhavo/app/services/admin/services.yaml
+++ b/assets/node_modules/@enhavo/app/services/admin/services.yaml
@@ -47,7 +47,8 @@ compiler_pass:
         priority: 150
     admin_form:
         path: '@enhavo/app/compiler-pass/admin-form-register.js'
-
+    client_error_handler:
+        path: '@enhavo/app/compiler-pass/client-error-handler-register.js'
 services:
     '@enhavo/core/Router':
         chunk: 'view'

--- a/assets/node_modules/@enhavo/app/ui/UiManager.ts
+++ b/assets/node_modules/@enhavo/app/ui/UiManager.ts
@@ -76,10 +76,11 @@ export class Alert
 {
     public message: string;
     public acceptLabel: string;
+    public onAccept: () => Promise<void> =  async () => {};
 
     constructor(
         options: object,
-        private onAccept: () => void,
+        private close: () => void,
     )
     {
         Object.assign(this, options);
@@ -87,8 +88,8 @@ export class Alert
 
     public accept()
     {
-        if (this.onAccept) {
-            this.onAccept();
-        }
+        this.onAccept().then(() => {
+            this.close();
+        });
     }
 }

--- a/assets/node_modules/@enhavo/user/client/UnauthenticatedErrorHandler.ts
+++ b/assets/node_modules/@enhavo/user/client/UnauthenticatedErrorHandler.ts
@@ -1,0 +1,43 @@
+import {ClientInterface, ErrorHandlerInterface, Options, Transport} from "@enhavo/app/client/ClientInterface"
+import {FlashMessenger} from "@enhavo/app/flash-message/FlashMessenger";
+import {UiManager} from "@enhavo/app/ui/UiManager";
+import {FrameManager} from "@enhavo/app/frame/FrameManager";
+import {Translator} from "@enhavo/app/translation/Translator";
+
+export class UnauthenticatedErrorHandler implements ErrorHandlerInterface
+{
+    constructor(
+        private uiManager: UiManager,
+        private flashMessenger: FlashMessenger,
+        private frameManager: FrameManager,
+        private translator: Translator,
+    ) {
+    }
+
+    handleError(transport: Transport, options: Options, client: ClientInterface): Promise<void>
+    {
+        return new Promise((resolve, reject) => {
+            if (options.confirm) {
+                this.uiManager.alert({
+                    message: this.translator.trans('enhavo_user.error.unauthenticated', {}, 'javascript')
+                }).then(() => {
+                    if (options.terminate) {
+                        this.frameManager.close(true);
+                    }
+                    resolve();
+                });
+            } else {
+                this.flashMessenger.error(this.translator.trans('enhavo_user.error.unauthenticated', {}, 'javascript'));
+                if (options.terminate) {
+                    this.frameManager.close(true);
+                }
+                resolve();
+            }
+        })
+    }
+
+    supports(transport: Transport, options: Options, client: ClientInterface): boolean
+    {
+        return transport.ok && transport.response.status === 401;
+    }
+}

--- a/assets/node_modules/@enhavo/user/client/UnauthorizedErrorHandler.ts
+++ b/assets/node_modules/@enhavo/user/client/UnauthorizedErrorHandler.ts
@@ -1,0 +1,43 @@
+import {ClientInterface, ErrorHandlerInterface, Options, Transport} from "@enhavo/app/client/ClientInterface"
+import {FlashMessenger} from "@enhavo/app/flash-message/FlashMessenger";
+import {UiManager} from "@enhavo/app/ui/UiManager";
+import {FrameManager} from "@enhavo/app/frame/FrameManager";
+import {Translator} from "@enhavo/app/translation/Translator";
+
+export class UnauthorizedErrorHandler implements ErrorHandlerInterface
+{
+    constructor(
+        private uiManager: UiManager,
+        private flashMessenger: FlashMessenger,
+        private frameManager: FrameManager,
+        private translator: Translator,
+    ) {
+    }
+
+    handleError(transport: Transport, options: Options, client: ClientInterface): Promise<void>
+    {
+        return new Promise((resolve, reject) => {
+            if (options.confirm) {
+                this.uiManager.alert({
+                    message: this.translator.trans('enhavo_user.error.unauthorized', {}, 'javascript')
+                }).then(() => {
+                    if (options.terminate) {
+                        this.frameManager.close(true);
+                    }
+                    resolve();
+                });
+            } else {
+                this.flashMessenger.error(this.translator.trans('enhavo_user.error.unauthorized', {}, 'javascript'));
+                if (options.terminate) {
+                    this.frameManager.close(true);
+                }
+                resolve();
+            }
+        })
+    }
+
+    supports(transport: Transport, options: Options, client: ClientInterface): boolean
+    {
+        return transport.ok && transport.response.status === 403;
+    }
+}

--- a/assets/node_modules/@enhavo/user/components/UserUnauthenticated.vue
+++ b/assets/node_modules/@enhavo/user/components/UserUnauthenticated.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="app-view">
+        <ui-components></ui-components>
+    </div>
+</template>
+
+<script setup lang="ts">
+import '@enhavo/app/assets/styles/view.scss'
+import {inject, onMounted} from "vue";
+import {UiManager} from "@enhavo/app/ui/UiManager";
+import {FrameManager} from "@enhavo/app/frame/FrameManager";
+import {Translator} from "@enhavo/app/translation/Translator";
+
+const uiManager = inject<UiManager>('uiManager');
+const frameManager = inject<FrameManager>('frameManager');
+const translator = inject<Translator>('translator');
+
+onMounted(() => {
+    frameManager.loaded();
+    uiManager.alert({
+        message: translator.trans('enhavo_user.error.unauthenticated', {}, 'javascript'),
+        onAccept: async () => {
+            uiManager.loading(true);
+            if (frameManager.isRoot()) {
+                window.location.reload();
+            } else {
+                frameManager.unload().then(() => {
+                    uiManager.loading(false);
+                    window.location.reload();
+                });
+            }
+        }
+    });
+})
+
+</script>

--- a/assets/node_modules/@enhavo/user/manager/UserManager.ts
+++ b/assets/node_modules/@enhavo/user/manager/UserManager.ts
@@ -22,7 +22,6 @@ export class UserManager
     ) {
 
     }
-
     public loadLogin()
     {
         this.loginForm = null;
@@ -55,7 +54,13 @@ export class UserManager
     public login()
     {
         this.loading = true;
-        const url = this.router.generate('enhavo_user_admin_api_login_form');
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const redirect = urlParams.get('redirect');
+
+        const url = this.router.generate('enhavo_user_admin_api_login_form', {
+            redirect: redirect,
+        });
         const data = FormUtil.serializeForm(this.loginForm);
 
         fetch(url, {

--- a/assets/node_modules/@enhavo/user/services/admin/services.yaml
+++ b/assets/node_modules/@enhavo/user/services/admin/services.yaml
@@ -50,6 +50,12 @@ services:
         tags:
             - { name: vue.component, component: 'user-reset-password-finish' }
 
+    '@enhavo/user/components/UserUnauthenticated.vue':
+        chunk: 'user'
+        static: true
+        tags:
+            - { name: vue.component, component: 'user-unauthenticated' }
+
     '@enhavo/user/controllers/UserController':
         chunk: user
         static: true
@@ -63,3 +69,23 @@ services:
             - 'string:branding'
             - 'string:branding'
             - 'container:'
+
+    '@enhavo/user/client/UnauthorizedErrorHandler':
+        import: UnauthorizedErrorHandler
+        arguments:
+            - '@enhavo/app/ui/UiManager'
+            - '@enhavo/app/flash-message/FlashMessenger'
+            - '@enhavo/app/frame/FrameManager'
+            - '@enhavo/app/translation/Translator'
+        tags:
+            - { name: enhavo_app.client_error_handler, priority: 20 }
+
+    '@enhavo/user/client/UnauthenticatedErrorHandler':
+        import: UnauthenticatedErrorHandler
+        arguments:
+            - '@enhavo/app/ui/UiManager'
+            - '@enhavo/app/flash-message/FlashMessenger'
+            - '@enhavo/app/frame/FrameManager'
+            - '@enhavo/app/translation/Translator'
+        tags:
+            - { name: enhavo_app.client_error_handler, priority: 30 }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -19,7 +19,7 @@ security:
             pattern:  ^/admin/?.*
             context: user
             user_checker: Enhavo\Bundle\UserBundle\Security\UserChecker
-            entry_point: Enhavo\Bundle\UserBundle\Security\EntryPoint\FormAuthenticationEntryPoint
+            entry_point: Enhavo\Bundle\UserBundle\Security\EntryPoint\AdminAuthenticationEntryPoint
             custom_authenticators:
                 - Enhavo\Bundle\UserBundle\Security\Authentication\FormLoginAuthenticator
                 - Enhavo\Bundle\UserBundle\Security\Authentication\ApiTokenAuthenticator

--- a/src/Enhavo/Bundle/AppBundle/Endpoint/Type/AbstractFormEndpointType.php
+++ b/src/Enhavo/Bundle/AppBundle/Endpoint/Type/AbstractFormEndpointType.php
@@ -23,8 +23,8 @@ abstract class AbstractFormEndpointType extends AbstractEndpointType
 
         if ($request->isMethod(Request::METHOD_POST)) {
             $form->handleRequest($request);
-            $url = null;
             if ($form->isSubmitted() && $form->isValid()) {
+                $data->set('success', true);
                 $this->handleSuccess($options, $request, $data, $context, $form);
 
                 if ($context->getResponse() || $context->isStopped()) {
@@ -36,15 +36,15 @@ abstract class AbstractFormEndpointType extends AbstractEndpointType
                     if ($request->get('_format') === 'html') {
                         $context->setResponse($this->redirect($url));
                         return;
+                    } else {
+                        $data->set('redirect', $url);
                     }
-                    $data->set('redirect', $url);
                 }
 
                 $form =  $this->getForm($options, $request, $data, $context);
                 $context->set('form', $form);
-                $success = true;
             } else {
-                $success = false;
+                $data->set('success', false);
                 $this->handleFailed($options, $request, $data, $context, $form);
 
                 if ($context->getResponse() || $context->isStopped()) {
@@ -53,9 +53,6 @@ abstract class AbstractFormEndpointType extends AbstractEndpointType
 
                 $context->setStatusCode(400);
             }
-
-            $data->set('success', $success);
-            $data->set('redirect', $url);
         }
 
         $data->set('form', $this->normalize($form));

--- a/src/Enhavo/Bundle/UserBundle/DependencyInjection/EnhavoUserExtension.php
+++ b/src/Enhavo/Bundle/UserBundle/DependencyInjection/EnhavoUserExtension.php
@@ -26,6 +26,7 @@ class EnhavoUserExtension extends Extension implements PrependExtensionInterface
 
         $configFiles = [
             'services/services.yaml',
+            'services/security.yaml',
             'services/subscriber.yaml',
             'services/command.yaml',
             'services/form.yaml',

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/routes/admin_login/login.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/routes/admin_login/login.yaml
@@ -4,11 +4,14 @@ enhavo_user_admin_login:
     defaults:
         _expose: admin_login
         _area: admin_login
+        _format: html
         _vue:
             component: user-login
             groups: admin_login
         _endpoint:
-            type: admin
+            type: user_login
+            template: /admin/base.html.twig
+            component: 'app-app'
 
 enhavo_user_admin_logout:
     path: /logout

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/services/endpoint.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/services/endpoint.yaml
@@ -197,6 +197,7 @@ services:
         arguments:
             - '@Enhavo\Bundle\UserBundle\Configuration\ConfigurationProvider'
             - '@security.firewall.map'
+            - '@security.token_storage'
         calls:
 #            - [setVueForm, ['@Enhavo\Bundle\VueFormBundle\Form\VueForm']]
             - [setTemplateResolver, ['@Enhavo\Bundle\AppBundle\Template\TemplateResolverInterface']]

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/services/security.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/services/security.yaml
@@ -1,0 +1,69 @@
+services:
+    Enhavo\Bundle\UserBundle\Security\Authentication\AuthenticationError:
+        arguments:
+            - '@security.authentication_utils'
+            - '@translator'
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\BadCredentialsError:
+        arguments:
+            - '@translator'
+        tags:
+            - { name: 'enhavo_user.error_message' }
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\NotEnabledError:
+        arguments:
+            - '@translator'
+        tags:
+            - { name: 'enhavo_user.error_message' }
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\PasswordExpiredError:
+        arguments:
+            - '@translator'
+        tags:
+            - { name: 'enhavo_user.error_message' }
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\TooManyLoginAttemptsError:
+        arguments:
+            - '@translator'
+        tags:
+            - { name: 'enhavo_user.error_message' }
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\VerificationRequiredError:
+        arguments:
+            - '@translator'
+        tags:
+            - { name: 'enhavo_user.error_message' }
+
+    Enhavo\Bundle\UserBundle\Security\EntryPoint\FormAuthenticationEntryPoint:
+        arguments:
+            - '@router'
+            - '@Enhavo\Bundle\UserBundle\Configuration\ConfigurationProvider'
+
+    Enhavo\Bundle\UserBundle\Security\EntryPoint\AdminAuthenticationEntryPoint:
+        arguments:
+            - '@Enhavo\Bundle\UserBundle\Security\EntryPoint\FormAuthenticationEntryPoint'
+            - '@Enhavo\Component\Type\FactoryInterface[Endpoint]'
+            - '#^/admin/api/.*#'
+            - '#^/admin/?$#'
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\Voter\GroupRoleVoter:
+        public: false
+        tags:
+            - { name: security.voter }
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\FormLoginAuthenticator:
+        arguments:
+            - '@Enhavo\Bundle\UserBundle\Configuration\ConfigurationProvider'
+            - '@router'
+            - '@event_dispatcher'
+            - '@form.factory'
+            - '@Enhavo\Component\Type\FactoryInterface[Endpoint]'
+            - '%enhavo_user.user.model.class%'
+
+    Enhavo\Bundle\UserBundle\Security\Authentication\ApiTokenAuthenticator:
+        arguments:
+            - '@enhavo_user.user.repository'
+
+    Enhavo\Bundle\UserBundle\Security\UserChecker:
+        arguments:
+            - '@event_dispatcher'

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/services/services.yaml
@@ -36,33 +36,6 @@ services:
             - [addConfigKeyProvider, ['@Enhavo\Bundle\UserBundle\Configuration\RequestConfigKeyProvider', 5]]
             - [addConfigKeyProvider, ['@Enhavo\Bundle\UserBundle\Configuration\FirewallConfigKeyProvider' , 20]]
 
-    Enhavo\Bundle\UserBundle\Security\EntryPoint\FormAuthenticationEntryPoint:
-        arguments:
-            - '@router'
-            - '@Enhavo\Bundle\UserBundle\Configuration\ConfigurationProvider'
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\Voter\GroupRoleVoter:
-        public: false
-        tags:
-            - { name: security.voter }
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\FormLoginAuthenticator:
-        arguments:
-            - '@Enhavo\Bundle\UserBundle\Configuration\ConfigurationProvider'
-            - '@router'
-            - '@event_dispatcher'
-            - '@form.factory'
-            - '@Enhavo\Component\Type\FactoryInterface[Endpoint]'
-            - '%enhavo_user.user.model.class%'
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\ApiTokenAuthenticator:
-        arguments:
-            - '@enhavo_user.user.repository'
-
-    Enhavo\Bundle\UserBundle\Security\UserChecker:
-        arguments:
-            - '@event_dispatcher'
-
     Enhavo\Bundle\UserBundle\Configuration\ConfigurationProvider:
         arguments:
             - '%enhavo_user.config%'
@@ -109,41 +82,6 @@ services:
             - '@Enhavo\Bundle\UserBundle\Security\Authentication\AuthenticationError'
         tags:
             - { name: twig.component, key: user_login,  template: 'theme/component/user/login.html.twig' }
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\AuthenticationError:
-        arguments:
-            - '@security.authentication_utils'
-            - '@translator'
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\BadCredentialsError:
-        arguments:
-            - '@translator'
-        tags:
-            - { name: 'enhavo_user.error_message' }
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\NotEnabledError:
-        arguments:
-            - '@translator'
-        tags:
-            - { name: 'enhavo_user.error_message' }
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\PasswordExpiredError:
-        arguments:
-            - '@translator'
-        tags:
-            - { name: 'enhavo_user.error_message' }
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\TooManyLoginAttemptsError:
-        arguments:
-            - '@translator'
-        tags:
-            - { name: 'enhavo_user.error_message' }
-
-    Enhavo\Bundle\UserBundle\Security\Authentication\ErrorMessage\VerificationRequiredError:
-        arguments:
-            - '@translator'
-        tags:
-            - { name: 'enhavo_user.error_message' }
 
     Enhavo\Bundle\UserBundle\UserIdentifier\UserIdentifierProviderResolver:
         arguments:

--- a/src/Enhavo/Bundle/UserBundle/Resources/translations/javascript.de.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/translations/javascript.de.yaml
@@ -1,4 +1,7 @@
 enhavo_user:
+    error:
+        unauthenticated: 'Nicht eingeloggt'
+        unauthorized: 'Keine Berechtigung'
     reset_password:
         label:
             login: 'Zur Anmeldung'

--- a/src/Enhavo/Bundle/UserBundle/Resources/translations/javascript.en.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/translations/javascript.en.yaml
@@ -1,4 +1,7 @@
 enhavo_user:
+    error:
+        unauthenticated: 'Not logged in'
+        unauthorized: 'No permission'
     reset_password:
         label:
             login: 'Login'

--- a/src/Enhavo/Bundle/UserBundle/Security/EntryPoint/AdminAuthenticationEntryPoint.php
+++ b/src/Enhavo/Bundle/UserBundle/Security/EntryPoint/AdminAuthenticationEntryPoint.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Enhavo\Bundle\UserBundle\Security\EntryPoint;
+
+use Enhavo\Bundle\ApiBundle\Endpoint\Endpoint;
+use Enhavo\Component\Type\FactoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+class AdminAuthenticationEntryPoint implements AuthenticationEntryPointInterface
+{
+    public function __construct(
+        private readonly FormAuthenticationEntryPoint $formAuthenticationEntryPoint,
+        private readonly FactoryInterface $factory,
+        private readonly string $apiAuthenticationRegex,
+        private readonly string $formAuthenticationRegex,
+    )
+    {
+    }
+
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
+    {
+        $path = $request->getPathInfo();
+        if (preg_match($this->apiAuthenticationRegex, $path)) {
+            return new JsonResponse('Not Authenticated', 401);
+        } else if (preg_match($this->formAuthenticationRegex, $path)) {
+            return $this->formAuthenticationEntryPoint->start($request, $authException);
+        }
+
+        /** @var Endpoint $endpoint */
+        $endpoint = $this->factory->create([
+            'type' => 'admin',
+            'component' => 'user-unauthenticated',
+        ]);
+
+        $response = $endpoint->getResponse($request);
+        $response->setStatusCode(401);
+        return $response;
+    }
+}

--- a/src/Enhavo/Bundle/UserBundle/Security/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Enhavo/Bundle/UserBundle/Security/EntryPoint/FormAuthenticationEntryPoint.php
@@ -9,9 +9,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
 
 class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
+    use TargetPathTrait;
+
     public function __construct(
         private RouterInterface $router,
         private ConfigurationProvider $configurationProvider,
@@ -21,13 +24,10 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 
     public function start(Request $request, AuthenticationException $authException = null): Response
     {
-        $params = [];
-        if ($request->query->has('view_id')) {
-            $params['view_id'] = $request->query->get('view_id');
-        }
-
+        $params = [
+            'redirect' => $request->getRequestUri()
+        ];
         $route = $this->configurationProvider->getLoginConfiguration()->getRoute();
-
         return new RedirectResponse($this->router->generate($route, $params));
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| License      | MIT

* add client wrapper for fetch function
* add error handling to client
* handle 500, 403, 401 and 400 errors
* add `AdminAuthenticationEntryPoint` to return error codes on api routes
* improve ui alert
