### PR TITLE
fix: remove file

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Storage/LocalChecksumFileStorage.php
+++ b/src/Enhavo/Bundle/MediaBundle/Storage/LocalChecksumFileStorage.php
@@ -41,12 +41,9 @@ class LocalChecksumFileStorage implements StorageInterface, StorageChecksumInter
 
         if ($amount === 0) {
             $path = $this->getFilePath($file);
-            if (!$this->filesystem->exists($path)) {
-                throw new FileNotFoundException(sprintf(
-                    'File not found for name "%s". Expected on path "%s"', $file->getBasename(), $path
-                ));
+            if ($this->filesystem->exists($path)) {
+                $this->filesystem->remove($path);
             }
-            $this->filesystem->remove($path);
         }
     }
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Remove check exists on remove file, because if the same file (same checksum) is connected to an entity multiple times with different file objects, then all files may remove first from database and then the postRemove event will be triggered for each file. The first call will already remove the file, while the next will throw the not found exception.
