### PR TITLE
fix: multiple and media duplicate

### DIFF
--- a/src/Enhavo/Bundle/BlockBundle/Duplicate/BlockDuplicateType.php
+++ b/src/Enhavo/Bundle/BlockBundle/Duplicate/BlockDuplicateType.php
@@ -13,10 +13,6 @@ class BlockDuplicateType extends AbstractDuplicateType
 {
     public function finish($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         $parent = $targetValue->getParent();
         $block = $targetValue->getValue();
         if ($block instanceof BlockInterface && $parent instanceof NodeInterface) {

--- a/src/Enhavo/Bundle/BlockBundle/Duplicate/NodeChildCollectionType.php
+++ b/src/Enhavo/Bundle/BlockBundle/Duplicate/NodeChildCollectionType.php
@@ -7,7 +7,6 @@ use Enhavo\Bundle\ResourceBundle\Duplicate\AbstractDuplicateType;
 use Enhavo\Bundle\ResourceBundle\Duplicate\DuplicateFactory;
 use Enhavo\Bundle\ResourceBundle\Duplicate\SourceValue;
 use Enhavo\Bundle\ResourceBundle\Duplicate\TargetValue;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class NodeChildCollectionType extends AbstractDuplicateType
@@ -18,10 +17,6 @@ class NodeChildCollectionType extends AbstractDuplicateType
 
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         if ($sourceValue->getValue() === null) {
             $targetValue->setValue(null);
         } else {
@@ -46,12 +41,5 @@ class NodeChildCollectionType extends AbstractDuplicateType
             $collection = $propertyAccessor->getValue($target, $targetValue->getPropertyName());
             $targetValue->setValue($collection);
         }
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'groups' => null,
-        ]);
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Duplicate/Type/ContentDuplicateType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Duplicate/Type/ContentDuplicateType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Enhavo\Bundle\MediaBundle\Duplicate\Type;
+
+use Enhavo\Bundle\MediaBundle\Content\Content;
+use Enhavo\Bundle\MediaBundle\Content\ContentInterface;
+use Enhavo\Bundle\MediaBundle\Content\PathContent;
+use Enhavo\Bundle\ResourceBundle\Duplicate\AbstractDuplicateType;
+use Enhavo\Bundle\ResourceBundle\Duplicate\SourceValue;
+use Enhavo\Bundle\ResourceBundle\Duplicate\TargetValue;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContentDuplicateType extends AbstractDuplicateType
+{
+    public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
+    {
+        $content = $sourceValue->getValue();
+        if ($content instanceof ContentInterface) {
+            if ($options['copy_content']) {
+                $targetValue->setValue(new Content($content->getContent()));
+            } else {
+                $targetValue->setValue(new PathContent($content->getFilePath()));
+            }
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'copy_content' => null,
+        ]);
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Duplicate/Type/FileDuplicateType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Duplicate/Type/FileDuplicateType.php
@@ -4,26 +4,21 @@ namespace Enhavo\Bundle\MediaBundle\Duplicate\Type;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Enhavo\Bundle\MediaBundle\Factory\FileFactory;
 use Enhavo\Bundle\ResourceBundle\Duplicate\AbstractDuplicateType;
+use Enhavo\Bundle\ResourceBundle\Duplicate\DuplicateFactory;
 use Enhavo\Bundle\ResourceBundle\Duplicate\SourceValue;
 use Enhavo\Bundle\ResourceBundle\Duplicate\TargetValue;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FileDuplicateType extends AbstractDuplicateType
 {
     public function __construct(
-        private readonly FileFactory $fileFactory,
+        private readonly DuplicateFactory $duplicateFactory,
     )
     {
     }
 
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         $source = $sourceValue->getValue();
 
         if ($source === null) {
@@ -31,21 +26,14 @@ class FileDuplicateType extends AbstractDuplicateType
         } else if ($source instanceof Collection) {
             $collection = new ArrayCollection();
             foreach ($source as $file) {
-                $newFile = $this->fileFactory->createFromFile($file);
+                $newFile = $this->duplicateFactory->duplicate($file, null, $context);
                 $collection->add($newFile);
             }
             $targetValue->setValue($collection);
         } else {
-            $newFile = $this->fileFactory->createFromFile($source);
+            $newFile = $this->duplicateFactory->duplicate($source, null, $context);
             $targetValue->setValue($newFile);
         }
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'groups' => null
-        ]);
     }
 
     public static function getName(): ?string

