### PR TITLE
[AppBundle] Fix flash messages type danger not getting shown

### DIFF
--- a/src/Enhavo/Bundle/AppBundle/View/ViewUtil.php
+++ b/src/Enhavo/Bundle/AppBundle/View/ViewUtil.php
@@ -204,12 +204,12 @@ class ViewUtil
     public function getFlashMessages()
     {
         $messages = [];
-        $types = ['success', 'error', 'notice', 'warning'];
+        $types = ['success', 'error', 'notice', 'warning', 'danger'];
         foreach($types as $type) {
             foreach($this->requestStack->getSession()->getFlashBag()->get($type) as $message) {
                 $messages[] = [
                     'message' => $this->translator->trans(is_array($message) ? $message['message'] : $message),
-                    'type' => $type
+                    'type' => $type === 'danger' ? 'error' : $type
                 ];
             }
         }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Fix flash messages type danger not getting shown
