### PR TITLE
fix: delete bin item

### DIFF
--- a/src/Enhavo/Bundle/RevisionBundle/Batch/Type/BinDeleteBatchType.php
+++ b/src/Enhavo/Bundle/RevisionBundle/Batch/Type/BinDeleteBatchType.php
@@ -23,15 +23,15 @@ class BinDeleteBatchType extends AbstractBatchType
 
     public function execute(array $options, array $ids, EntityRepository $repository, Data $data, Context $context): void
     {
+        $this->em->getFilters()->disable('revision');
         foreach ($ids as $id) {
-            $this->em->getFilters()->disable('revision');
             $resource = $repository->find($id);
-            $this->em->getFilters()->enable('revision');
 
             if ($resource instanceof Bin) {
                 $this->deleteHandler->delete($resource);
             }
         }
+        $this->em->getFilters()->enable('revision');
     }
 
     public function configureOptions(OptionsResolver $resolver): void


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Items are not able to delete if the doctrine revision filter is still active while flushing