--- a/src/Enhavo/Bundle/MediaBundle/Duplicate/Type/FileTokenDuplicateType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Duplicate/Type/FileTokenDuplicateType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Enhavo\Bundle\MediaBundle\Duplicate\Type;
+
+use Enhavo\Bundle\AppBundle\Util\TokenGeneratorInterface;
+use Enhavo\Bundle\ResourceBundle\Duplicate\AbstractDuplicateType;
+use Enhavo\Bundle\ResourceBundle\Duplicate\SourceValue;
+use Enhavo\Bundle\ResourceBundle\Duplicate\TargetValue;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class FileTokenDuplicateType extends AbstractDuplicateType
+{
+    public function __construct(
+        private readonly TokenGeneratorInterface $tokenGenerator,
+    )
+    {
+    }
+
+    public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
+    {
+        $targetValue->setValue($this->tokenGenerator->generateToken());
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Entity/Format.php
+++ b/src/Enhavo/Bundle/MediaBundle/Entity/Format.php
@@ -15,12 +15,12 @@ use Enhavo\Bundle\MediaBundle\Model\FormatInterface;
 class Format implements FormatInterface
 {
     private ?int $id = null;
-    private string $name;
+    private ?string $name = null;
     private array $parameters = [];
-    private string $mimeType;
-    private ?string $extension;
-    private FileInterface $file;
-    private ContentInterface $content;
+    private ?string $mimeType = null;
+    private ?string $extension = null;
+    private ?FileInterface $file = null;
+    private ?ContentInterface $content = null;
     private ?\DateTime $lockAt = null;
     private ?string $checksum = null;
 

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/resources/file.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/resources/file.yaml
@@ -6,3 +6,43 @@ enhavo_resource:
                 model: Enhavo\Bundle\MediaBundle\Entity\File
                 factory: Enhavo\Bundle\MediaBundle\Factory\FileFactory
                 repository: Enhavo\Bundle\MediaBundle\Repository\FileRepository
+
+    duplicate:
+        Enhavo\Bundle\MediaBundle\Entity\File:
+            properties:
+                mimeType:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                extension:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                order:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                filename:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                parameters:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                content:
+                    -   type: Enhavo\Bundle\MediaBundle\Duplicate\Type\ContentDuplicateType
+                        groups: ['duplicate']
+                        copy_content: true
+                    -   type: Enhavo\Bundle\MediaBundle\Duplicate\Type\ContentDuplicateType
+                        groups: ['revision', 'restore']
+                        copy_content: false
+                token:
+                    type: Enhavo\Bundle\MediaBundle\Duplicate\Type\FileTokenDuplicateType
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                checksum:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                createdAt:
+                    -   type: datetime
+                        groups: [ 'duplicate' ]
+                    -   type: clone
+                        groups: ['revision', 'restore' ]
+                formats:
+                    type: collection
+                    groups: [ 'duplicate', 'revision', 'restore' ]

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/resources/format.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/resources/format.yaml
@@ -6,3 +6,26 @@ enhavo_resource:
                 model: Enhavo\Bundle\MediaBundle\Entity\Format
                 factory: Enhavo\Bundle\MediaBundle\Factory\FormatFactory
                 repository: Enhavo\Bundle\MediaBundle\Repository\FormatRepository
+
+    duplicate:
+        Enhavo\Bundle\MediaBundle\Entity\Format:
+            properties:
+                name:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                parameters:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                mimeType:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]
+                content:
+                    -   type: Enhavo\Bundle\MediaBundle\Duplicate\Type\ContentDuplicateType
+                        groups: ['duplicate']
+                        copy_content: true
+                    -   type: Enhavo\Bundle\MediaBundle\Duplicate\Type\ContentDuplicateType
+                        groups: ['revision', 'restore']
+                        copy_content: false
+                checksum:
+                    type: property
+                    groups: [ 'duplicate', 'revision', 'restore' ]

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
@@ -173,6 +173,16 @@ services:
 
     Enhavo\Bundle\MediaBundle\Duplicate\Type\FileDuplicateType:
         arguments:
-            - '@enhavo_media.file.factory'
+            - '@Enhavo\Bundle\ResourceBundle\Duplicate\DuplicateFactory'
+        tags:
+            - { name: enhavo_resource.duplicate }
+
+    Enhavo\Bundle\MediaBundle\Duplicate\Type\ContentDuplicateType:
+        tags:
+            - { name: enhavo_resource.duplicate }
+
+    Enhavo\Bundle\MediaBundle\Duplicate\Type\FileTokenDuplicateType:
+        arguments:
+            - '@enhavo_app.util.secure_url_token_generator'
         tags:
             - { name: enhavo_resource.duplicate }

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/AbstractDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/AbstractDuplicateType.php
@@ -2,6 +2,7 @@
 
 namespace Enhavo\Bundle\ResourceBundle\Duplicate;
 
+use Enhavo\Bundle\ResourceBundle\Duplicate\Type\BaseDuplicateType;
 use Enhavo\Component\Type\AbstractType;
 
 /**
@@ -9,6 +10,11 @@ use Enhavo\Component\Type\AbstractType;
  */
 abstract class AbstractDuplicateType extends AbstractType implements DuplicateTypeInterface
 {
+    public function isApplicable($options, SourceValue $sourceValue, TargetValue $targetValue, $context): bool
+    {
+        return $this->parent->isApplicable($options, $sourceValue, $targetValue, $context);
+    }
+
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
 
@@ -19,36 +25,8 @@ abstract class AbstractDuplicateType extends AbstractType implements DuplicateTy
 
     }
 
-    protected function isGroupSelected($options, $context): bool
+    public static function getParentType(): ?string
     {
-        $group = $context['groups'] ?? null;
-
-        if ($options['groups'] === null && $group === null) {
-            return true;
-        }
-
-        if (isset($options['groups']) && $options['groups'] === true) {
-            return true;
-        }
-
-        $groups = match (gettype($options['groups'])) {
-            'array' => $options['groups'],
-            'string' => [$options['groups']],
-            default => [],
-        };
-
-        $targetGroups = match (gettype($group)) {
-            'array' => $group,
-            'string' => [$group],
-            default => [],
-        };
-
-        foreach ($targetGroups as $targetGroup) {
-            if (in_array($targetGroup, $groups)) {
-                return true;
-            }
-        }
-
-        return false;
+        return BaseDuplicateType::class;
     }
 }

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Duplicate.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Duplicate.php
@@ -16,6 +16,11 @@ use Enhavo\Component\Type\AbstractContainerType;
  */
 class Duplicate extends AbstractContainerType
 {
+    function isApplicable(SourceValue $sourceValue, TargetValue $targetValue, array $context = []): bool
+    {
+        return $this->type->isApplicable($this->options, $sourceValue, $targetValue, $context);
+    }
+
     function duplicate(SourceValue $sourceValue, TargetValue $targetValue, array $context = []): mixed
     {
         foreach ($this->parents as $parent) {

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/DuplicateFactory.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/DuplicateFactory.php
@@ -57,8 +57,10 @@ class DuplicateFactory
 
                     /** @var Duplicate $duplicate */
                     $duplicate = $this->duplicateFactory->create($config);
-                    $newValue = $duplicate->duplicate($sourceValue, $targetValue, $context);
-                    $reflectionProperty->setValue($target, $newValue);
+                    if ($duplicate->isApplicable($sourceValue, $targetValue, $context)) {
+                        $newValue = $duplicate->duplicate($sourceValue, $targetValue, $context);
+                        $reflectionProperty->setValue($target, $newValue);
+                    }
                 }
             }
         }

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/DuplicateTypeInterface.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/DuplicateTypeInterface.php
@@ -7,6 +7,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 interface DuplicateTypeInterface extends TypeInterface
 {
+    public function isApplicable($options, SourceValue $sourceValue, TargetValue $targetValue, $context): bool;
+
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void;
 
     public function finish($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void;

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/BaseDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/BaseDuplicateType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Enhavo\Bundle\ResourceBundle\Duplicate\Type;
+
+use Enhavo\Bundle\ResourceBundle\Duplicate\AbstractDuplicateType;
+use Enhavo\Bundle\ResourceBundle\Duplicate\DuplicateTypeInterface;
+use Enhavo\Bundle\ResourceBundle\Duplicate\SourceValue;
+use Enhavo\Bundle\ResourceBundle\Duplicate\TargetValue;
+use Enhavo\Component\Type\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class BaseDuplicateType extends AbstractType implements DuplicateTypeInterface
+{
+    public function isApplicable($options, SourceValue $sourceValue, TargetValue $targetValue, $context): bool
+    {
+        return $this->isGroupSelected($options, $context);
+    }
+
+    public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
+    {
+
+    }
+
+    public function finish($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
+    {
+
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'groups' => null
+        ]);
+    }
+
+    private function isGroupSelected($options, $context): bool
+    {
+        $group = $context['groups'] ?? null;
+
+        if ($options['groups'] === null && $group === null) {
+            return true;
+        }
+
+        if (isset($options['groups']) && $options['groups'] === true) {
+            return true;
+        }
+
+        $groups = match (gettype($options['groups'])) {
+            'array' => $options['groups'],
+            'string' => [$options['groups']],
+            default => [],
+        };
+
+        $targetGroups = match (gettype($group)) {
+            'array' => $group,
+            'string' => [$group],
+            default => [],
+        };
+
+        foreach ($targetGroups as $targetGroup) {
+            if (in_array($targetGroup, $groups)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/CloneDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/CloneDuplicateType.php
@@ -11,10 +11,6 @@ class CloneDuplicateType extends AbstractDuplicateType
 {
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         if ($sourceValue->getValue() === null) {
             $targetValue->setValue(null);
             return;
@@ -22,13 +18,6 @@ class CloneDuplicateType extends AbstractDuplicateType
 
         $value = clone $sourceValue->getValue();
         $targetValue->setValue($value);
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'groups' => null
-        ]);
     }
 
     public static function getName(): ?string

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/CollectionDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/CollectionDuplicateType.php
@@ -21,10 +21,6 @@ class CollectionDuplicateType extends AbstractDuplicateType
 
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         if ($sourceValue->getValue() === null) {
             $targetValue->setValue(null);
         } else if ($options['by_reference']) {
@@ -59,7 +55,6 @@ class CollectionDuplicateType extends AbstractDuplicateType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'groups' => null,
             'map_target' => false,
             'by_reference' => false,
         ]);

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/CollectionReferenceDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/CollectionReferenceDuplicateType.php
@@ -12,10 +12,6 @@ class CollectionReferenceDuplicateType extends AbstractDuplicateType
 {
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         $originalValue = $targetValue->getOriginalValue();
 
         if ($sourceValue->getValue() === null) {
@@ -72,13 +68,6 @@ class CollectionReferenceDuplicateType extends AbstractDuplicateType
         } else {
             unset($collection[$key]);
         }
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'groups' => null,
-        ]);
     }
 
     public static function getName(): ?string

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/DateTimeDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/DateTimeDuplicateType.php
@@ -5,15 +5,12 @@ namespace Enhavo\Bundle\ResourceBundle\Duplicate\Type;
 use Enhavo\Bundle\ResourceBundle\Duplicate\AbstractDuplicateType;
 use Enhavo\Bundle\ResourceBundle\Duplicate\SourceValue;
 use Enhavo\Bundle\ResourceBundle\Duplicate\TargetValue;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DateTimeDuplicateType extends AbstractDuplicateType
 {
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         $targetValue->setValue(new \DateTime());
     }
 

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/ModelDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/ModelDuplicateType.php
@@ -18,10 +18,6 @@ class ModelDuplicateType extends AbstractDuplicateType
 
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         if ($sourceValue->getValue() === null) {
             $targetValue->setValue(null);
             return;
@@ -29,13 +25,6 @@ class ModelDuplicateType extends AbstractDuplicateType
 
         $value = $this->duplicateFactory->duplicate($sourceValue->getValue(), $targetValue->getValue(), $context);
         $targetValue->setValue($value);
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'groups' => null
-        ]);
     }
 
     public static function getName(): ?string

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/PropertyDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/PropertyDuplicateType.php
@@ -11,10 +11,6 @@ class PropertyDuplicateType extends AbstractDuplicateType
 {
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         $value = $sourceValue->getValue();
         if (!is_null($value) && !(is_scalar($value) || is_array($value))) {
             throw new \InvalidArgumentException(sprintf('Duplicate type property only accept scalar or array values but "%s" given for property "%s" on class "%s"',
@@ -25,13 +21,6 @@ class PropertyDuplicateType extends AbstractDuplicateType
         }
 
         $targetValue->setValue($value);
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'groups' => null
-        ]);
     }
 
     public static function getName(): ?string

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/ReferenceDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/ReferenceDuplicateType.php
@@ -11,19 +11,8 @@ class ReferenceDuplicateType extends AbstractDuplicateType
 {
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         $value = $sourceValue->getValue();
         $targetValue->setValue($value);
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'groups' => null
-        ]);
     }
 
     public static function getName(): ?string

