### PR TITLE
[MediaBundle] Predict format extension in media url generation instea…

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/BackgroundFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/BackgroundFilter.php
@@ -42,6 +42,14 @@ class BackgroundFilter extends AbstractFilter
         return $newImage;
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return $originalExtension;
+    }
+
     public function getType()
     {
         return 'background';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageBlurFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageBlurFilter.php
@@ -35,6 +35,14 @@ class ImageBlurFilter extends AbstractFilter
         }
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return $originalExtension;
+    }
+
     public function getType()
     {
         return 'image_blur';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageCompressionFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageCompressionFilter.php
@@ -96,6 +96,14 @@ class ImageCompressionFilter extends AbstractFilter
         return $optimizer;
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return $originalExtension;
+    }
+
     public function getType()
     {
         return 'image_compression';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageFilter.php
@@ -335,6 +335,18 @@ class ImageFilter extends AbstractFilter
         return sscanf($backgroundColorHex, '%02x%02x%02x');
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        $format = $setting->getSetting('format');
+        if ($format) {
+            return $format;
+        }
+        return $originalExtension;
+    }
+
     public function getType()
     {
         return 'image';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageZoomFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ImageZoomFilter.php
@@ -37,6 +37,14 @@ class ImageZoomFilter extends AbstractFilter
         ]);
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return $originalExtension;
+    }
+
     public function getType()
     {
         return 'image_zoom';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/MimetypeFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/MimetypeFilter.php
@@ -44,6 +44,14 @@ class MimetypeFilter extends AbstractFilter
         }
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return $originalExtension;
+    }
+
     public function getType()
     {
         return 'mimetype';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/PDFImageFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/PDFImageFilter.php
@@ -60,6 +60,14 @@ class PDFImageFilter extends AbstractFilter
         $this->setMimeType($file, 'image/jpeg');
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return 'jpg';
+    }
+
     public function getType()
     {
         return 'pdf_image';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ParentFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/ParentFilter.php
@@ -45,6 +45,26 @@ class ParentFilter extends AbstractFilter
         }
     }
 
+
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        $parent = $setting->getSetting('parent');
+        $exclude = $setting->getSetting('exclude', []);
+        $settings = $this->formatManager->getFormatSettings($parent);
+        $extension = $originalExtension;
+        foreach ($settings as $setting) {
+            if (in_array($setting->getType(), $exclude)) {
+                continue;
+            }
+            $filter = $this->formatManager->getFilter($setting->getType());
+            $extension = $filter->predictExtension($extension, $setting);
+        }
+        return $extension;
+    }
+
     public function getType()
     {
         return 'parent';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/TextImageFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/TextImageFilter.php
@@ -45,6 +45,14 @@ class TextImageFilter extends AbstractFilter
         $this->setMimeType($file, 'image/png');
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return 'png';
+    }
+
     public function getType()
     {
         return 'text_image';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/Filter/VideoImageFilter.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/Filter/VideoImageFilter.php
@@ -46,6 +46,14 @@ class VideoImageFilter extends AbstractFilter
         $this->setMimeType($file, 'image/jpeg');
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string
+    {
+        return 'jpg';
+    }
+
     public function getType()
     {
         return 'video_image';

--- a/src/Enhavo/Bundle/MediaBundle/Filter/FilterInterface.php
+++ b/src/Enhavo/Bundle/MediaBundle/Filter/FilterInterface.php
@@ -25,4 +25,15 @@ interface FilterInterface extends TypeInterface
      * @return void
      */
     public function apply($file, FilterSetting $setting);
+
+    /**
+     * Predicts the file extension of the resulting file after running this filter.
+     * This function needs to run fast without any actual conversions happening. If the extension cannot be predicted
+     * without any slow code, return null.
+     *
+     * @param string|null $originalExtension Extension predicted by the previous filter or the original file
+     * @param FilterSetting $setting
+     * @return string|null Predicted extension or null if unpredictable
+     */
+    public function predictExtension(?string $originalExtension, FilterSetting $setting): ?string;
 }

--- a/src/Enhavo/Bundle/MediaBundle/Media/FormatManager.php
+++ b/src/Enhavo/Bundle/MediaBundle/Media/FormatManager.php
@@ -159,6 +159,17 @@ class FormatManager
         return $fileFormat;
     }
 
+    public function predictFormatExtension(?string $originalExtension, string $formatName): ?string
+    {
+        $settings = $this->getFormatSettings($formatName, []);
+        $extension = $originalExtension;
+        foreach ($settings as $setting) {
+            $filter = $this->getFilter($setting->getType());
+            $extension = $filter->predictExtension($extension, $setting);
+        }
+        return $extension;
+    }
+
     private function saveFormat(FormatInterface $fileFormat): FormatInterface
     {
         $this->resourceManager->save($fileFormat);

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/media.yaml
@@ -71,6 +71,7 @@ services:
     Enhavo\Bundle\MediaBundle\Twig\MediaTwigExtension:
         arguments:
             - '@Enhavo\Bundle\AppBundle\Twig\TwigRouter'
+            - '@enhavo_media.media.format_manager'
         tags:
             - { name: twig.extension }
 

--- a/src/Enhavo/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Enhavo/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -12,6 +12,7 @@
 namespace Enhavo\Bundle\MediaBundle\Twig;
 
 use Enhavo\Bundle\AppBundle\Twig\TwigRouter;
+use Enhavo\Bundle\MediaBundle\Media\FormatManager;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -20,6 +21,7 @@ class MediaTwigExtension extends AbstractExtension
 {
     public function __construct(
         private readonly TwigRouter $twigRouter,
+        private readonly FormatManager $formatManager,
     ) {
     }
 
@@ -38,11 +40,16 @@ class MediaTwigExtension extends AbstractExtension
         if (null === $file) {
             return null;
         } elseif (null !== $format) {
+            $extension = $this->formatManager->predictFormatExtension($file['extension'], $format);
+            if (null === $extension) {
+                $extension = $file['extension'];
+            }
+
             return $this->twigRouter->generate('enhavo_media_theme_format', [
                 'token' => $file['token'],
                 'shortChecksum' => $file['shortChecksum'],
                 'filename' => $file['filename'],
-                'extension' => $file['extension'],
+                'extension' => $extension,
                 'format' => $format,
             ], $referenceType);
         }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | yes
| License      | MIT

Predict format extension in media url generation instead of using extension of original file
