### PR TITLE
feat: provide fantasticon hash

### DIFF
--- a/assets/node_modules/@enhavo/app/vite/fantasticon-plugin/build-assets.js
+++ b/assets/node_modules/@enhavo/app/vite/fantasticon-plugin/build-assets.js
@@ -4,6 +4,7 @@ import { URL } from "node:url";
 import { dirname, relative } from "path/posix";
 import { assetPath, assetType, withoutQuery } from "@enhavo/app/vite/fantasticon-plugin/paths.js";
 import { watchDebounced } from "@enhavo/app/vite/fantasticon-plugin/util.js";
+import { getHash } from "fantasticon/lib/utils/hash.js";
 
 const fontAssetTypes = [
     "svg",
@@ -69,6 +70,7 @@ async function assetBuilder(config, generateFonts) {
                 name: cfg.name,
                 assetVersion: cfg.assetVersion,
                 files: files,
+                hash: results.assetsOut.svg ? getHash(results.assetsOut.svg.toString('utf8')) : null,
             }));
         }
 

--- a/assets/node_modules/@enhavo/app/vite/fantasticon-settings.js
+++ b/assets/node_modules/@enhavo/app/vite/fantasticon-settings.js
@@ -6,7 +6,6 @@ export function fantasticonSetting(setting)
     let defaultSettings =  {
         name: "icon",
         inputDir: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../assets/icons'),
-        fontTypes: ["ttf", "woff", "woff2"],
         assetTypes: ["css", "html"],
         prefix: 'icon',
         tag: '*',


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

provide fantasticon hash in `fantasticon.json`. Works only if svg is also an export format.
