### PR TITLE
fix: soft delete route

### DIFF
--- a/src/Enhavo/Bundle/ResourceBundle/Delete/DoctrineDeleteHandler.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Delete/DoctrineDeleteHandler.php
@@ -3,18 +3,24 @@
 namespace Enhavo\Bundle\ResourceBundle\Delete;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Enhavo\Bundle\ResourceBundle\Event\ResourcePostDeleteEvent;
+use Enhavo\Bundle\ResourceBundle\Event\ResourcePreDeleteEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class DoctrineDeleteHandler implements DeleteHandlerInterface
 {
     public function __construct(
-        private EntityManagerInterface $em,
+        private readonly EntityManagerInterface $em,
+        private readonly EventDispatcherInterface $eventDispatcher,
     )
     {
     }
 
     public function delete(object $resource): void
     {
+        $this->eventDispatcher->dispatch(new ResourcePreDeleteEvent($resource),'enhavo_resource.pre_delete');
         $this->em->remove($resource);
         $this->em->flush();
+        $this->eventDispatcher->dispatch(new ResourcePostDeleteEvent($resource),'enhavo_resource.post_delete');
     }
 }

--- a/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
@@ -8,10 +8,8 @@ use Enhavo\Bundle\ResourceBundle\Delete\DeleteHandlerInterface;
 use Enhavo\Bundle\ResourceBundle\Duplicate\DuplicateFactory;
 use Enhavo\Bundle\ResourceBundle\Event\ResourcePreCreateEvent;
 use Enhavo\Bundle\ResourceBundle\Event\ResourcePostCreateEvent;
-use Enhavo\Bundle\ResourceBundle\Event\ResourcePostDeleteEvent;
 use Enhavo\Bundle\ResourceBundle\Event\ResourcePostTransitionEvent;
 use Enhavo\Bundle\ResourceBundle\Event\ResourcePostUpdateEvent;
-use Enhavo\Bundle\ResourceBundle\Event\ResourcePreDeleteEvent;
 use Enhavo\Bundle\ResourceBundle\Event\ResourcePreTransitionEvent;
 use Enhavo\Bundle\ResourceBundle\Event\ResourcePreUpdateEvent;
 use Enhavo\Bundle\ResourceBundle\Factory\FactoryInterface;
@@ -90,11 +88,7 @@ class ResourceManager
 
     public function delete(object $resource): void
     {
-        $this->dispatch(new ResourcePreDeleteEvent($resource), 'pre_delete');
-
         $this->deleteHandler->delete($resource);
-
-        $this->dispatch(new ResourcePostDeleteEvent($resource), 'post_delete');
     }
 
     public function duplicate(object $resource, $target = null, array $context = []): object

--- a/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/services.yaml
@@ -72,6 +72,7 @@ services:
     Enhavo\Bundle\ResourceBundle\Delete\DoctrineDeleteHandler:
         arguments:
             - '@doctrine.orm.entity_manager'
+            - '@event_dispatcher'
 
     Enhavo\Bundle\ResourceBundle\Doctrine\MetadataListener:
         arguments:

--- a/src/Enhavo/Bundle/RevisionBundle/Delete/SoftDeleteHandler.php
+++ b/src/Enhavo/Bundle/RevisionBundle/Delete/SoftDeleteHandler.php
@@ -14,7 +14,7 @@ class SoftDeleteHandler implements DeleteHandlerInterface, ServiceSubscriberInte
     private ContainerInterface $container;
 
     public function __construct(
-        private readonly EntityManagerInterface $em
+        private readonly DeleteHandlerInterface $deleteHandler,
     )
     {
     }
@@ -31,8 +31,7 @@ class SoftDeleteHandler implements DeleteHandlerInterface, ServiceSubscriberInte
         if ($resource instanceof RevisionInterface) {
             $this->container->get(RevisionManager::class)->softDelete($resource);
         } else {
-            $this->em->remove($resource);
-            $this->em->flush();
+            $this->deleteHandler->delete($resource);
         }
     }
 

--- a/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePostSoftDeleteEvent.php
+++ b/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePostSoftDeleteEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Enhavo\Bundle\RevisionBundle\Event;
+
+use Enhavo\Bundle\ResourceBundle\Event\ResourceEvent;
+
+class ResourcePostSoftDeleteEvent extends ResourceEvent
+{
+
+}

--- a/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePostUndeleteEvent.php
+++ b/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePostUndeleteEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Enhavo\Bundle\RevisionBundle\Event;
+
+use Enhavo\Bundle\ResourceBundle\Event\ResourceEvent;
+
+class ResourcePostUndeleteEvent extends ResourceEvent
+{
+
+}

--- a/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePreSoftDeleteEvent.php
+++ b/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePreSoftDeleteEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Enhavo\Bundle\RevisionBundle\Event;
+
+use Enhavo\Bundle\ResourceBundle\Event\ResourceEvent;
+
+class ResourcePreSoftDeleteEvent extends ResourceEvent
+{
+
+}

