### PR TITLE
feat: assetVersion for fantasticon

### DIFF
--- a/assets/node_modules/@enhavo/app/vite/fantasticon-plugin/defaults.js
+++ b/assets/node_modules/@enhavo/app/vite/fantasticon-plugin/defaults.js
@@ -14,6 +14,7 @@ export function defaults(options)
         prefix: name,
         descent: 60,
         normalize: true,
+        assetVersion: Date.now(),
         formatOptions: {
             svg: { ascent: 0 },
             json: { indent: 2 },

--- a/assets/node_modules/@enhavo/app/vite/fantasticon-plugin/hmr-template.js
+++ b/assets/node_modules/@enhavo/app/vite/fantasticon-plugin/hmr-template.js
@@ -5,7 +5,7 @@ export const hmrTemplate = (event, id, config, base) => `
 (function() {
   var link = document.createElement('link');
   link.setAttribute('data-id', '${id}');
-  link.setAttribute("href", "${base}${assetPath(config, "css")}?${Date.now()}");
+  link.setAttribute("href", "${base}${assetPath(config, "css")}?${config.assetVersion}");
   link.setAttribute("rel", "stylesheet");
   link.setAttribute("type", "text/css");
   var head = document.getElementsByTagName('head')[0];


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Add `assetVersion` as config key to fantasticon and write a `fantasticon.json` in the build directory, to read the `assetVersion` for preloading
