### PR TITLE
fix: prepare compiler builder

### DIFF
--- a/packages/app/vite/rollup-plugin-container-di.js
+++ b/packages/app/vite/rollup-plugin-container-di.js
@@ -23,16 +23,19 @@ export default function (opts = {}) {
             if (!extensions.some((ext) => id.toLowerCase().endsWith(ext))) return null;
             if (!filter(id)) return null;
 
-            let loader = new Loader();
-            loader.loadFile(id, builder)
 
-            for (let loadedFile of loader.loadedFiles) {
-                if (fs.existsSync(loadedFile) && fs.lstatSync(loadedFile).isFile()) {
-                    this.addWatchFile(loadedFile);
+            if (!builder.isPrepared()) {
+                let loader = new Loader();
+                loader.loadFile(id, builder)
+
+                for (let loadedFile of loader.loadedFiles) {
+                    if (fs.existsSync(loadedFile) && fs.lstatSync(loadedFile).isFile()) {
+                        this.addWatchFile(loadedFile);
+                    }
                 }
+                await builder.prepare();
             }
 
-            await builder.prepare();
             let compiler = new Compiler;
             let resultData = compiler.compile(builder);
 

--- a/packages/dependency-injection/container/ContainerBuilder.js
+++ b/packages/dependency-injection/container/ContainerBuilder.js
@@ -17,6 +17,10 @@ export default class ContainerBuilder
     }
 
     addFile(file) {
+        if (this._prepared) {
+            throw 'Can\'t add file to prepared builder';
+        }
+
         this.files.push(file);
     }
 
@@ -55,6 +59,9 @@ export default class ContainerBuilder
      * @param {Definition} definition
      */
     addDefinition(definition) {
+        if (this._prepared) {
+            throw 'Can\'t add definition to prepared builder';
+        }
         this.definitions.add(definition.getName(), definition);
     }
 
@@ -85,6 +92,9 @@ export default class ContainerBuilder
      * @param {CompilerPass} compilerPass
      */
     addCompilerPass(compilerPass) {
+        if (this._prepared) {
+            throw 'Can\'t add compiler pass to prepared builder';
+        }
         this.compilerPasses.add(compilerPass.getName(), compilerPass);
     }
 
@@ -100,8 +110,6 @@ export default class ContainerBuilder
             return;
         }
 
-        this._prepared = true;
-
         let compilers = this.getCompilerPasses().sort((a, b) => {
             return b.priority - a.priority;
         });
@@ -114,11 +122,18 @@ export default class ContainerBuilder
                 throw 'Error occurred while using compiler pass "'+compilerPass.path+'" with error: ' + e + "\n" + e.stack;
             }
         }
+
+        this._prepared = true;
     }
 
     reset() {
+        this._prepared = false;
         this.definitions = new Map();
         this.compilerPasses = new Map();
         this.files = [];
+    }
+
+    isPrepared() {
+        return this._prepared
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Fix builder prepare. It should not be possible to manipulate the builder after it was prepared. A rollup transform should not load files into a prepared builder.