### PR TITLE
fix: ignore tags in route generator

### DIFF
--- a/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/GuessPrefixGenerator.php
+++ b/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/GuessPrefixGenerator.php
@@ -28,7 +28,7 @@ class GuessPrefixGenerator extends AbstractGenerator
             if (!$options['overwrite'] && $route->getStaticPrefix()) {
                 return;
             }
-            $route->setStaticPrefix(sprintf('/%s', Slugifier::slugify($value)));
+            $route->setStaticPrefix(sprintf('/%s', Slugifier::slugify(strip_tags($value))));
         }
     }
 

--- a/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/HierarchyPrefixGenerator.php
+++ b/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/HierarchyPrefixGenerator.php
@@ -35,9 +35,9 @@ class HierarchyPrefixGenerator extends AbstractGenerator
 
         $slugs = [];
         foreach (array_reverse($parents) as $parent) {
-            $slugs[] = Slugifier::slugify($this->getProperty($parent, $options['prefix_property']));
+            $slugs[] = Slugifier::slugify(strip_tags($this->getProperty($parent, $options['prefix_property'])));
         }
-        $slugs[] = Slugifier::slugify($this->getProperty($resource, $options['prefix_property']));
+        $slugs[] = Slugifier::slugify(strip_tags($this->getProperty($resource, $options['prefix_property'])));
         $route->setStaticPrefix('/'.implode('/', $slugs));
     }
 

--- a/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/PrefixGenerator.php
+++ b/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/PrefixGenerator.php
@@ -76,7 +76,7 @@ class PrefixGenerator extends AbstractGenerator
             $input = $input->format($options['date_format']);
         }
 
-        return Slugifier::slugify($input);
+        return Slugifier::slugify(strip_tags($input));
     }
 
     private function createPrefix(array $properties, $resource, array $options)

--- a/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/SlugGenerator.php
+++ b/src/Enhavo/Bundle/RoutingBundle/AutoGenerator/Generator/SlugGenerator.php
@@ -46,12 +46,12 @@ class SlugGenerator extends AbstractGenerator
 
     protected function createSlug($value, $resource, $options)
     {
-        return $options['unique'] ? $this->createUniqueSlug($value, $resource, $options) : Slugifier::slugify($value);
+        return $options['unique'] ? $this->createUniqueSlug($value, $resource, $options) : Slugifier::slugify(strip_tags($value));
     }
 
     protected function createUniqueSlug($value, $resource, $options)
     {
-        $baseSlug = Slugifier::slugify($value);
+        $baseSlug = Slugifier::slugify(strip_tags($value));
 
         if (!$this->slugExists($baseSlug, $resource, $options)) {
             return $baseSlug;


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Ignore tags in route generators
