### PR TITLE
refactor: reference subscriber

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "doctrine/collections": "^1.8",
     "doctrine/dbal": "^3.6",
     "doctrine/doctrine-migrations-bundle": "^3.1",
-    "doctrine/orm": "^2.20",
+    "doctrine/orm": "^2.20.6",
     "ezyang/htmlpurifier": "^4.12",
     "imagine/imagine": "^1.2",
     "johngrogg/ics-parser": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "doctrine/collections": "^1.8",
     "doctrine/dbal": "^3.6",
     "doctrine/doctrine-migrations-bundle": "^3.1",
-    "doctrine/orm": "^2.14",
+    "doctrine/orm": "^2.20",
     "ezyang/htmlpurifier": "^4.12",
     "imagine/imagine": "^1.2",
     "johngrogg/ics-parser": "^2.2",

--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\Event\PrePersistEventArgs;
 use Doctrine\ORM\Event\PreRemoveEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\Proxy;
 use Enhavo\Bundle\DoctrineExtensionBundle\EntityResolver\EntityResolverInterface;
 use Enhavo\Bundle\DoctrineExtensionBundle\Metadata\Metadata;
@@ -32,14 +33,23 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  *
  * A reference extension for doctrine, to reference multiple entities within one property.
  */
-class ReferenceSubscriber implements EventSubscriber
+readonly class ReferenceSubscriber implements EventSubscriber
 {
-    private array $scheduleDeleted = [];
-
     public function __construct(
         private readonly MetadataRepository $metadataRepository,
         private readonly EntityResolverInterface $entityResolver,
     ) {
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            Events::postLoad,
+            Events::preFlush,
+            Events::postFlush,
+            Events::prePersist,
+            Events::preRemove,
+        ];
     }
 
     private function getMetadata($object): ?Metadata
@@ -69,15 +79,13 @@ class ReferenceSubscriber implements EventSubscriber
         return $data;
     }
 
-    public function getSubscribedEvents(): array
+    private function getClass($object): string
     {
-        return [
-            Events::postLoad,
-            Events::preFlush,
-            Events::postFlush,
-            Events::preRemove,
-            Events::prePersist,
-        ];
+        if ($object instanceof Proxy) {
+            return get_parent_class($object);
+        }
+
+        return get_class($object);
     }
 
     public function postLoad(PostLoadEventArgs $args): void
@@ -86,7 +94,7 @@ class ReferenceSubscriber implements EventSubscriber
 
         $object = $args->getObject();
 
-        $metadata = $this->getMetadata($object);
+        $metadata = $this->getMetadata($this->getClass($object));
         if (null === $metadata) {
             return;
         }
@@ -94,26 +102,6 @@ class ReferenceSubscriber implements EventSubscriber
         if ($this->getClass($object) === $metadata->getClassName() || $this->isParentClass($object, $metadata->getClassName())) {
             foreach ($metadata->getReferences() as $reference) {
                 $this->loadEntity($reference, $object);
-            }
-        }
-    }
-
-    public function prePersist(PrePersistEventArgs $args): void
-    {
-    }
-
-    public function preRemove(PreRemoveEventArgs $args): void
-    {
-        $metadata = $this->getMetadata($args->getObject());
-        if (null !== $metadata) {
-            foreach ($metadata->getReferences() as $reference) {
-                if ($reference->hasCascade(Reference::CASCADE_REMOVE)) {
-                    $propertyAccessor = PropertyAccess::createPropertyAccessor();
-                    $targetEntity = $propertyAccessor->getValue($args->getObject(), $reference->getProperty());
-                    if (null !== $targetEntity) {
-                        $args->getObjectManager()->remove($targetEntity);
-                    }
-                }
             }
         }
     }
@@ -144,50 +132,72 @@ class ReferenceSubscriber implements EventSubscriber
         }
     }
 
