### PR TITLE
[AppBundle] Enable support for content type text/plain in mailer config

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/Mailer/MailerManager.php
+++ b/src/Enhavo/Bundle/AppBundle/Mailer/MailerManager.php
@@ -149,6 +149,8 @@ class MailerManager
             if (Message::CONTENT_TYPE_MIXED === $message->getContentType()) {
                 $email->html($template->renderBlock('text_html', $message->getContext()));
                 $email->text($template->renderBlock('text_plain', $message->getContext()));
+            } elseif (Message::CONTENT_TYPE_PLAIN === $message->getContentType()) {
+                $email->text($template->render($message->getContext()));
             } else {
                 $email->html($template->render($message->getContext()));
             }

--- a/src/Enhavo/Bundle/AppBundle/Tests/Mailer/MailerManagerTest.php
+++ b/src/Enhavo/Bundle/AppBundle/Tests/Mailer/MailerManagerTest.php
@@ -130,7 +130,7 @@ class MailerManagerTest extends TestCase
         $manager = $this->createInstance($dependencies);
 
         $dependencies->mailer->expects($this->once())->method('send')->willReturnCallback(function (Email $email): void {
-            $this->assertEquals('__text__', $email->getHtmlBody());
+            $this->assertEquals('__text__', $email->getTextBody());
             $this->assertEquals('__subject__trans', $email->getSubject());
             $this->assertEquals('cc1@test.de', $email->getCc()[0]->getAddress());
             $this->assertEquals('cc2@test.de', $email->getCc()[1]->getAddress());


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Enable support for content type text/plain in mailer config
