### PR TITLE
[FormBundle] Fix autocomplete endpoint searching for the letter q if …

### DIFF
--- a/src/Enhavo/Bundle/FormBundle/Endpoint/AutoCompleteEndpointType.php
+++ b/src/Enhavo/Bundle/FormBundle/Endpoint/AutoCompleteEndpointType.php
@@ -31,7 +31,7 @@ class AutoCompleteEndpointType extends AbstractEndpointType
 
     public function handleRequest($options, Request $request, Data $data, Context $context): void
     {
-        $term = $request->get('q', $options['term_key']);
+        $term = $request->get($options['term_key'], '');
         $page = $request->get('page', 1);
 
         $entities = $this->getEntities($options, $request, $term);


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

[FormBundle] Fix autocomplete endpoint searching for the letter q if the search parameter is missing
