### PR TITLE
[MediaBundle] In MediaType, remove closing edit area when clicking ou…

### DIFF
--- a/assets/node_modules/@enhavo/media/components/FormMedia.vue
+++ b/assets/node_modules/@enhavo/media/components/FormMedia.vue
@@ -21,7 +21,7 @@
                     :class="'media-items'"
                 >
                     <template #item="{ element }">
-                        <li>
+                        <li @dragstart="dragStart">
                             <component
                                 :is="form.itemComponent"
                                 :form="element"
@@ -64,5 +64,14 @@ const draggable = draggableComponent;
 const props = defineProps<{
     form: MediaForm
 }>()
+
+function dragStart(event: DragEvent)
+{
+    // For event.dataTransfer to work in time, this event must be on the original DragStart event, not the event fired by vuedraggable
+    const dragThumbElement = (event.target as HTMLElement).querySelectorAll('[data-drag-thumb]');
+    if (dragThumbElement.length > 0) {
+        event.dataTransfer.setDragImage(dragThumbElement[0], 10, 10);
+    }
+}
 
 </script>

--- a/assets/node_modules/@enhavo/media/components/FormMediaItem.vue
+++ b/assets/node_modules/@enhavo/media/components/FormMediaItem.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="form-media-item" :class="{ 'edit-show': form.editOpen }" :ref="(el) => form.setElement(el as HTMLElement)" v-click-outside="closeEdit">
-        <div class="thumb" :class="{ 'drag-button' : sortable }" @click="toggleEdit">
+    <div class="form-media-item" :class="{ 'edit-show': form.editOpen }" :ref="(el) => form.setElement(el as HTMLElement)">
+        <div class="thumb" :class="{ 'drag-button' : sortable }" @click="toggleEdit" data-drag-thumb>
             <img v-if="isImage(form.file)" :src="form.path('enhavoPreviewThumb')" draggable="false" />
             <div v-else><span class="icon" :class="'icon-'+getIcon(form.file)"></span></div>
         </div>
@@ -90,11 +90,6 @@ function toggleEdit()
     } else {
         props.form.editOpen = false;
     }
-}
-
-function closeEdit()
-{
-    props.form.editOpen = false;
 }
 
 </script>


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

- in MediaType, remove closing edit area when clicking outside
- change drag drop ghost behavior