-    /**
-     * Update entity before flush to prevent possible changes after flush
-     */
+    public function prePersist(PrePersistEventArgs $args): void
+    {
+        $uow = $args->getObjectManager()->getUnitOfWork();
+
+        $metadata = $this->getMetadata($args->getObject());
+        if ($metadata !== null) {
+            foreach ($metadata->getReferences() as $reference) {
+                if ($reference->hasCascade(Reference::CASCADE_PERSIST)) {
+                    $propertyAccessor = PropertyAccess::createPropertyAccessor();
+                    $targetEntity = $propertyAccessor->getValue($args->getObject(), $reference->getProperty());
+                    if ($targetEntity !== null &&
+                        !$uow->isInIdentityMap($targetEntity) &&
+                        !$uow->isScheduledForDelete($targetEntity) &&
+                        !$uow->isScheduledForInsert($targetEntity)
+                    ) {
+                        $uow->persist($targetEntity);
+                    }
+                }
+            }
+        }
+    }
+
+    public function preRemove(PreRemoveEventArgs $args): void
+    {
+        $metadata = $this->getMetadata($args->getObject());
+        if ($metadata !== null) {
+            foreach ($metadata->getReferences() as $reference) {
+                if ($reference->hasCascade(Reference::CASCADE_REMOVE)) {
+                    $propertyAccessor = PropertyAccess::createPropertyAccessor();
+                    $targetEntity = $propertyAccessor->getValue($args->getObject(), $reference->getProperty());
+                    if ($targetEntity !== null) {
+                        $args->getObjectManager()->remove($targetEntity);
+                    }
+                }
+            }
+        }
+    }
+
     public function preFlush(PreFlushEventArgs $args): void
     {
         $uow = $args->getObjectManager()->getUnitOfWork();
-        $em = $args->getObjectManager();
-        $identityMap = $uow->getIdentityMap();
+        $this->persistEntities($uow, $args->getObjectManager());
+    }
 