--- a/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/StringDuplicateType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Duplicate/Type/StringDuplicateType.php
@@ -11,10 +11,6 @@ class StringDuplicateType extends AbstractDuplicateType
 {
     public function duplicate($options, SourceValue $sourceValue, TargetValue $targetValue, $context): void
     {
-        if (!$this->isGroupSelected($options, $context)) {
-            return;
-        }
-
         if ($sourceValue->getValue() === null) {
             $targetValue->setValue(null);
             return;
@@ -27,7 +23,6 @@ class StringDuplicateType extends AbstractDuplicateType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'groups' => null,
             'prefix' => null,
             'postfix' => null,
         ]);

--- a/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/duplicate.yaml
+++ b/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/duplicate.yaml
@@ -30,6 +30,10 @@ services:
             - '@Enhavo\Component\Metadata\MetadataRepository[Duplicate]'
             - '@Enhavo\Component\Type\FactoryInterface[Duplicate]'
 
+    Enhavo\Bundle\ResourceBundle\Duplicate\Type\BaseDuplicateType:
+        tags:
+            - { name: enhavo_resource.duplicate }
+
     Enhavo\Bundle\ResourceBundle\Duplicate\Type\PropertyDuplicateType:
         tags:
             - { name: enhavo_resource.duplicate }

--- a/src/Enhavo/Bundle/ResourceBundle/Tests/Duplicate/DuplicateFactoryTest.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Tests/Duplicate/DuplicateFactoryTest.php
@@ -101,4 +101,9 @@ class SimpleDuplicateType extends AbstractDuplicateType
     {
         $targetValue->setValue($sourceValue->getValue());
     }
+
+    public function isApplicable($options, SourceValue $sourceValue, TargetValue $targetValue, $context): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| License      | MIT

* fix: multiple duplicate by adding `isApplicable` function 
* chore: move duplicate groups to base type
* use duplicate meta for media file and copy all properties
