### PR TITLE
[MediaBundle] Fix Formats ALWAYS deleted

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Repository/FormatRepository.php
+++ b/src/Enhavo/Bundle/MediaBundle/Repository/FormatRepository.php
@@ -14,6 +14,18 @@ use Enhavo\Bundle\ResourceBundle\Repository\EntityRepository;
 
 class FormatRepository extends EntityRepository
 {
+    public function countByChecksum(string $checksum): int
+    {
+        $query = $this->createQueryBuilder('f')
+            ->select('count(f.id) as count')
+            ->where('f.checksum = :checksum')
+            ->setParameter('checksum', $checksum)
+            ->getQuery();
+
+        $result = $query->getSingleScalarResult();
+        return intval($result);
+    }
+
     public function findByFormatNameAndFile($formatName, FileInterface $file)
     {
         $queryBuilder = $this->createQueryBuilder('format');

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
@@ -66,6 +66,7 @@ services:
             - '%kernel.project_dir%/var/media'
             - '@filesystem'
             - '@enhavo_media.file.repository'
+            - '@enhavo_media.format.repository'
 
     Enhavo\Bundle\MediaBundle\Twig\MediaTwigExtension:
         arguments:

--- a/src/Enhavo/Bundle/MediaBundle/Storage/LocalChecksumFileStorage.php
+++ b/src/Enhavo/Bundle/MediaBundle/Storage/LocalChecksumFileStorage.php
@@ -10,6 +10,7 @@ namespace Enhavo\Bundle\MediaBundle\Storage;
 
 use Enhavo\Bundle\MediaBundle\Exception\FileNotFoundException;
 use Enhavo\Bundle\MediaBundle\Repository\FileRepository;
+use Enhavo\Bundle\MediaBundle\Repository\FormatRepository;
 use Symfony\Component\Filesystem\Filesystem;
 use Enhavo\Bundle\MediaBundle\Content\PathContent;
 use Enhavo\Bundle\MediaBundle\Exception\StorageException;
@@ -23,6 +24,7 @@ class LocalChecksumFileStorage implements StorageInterface, StorageChecksumInter
         private readonly string $basePath,
         private readonly Filesystem $filesystem,
         private readonly FileRepository $fileRepository,
+        private readonly FormatRepository $formatRepository,
     )
     {
     }
@@ -31,7 +33,11 @@ class LocalChecksumFileStorage implements StorageInterface, StorageChecksumInter
     {
         $this->checkFile($file);
 
-        $amount = $this->fileRepository->countByChecksum($file->getChecksum());
+        if ($file instanceof FileInterface) {
+            $amount = $this->fileRepository->countByChecksum($file->getChecksum());
+        } else if ($file instanceof FormatInterface) {
+            $amount = $this->formatRepository->countByChecksum($file->getChecksum());
+        }
 
         if ($amount === 0) {
             $path = $this->getFilePath($file);


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

If a reference to a file is deleted. The persistence of a format ought to be checked in the format table instead of the file table.
Otherwise formats are always deleted if a file is used as a certain format in multiple places.