-        foreach ($em->getUnitOfWork()->getScheduledEntityDeletions() as $scheduledEntityDeletions) {
-            $this->scheduleDeleted[] = $scheduledEntityDeletions;
-        }
+    /**
+     * Check the identity map for entities with containing new references and persist them if cascade persists and the
+     * referenced entity is not persists or removed yet. This case happen if an entity received from a repository,
+     * and apply an entity as reference afterward, so a persist call was never triggered at this point
+     */
+    public function persistEntities(UnitOfWork $uow, ObjectManager $em): void
+    {
+        $identityMap = $uow->getIdentityMap();
 
         foreach ($this->getAllMetadata() as $metadata) {
             if (isset($identityMap[$metadata->getClassName()])) {
                 foreach ($identityMap[$metadata->getClassName()] as $entity) {
                     foreach ($metadata->getReferences() as $reference) {
-                        $this->updateEntity($reference, $entity);
                         if ($reference->hasCascade(Reference::CASCADE_PERSIST)) {
-                            $this->updatePersist($reference, $entity, $em);
-                        }
-                    }
-                }
-            }
-
-            foreach ($uow->getScheduledEntityInsertions() as $entity) {
-                if ($this->getClass($entity) === $metadata->getClassName()) {
-                    foreach ($metadata->getReferences() as $reference) {
-                        $this->updateEntity($reference, $entity);
-                        if ($reference->hasCascade(Reference::CASCADE_PERSIST)) {
-                            $this->updatePersist($reference, $entity, $em);
-                        }
-                    }
-                }
-            }
-
-            foreach ($em->getUnitOfWork()->getScheduledEntityDeletions() as $entity) {
-                if ($this->getClass($entity) === $metadata->getClassName()) {
-                    foreach ($metadata->getReferences() as $reference) {
-                        if ($reference->hasCascade(Reference::CASCADE_REMOVE)) {
                             $propertyAccessor = PropertyAccess::createPropertyAccessor();
                             $targetEntity = $propertyAccessor->getValue($entity, $reference->getProperty());
-                            if (null !== $targetEntity && !in_array($targetEntity, $this->scheduleDeleted)) {
-                                $em->remove($targetEntity);
+                            if (null !== $targetEntity &&
+                                !$uow->isInIdentityMap($targetEntity) &&
+                                !$uow->isScheduledForDelete($targetEntity) &&
+                                !$uow->isScheduledForInsert($targetEntity)
+                            ) {
+                                $em->persist($targetEntity);
                             }
                         }
                     }
@@ -196,28 +206,11 @@ class ReferenceSubscriber implements EventSubscriber
         }
     }
 
-    private function updatePersist(Reference $reference, $entity, EntityManagerInterface $em): void
-    {
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        $targetProperty = $propertyAccessor->getValue($entity, $reference->getProperty());
-
-        if ($targetProperty
-            && UnitOfWork::STATE_MANAGED !== $em->getUnitOfWork()->getEntityState($targetProperty) // is not managed yet
-            && !in_array($targetProperty, $this->scheduleDeleted) // should not be deleted
-            && $reference->hasCascade(Reference::CASCADE_PERSIST)
-        ) {
-            $em->persist($targetProperty);
-        }
-    }
-
     public function postFlush(PostFlushEventArgs $args): void
     {
         // Check if entity is not up-to-date and execute changes
-
-        $persist = false;
         $changes = [];
 
-        $em = $args->getObjectManager();
         $uow = $args->getObjectManager()->getUnitOfWork();
         $result = $uow->getIdentityMap();
 
@@ -225,21 +218,9 @@ class ReferenceSubscriber implements EventSubscriber
             if (isset($result[$metadata->getClassName()])) {
                 foreach ($result[$metadata->getClassName()] as $entity) {
                     foreach ($metadata->getReferences() as $reference) {
-                        $entityChanges = $this->updateEntity($reference, $entity);
+                        $entityChanges = $this->calculateChanges($reference, $entity);
                         foreach ($entityChanges as $entityChange) {
                             $changes[] = $entityChange;
-                        }
-
-                        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-                        $targetProperty = $propertyAccessor->getValue($entity, $reference->getProperty());
-
-                        if ($targetProperty
-                            && UnitOfWork::STATE_MANAGED !== $uow->getEntityState($targetProperty) // is not managed yet
-                            && !in_array($targetProperty, $this->scheduleDeleted) // should not be deleted
-                            && $reference->hasCascade(Reference::CASCADE_PERSIST) // should persist
-                        ) {
-                            $em->persist($targetProperty);
-                            $persist = true;
                         }
                     }
                 }
@@ -249,18 +230,12 @@ class ReferenceSubscriber implements EventSubscriber
         if (count($changes)) {
             $this->executeChanges($changes, $args->getObjectManager());
         }
-
-        if ($persist) {
-            $em->flush();
-        }
-
-        $this->scheduleDeleted = [];
     }
 
     /**
-     * Update entity values
+     * @return ReferenceChange[]
      */
-    private function updateEntity(Reference $reference, object $entity): array
+    private function calculateChanges(Reference $reference, object $entity): array
     {
         $changes = [];
 
@@ -334,18 +309,5 @@ class ReferenceSubscriber implements EventSubscriber
         foreach ($queries as $query) {
             $query->execute();
         }
-
-        foreach ($entities as $entity) {
-            $em->refresh($entity);
-        }
-    }
-
-    private function getClass($object): string
-    {
-        if ($object instanceof Proxy) {
-            return get_parent_class($object);
-        }
-
-        return get_class($object);
     }
 }

--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/Tests/EventListener/ReferenceSubscriberTest.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/Tests/EventListener/ReferenceSubscriberTest.php
@@ -518,6 +518,55 @@ class ReferenceSubscriberTest extends SubscriberTest
         $this->assertNotNull($entityOne->node);
         $this->assertNotNull($entityOne->node->entity);
     }
+
+    public function testDeleteSameEntity()
+    {
+        $this->bootstrap(__DIR__ . "/../Fixtures/Entity/Reference");
+
+        $dependencies = $this->createDependencies([
+            Entity::class => [
+                'reference' => [
+                    'node' => [
+                        'nameField' => 'nodeName',
+                        'idField' => 'nodeId',
+                        'cascade' => ['persist', 'remove']
+                    ]
+                ]
+            ]
+        ]);
+
+        $subscriber = $this->createInstance($dependencies);
+
+        $this->em->getEventManager()->addEventSubscriber($subscriber);
+        $this->updateSchema();
+
+        $nodeOne = new NodeBase();
+        $nodeOne->name = 'one';
+
+        $entityOne = new Entity();
+        $entityOne->name = 'one';
+        $entityOne->node = $nodeOne;
+
+        $entityTwo = new Entity();
+        $entityTwo->name = 'two';
+        $entityTwo->node = $nodeOne;
+
+        $this->em->persist($entityOne);
+        $this->em->persist($entityTwo);
+        $this->em->flush();
+        $this->em->clear();
+
+        $entityOne = $this->em->getRepository(Entity::class)->findOneBy(['name' => 'one']);
+        $entityTwo = $this->em->getRepository(Entity::class)->findOneBy(['name' => 'two']);
+
+        $this->em->remove($entityOne);
+        $this->em->flush();
+
+        $this->assertNull($this->em->getRepository(NodeEntity::class)->findOneBy(['name' => 'one']));
+
+        $this->em->remove($entityTwo);
+        $this->em->flush();
+    }
 }
 
 class ReferenceSubscriberDependencies

--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/composer.json
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/composer.json
@@ -13,7 +13,8 @@
   ],
   "require": {
     "php": "^8.2",
-    "enhavo/metadata": "^0.15"
+    "enhavo/metadata": "^0.15",
+    "doctrine/orm": "^2.20"
   },
   "autoload": {
     "psr-4": { "Enhavo\\Bundle\\DoctrineExtensionBundle\\": "" }

--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/composer.json
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.2",
     "enhavo/metadata": "^0.15",
-    "doctrine/orm": "^2.20"
+    "doctrine/orm": "^2.20.6"
   },
   "autoload": {
     "psr-4": { "Enhavo\\Bundle\\DoctrineExtensionBundle\\": "" }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | no
| BC-Break?    | no
| License      | MIT

Refactor the `ReferenceSubscriber` and make it more understandable by using the `prePersist` hook, instead of detecting unpersisted references on `postFlush` hook.  According to the docs, calling `flush` inside the hooks is deprecated and may prevent on future orm versions.
