### PR TITLE
[AppBundle] Fix AppBundle ModalController using ->get() Controller me…

### DIFF
--- a/src/Enhavo/Bundle/ApiBundle/composer.json
+++ b/src/Enhavo/Bundle/ApiBundle/composer.json
@@ -12,7 +12,8 @@
     }
   ],
   "require": {
-    "php": "^8.0"
+    "php": "^8.0",
+    "symfony/serializer": "^6.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5"

--- a/src/Enhavo/Bundle/AppBundle/Controller/ModalController.php
+++ b/src/Enhavo/Bundle/AppBundle/Controller/ModalController.php
@@ -10,6 +10,7 @@ namespace Enhavo\Bundle\AppBundle\Controller;
 
 use Enhavo\Bundle\AppBundle\Template\TemplateResolverTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -17,10 +18,14 @@ class ModalController extends AbstractController
 {
     use TemplateResolverTrait;
 
+    public function __construct(
+        private FormFactoryInterface $formFactory
+    ) {}
+
     public function formAction(Request $request)
     {
         $configuration = $this->createConfiguration($request);
-        $form = $this->get('form.factory')->create($configuration->getForm(), null, $configuration->getOptions());
+        $form = $this->formFactory->create($configuration->getForm(), null, $configuration->getOptions());
         $template = $configuration->getTemplate() ? $configuration->getTemplate() : 'admin/view/modal-form.html.twig';
 
         $form->handleRequest($request);

--- a/src/Enhavo/Bundle/AppBundle/Resources/config/services/controller.yaml
+++ b/src/Enhavo/Bundle/AppBundle/Resources/config/services/controller.yaml
@@ -39,6 +39,8 @@ services:
         alias: Enhavo\Bundle\AppBundle\Controller\ModalController
 
     Enhavo\Bundle\AppBundle\Controller\ModalController:
+        arguments:
+            - '@form.factory'
         calls:
             - [setContainer, ['@Psr\Container\ContainerInterface']]
             - [setTemplateResolver, ['@Enhavo\Bundle\AppBundle\Template\TemplateResolverInterface']]

--- a/src/Enhavo/Bundle/AppBundle/composer.json
+++ b/src/Enhavo/Bundle/AppBundle/composer.json
@@ -29,6 +29,7 @@
     "symfony/asset": "^6.4",
     "symfony/console": "^6.4",
     "symfony/expression-language": "^6.4",
+    "symfony/filesystem": "^6.4",
     "symfony/form": "^6.4",
     "symfony/framework-bundle": "^6.4",
     "symfony/monolog-bundle": "^3.1",

--- a/templates/theme/endpoint/hello.html.twig
+++ b/templates/theme/endpoint/hello.html.twig
@@ -1,3 +1,6 @@
 <html>
-  <body>{{ message }}</body>
+  <body>
+  {{ message }}
+  {{ dump() }}
+  </body>
 </html>


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[AppBundle] Fix AppBundle ModalController using $this->get() Controller method which no longer exists in this Version of Symfony