--- a/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePreUndeleteEvent.php
+++ b/src/Enhavo/Bundle/RevisionBundle/Event/ResourcePreUndeleteEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Enhavo\Bundle\RevisionBundle\Event;
+
+use Enhavo\Bundle\ResourceBundle\Event\ResourceEvent;
+
+class ResourcePreUndeleteEvent extends ResourceEvent
+{
+
+}

--- a/src/Enhavo/Bundle/RevisionBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/RevisionBundle/Resources/config/services/services.yaml
@@ -5,10 +5,11 @@ services:
             - '@doctrine.orm.entity_manager'
             - '@enhavo_revision.bin.factory'
             - '@enhavo_revision.archive.factory'
+            - '@event_dispatcher'
 
     Enhavo\Bundle\RevisionBundle\Delete\SoftDeleteHandler:
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@Enhavo\Bundle\ResourceBundle\Delete\DoctrineDeleteHandler'
         calls:
             - [setContainer, ['@Psr\Container\ContainerInterface']]
         tags:

--- a/src/Enhavo/Bundle/RoutingBundle/EventListener/SoftDeleteListener.php
+++ b/src/Enhavo/Bundle/RoutingBundle/EventListener/SoftDeleteListener.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Enhavo\Bundle\RoutingBundle\EventListener;
+
+use Enhavo\Bundle\AppBundle\Util\TokenGeneratorInterface;
+use Enhavo\Bundle\ResourceBundle\Event\ResourceEvent;
+use Enhavo\Bundle\RoutingBundle\Model\Routeable;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SoftDeleteListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly TokenGeneratorInterface $tokenGenerator,
+    )
+    {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'enhavo_resource.pre_soft_delete' => 'preSoftDelete',
+            'enhavo_resource.pre_undelete' => 'preUndelete'
+        );
+    }
+
+    public function preSoftDelete(ResourceEvent $event)
+    {
+        $resource = $event->getSubject();
+        if ($resource instanceof Routeable && $resource->getRoute() && is_subclass_of($resource, 'Enhavo\Bundle\RevisionBundle\Model\RevisionInterface')) {
+            /** @var $resource \Enhavo\Bundle\RevisionBundle\Model\RevisionInterface&Routeable */
+            $condition = $resource->getRoute()->getCondition();
+            $staticPrefix = $resource->getRoute()->getStaticPrefix();
+            $parameters = $resource->getRevisionParameters();
+            $parameters['route_condition'] = $condition;
+            $parameters['route_static_prefix'] = $staticPrefix;
+            $resource->setRevisionParameters($parameters);
+
+            $resource->getRoute()->setCondition('false');
+            $resource->getRoute()->setStaticPrefix(sprintf('/soft_deleted_%s' , $this->tokenGenerator->generateToken()));
+        }
+    }
+
+    public function preUndelete(ResourceEvent $event)
+    {
+        $resource = $event->getSubject();
+        if ($resource instanceof Routeable && $resource->getRoute() && is_subclass_of($resource, 'Enhavo\Bundle\RevisionBundle\Model\RevisionInterface')) {
+            /** @var $resource \Enhavo\Bundle\RevisionBundle\Model\RevisionInterface&Routeable */
+            $parameters = $resource->getRevisionParameters();
+            $resource->getRoute()->setCondition($parameters['route_condition'] ?? '');
+            if (isset($parameters['route_static_prefix'])) {
+                $resource->getRoute()->setStaticPrefix($parameters['route_static_prefix']);
+            }
+        }
+    }
+}

--- a/src/Enhavo/Bundle/RoutingBundle/Resources/config/services/general.yaml
+++ b/src/Enhavo/Bundle/RoutingBundle/Resources/config/services/general.yaml
@@ -6,10 +6,15 @@ services:
             - '@enhavo_routing.route.factory'
             - '@doctrine.orm.entity_manager'
 
-    enhavo_routing.listener.routeable_listener:
-        class: Enhavo\Bundle\RoutingBundle\EventListener\RouteableListener
+    Enhavo\Bundle\RoutingBundle\EventListener\RouteableListener:
         arguments:
             - '@Enhavo\Bundle\RoutingBundle\Manager\RouteManager'
+        tags:
+            - { name: kernel.event_subscriber }
+
+    Enhavo\Bundle\RoutingBundle\EventListener\SoftDeleteListener:
+        arguments:
+            - '@enhavo_app.util.secure_url_token_generator'
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

If a resource with a route was deleted, then the route still exists but refer to a null object, because doctrine will filter it out. This leads to unexpected behaviour if a new route was created with the same path. So if a route, which is soft deleted will get invisible by overwriting the staticPrefix with random data and setting the condition to false.
