### PR TITLE
Revision filter command hook

### DIFF
--- a/src/Enhavo/Bundle/RevisionBundle/EventListener/RevisionDoctrineFilterListener.php
+++ b/src/Enhavo/Bundle/RevisionBundle/EventListener/RevisionDoctrineFilterListener.php
@@ -32,13 +32,8 @@ class RevisionDoctrineFilterListener
 
         $config = $this->entityManager->getConfiguration();
 
-        if (!$config->getFilterClassName('revision')) {
-            $config->addFilter('revision', RevisionFilter::class);
-        }
-
+        $config->addFilter('revision', RevisionFilter::class);
         $filters = $this->entityManager->getFilters();
-        if (!$filters->isEnabled('revision')) {
-            $filters->enable('revision');
-        }
+        $filters->enable('revision');
     }
 }

--- a/src/Enhavo/Bundle/RevisionBundle/EventListener/RevisionDoctrineFilterListener.php
+++ b/src/Enhavo/Bundle/RevisionBundle/EventListener/RevisionDoctrineFilterListener.php
@@ -16,9 +16,29 @@ class RevisionDoctrineFilterListener
 
     public function onKernelRequest(): void
     {
-        if ($this->enabled) {
-            $this->entityManager->getConfiguration()->addFilter('revision', RevisionFilter::class);
-            $this->entityManager->getFilters()->enable('revision');
+        $this->enableFilter();
+    }
+
+    public function onConsoleCommand(): void
+    {
+        $this->enableFilter();
+    }
+
+    private function enableFilter(): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        $config = $this->entityManager->getConfiguration();
+
+        if (!$config->getFilterClassName('revision')) {
+            $config->addFilter('revision', RevisionFilter::class);
+        }
+
+        $filters = $this->entityManager->getFilters();
+        if (!$filters->isEnabled('revision')) {
+            $filters->enable('revision');
         }
     }
 }

--- a/src/Enhavo/Bundle/RevisionBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/RevisionBundle/Resources/config/services/services.yaml
@@ -104,3 +104,4 @@ services:
             - '%enhavo_revision.doctrine_filter.enabled%'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+            - { name: kernel.event_listener, event: console.command, method: onConsoleCommand }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| License      | MIT

In order to also have revisions filtered out by default when commands like SearchBundle index command are beeing run, add a hook to also filter revisions in commands.
