### PR TITLE
feat: chain file not found handler

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/DependencyInjection/Compiler/ChainFileNotFoundHandlerServicePass.php
+++ b/src/Enhavo/Bundle/MediaBundle/DependencyInjection/Compiler/ChainFileNotFoundHandlerServicePass.php
@@ -25,7 +25,7 @@ class ChainFileNotFoundHandlerServicePass implements CompilerPassInterface
 
         $services = [];
         foreach ($container->findTaggedServiceIds('enhavo_media.file_not_found_handler') as $id => $tagAttributes) {
-            if ($id !== ChainFileNotFoundHandler::class) {
+            if (ChainFileNotFoundHandler::class !== $id) {
                 $services[$id] = new Reference($id);
             }
         }

--- a/src/Enhavo/Bundle/MediaBundle/DependencyInjection/Compiler/ChainFileNotFoundHandlerServicePass.php
+++ b/src/Enhavo/Bundle/MediaBundle/DependencyInjection/Compiler/ChainFileNotFoundHandlerServicePass.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\MediaBundle\DependencyInjection\Compiler;
+
+use Enhavo\Bundle\MediaBundle\FileNotFound\ChainFileNotFoundHandler;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ChainFileNotFoundHandlerServicePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $chainHandler = $container->findDefinition(ChainFileNotFoundHandler::class);
+
+        $services = [];
+        foreach ($container->findTaggedServiceIds('enhavo_media.file_not_found_handler') as $id => $tagAttributes) {
+            if ($id !== ChainFileNotFoundHandler::class) {
+                $services[$id] = new Reference($id);
+            }
+        }
+
+        $chainHandler->addMethodCall('setContainer', [ServiceLocatorTagPass::register($container, $services)]);
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/EnhavoMediaBundle.php
+++ b/src/Enhavo/Bundle/MediaBundle/EnhavoMediaBundle.php
@@ -12,7 +12,9 @@
 namespace Enhavo\Bundle\MediaBundle;
 
 use Enhavo\Bundle\AppBundle\Type\TypeCompilerPass;
+use Enhavo\Bundle\MediaBundle\DependencyInjection\Compiler\ChainFileNotFoundHandlerServicePass;
 use Enhavo\Bundle\MediaBundle\DependencyInjection\Compiler\MediaCompilerPass;
+use Enhavo\Bundle\MediaBundle\FileNotFound\FileNotFoundHandlerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,6 +23,11 @@ class EnhavoMediaBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new MediaCompilerPass());
+        $container->addCompilerPass(new ChainFileNotFoundHandlerServicePass());
+
+        $container
+            ->registerForAutoconfiguration(FileNotFoundHandlerInterface::class)
+            ->addTag('enhavo_media.file_not_found_handler');
 
         $container->addCompilerPass(
             new TypeCompilerPass('enhavo_media.extension_collector', 'enhavo.media_extension')

--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/ChainFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/ChainFileNotFoundHandler.php
@@ -33,7 +33,6 @@ use Psr\Container\ContainerInterface;
  *      'MyOtherFileNotFoundServiceWithParameters' => ['param1' => 'value1'],
  *   ]
  * ]
- *
  */
 class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
 {
@@ -49,6 +48,7 @@ class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
         foreach ($this->getHandlers($parameters) as $handlerData) {
             try {
                 $this->container->get($handlerData['handler'])->handleSave($file, $storage, $exception, $handlerData['parameters']);
+                return;
             } catch (FileException|StorageException|FileNotFoundException $e) {
                 // next handler
             }
@@ -62,6 +62,7 @@ class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
         foreach ($this->getHandlers($parameters) as $handlerData) {
             try {
                 $this->container->get($handlerData['handler'])->handleLoad($file, $storage, $exception, $handlerData['parameters']);
+                return;
             } catch (FileException|StorageException|FileNotFoundException $e) {
                 // next handler
             }
@@ -75,6 +76,7 @@ class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
         foreach ($this->getHandlers($parameters) as $handlerData) {
             try {
                 $this->container->get($handlerData['handler'])->handleDelete($file, $storage, $exception, $handlerData['parameters']);
+                return;
             } catch (FileException|StorageException|FileNotFoundException $e) {
                 // next handler
             }
@@ -88,6 +90,7 @@ class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
         foreach ($this->getHandlers($parameters) as $handlerData) {
             try {
                 $this->container->get($handlerData['handler'])->handleFileNotFound($file, $handlerData['parameters']);
+                return;
             } catch (FileException|StorageException|FileNotFoundException $e) {
                 // next handler
             }
@@ -97,8 +100,8 @@ class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
     }
 
     /**
-     * @return array of an array with key handler and parameters
-     * e.g.:
+     * @return array of an array with key handler and parameters e.g.:
+     *
      * [
      *   ["handler" => "service", "parameters" => []],
      *   ["handler" => "service2", "parameters" => []],
@@ -122,6 +125,7 @@ class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
                 }
             }
         }
+
         return $handlers;
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/ChainFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/ChainFileNotFoundHandler.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\MediaBundle\FileNotFound;
+
+use Enhavo\Bundle\MediaBundle\Exception\FileException;
+use Enhavo\Bundle\MediaBundle\Exception\FileNotFoundException;
+use Enhavo\Bundle\MediaBundle\Exception\StorageException;
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
+use Enhavo\Bundle\MediaBundle\Model\FormatInterface;
+use Enhavo\Bundle\MediaBundle\Storage\StorageInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Chain multiple FileNotFoundHandler.
+ *
+ * If one handler throw a FileException, StorageException or FileNotFoundException,
+ * then the next handler will be used.
+ *
+ * Define handlers over parameters like:
+ *
+ * [
+ *   "handlers" => [
+ *      'MyFileNotFoundService',
+ *      'MyOtherFileNotFoundServiceWithParameters' => ['param1' => 'value1'],
+ *   ]
+ * ]
+ *
+ */
+class ChainFileNotFoundHandler implements FileNotFoundHandlerInterface
+{
+    private ContainerInterface $container;
+
+    public function setContainer(ContainerInterface $container): void
+    {
+        $this->container = $container;
+    }
+
+    public function handleSave(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
+    {
+        foreach ($this->getHandlers($parameters) as $handlerData) {
+            try {
+                $this->container->get($handlerData['handler'])->handleSave($file, $storage, $exception, $handlerData['parameters']);
+            } catch (FileException|StorageException|FileNotFoundException $e) {
+                // next handler
+            }
+        }
+
+        throw new FileException('No FileNotFound handler can handle save');
+    }
+
+    public function handleLoad(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
+    {
+        foreach ($this->getHandlers($parameters) as $handlerData) {
+            try {
+                $this->container->get($handlerData['handler'])->handleLoad($file, $storage, $exception, $handlerData['parameters']);
+            } catch (FileException|StorageException|FileNotFoundException $e) {
+                // next handler
+            }
+        }
+
+        throw new FileException('No FileNotFound handler can handle load');
+    }
+
+    public function handleDelete(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
+    {
+        foreach ($this->getHandlers($parameters) as $handlerData) {
+            try {
+                $this->container->get($handlerData['handler'])->handleDelete($file, $storage, $exception, $handlerData['parameters']);
+            } catch (FileException|StorageException|FileNotFoundException $e) {
+                // next handler
+            }
+        }
+
+        throw new FileException('No FileNotFound handler can handle delete');
+    }
+
+    public function handleFileNotFound(FileInterface|FormatInterface $file, array $parameters = []): void
+    {
+        foreach ($this->getHandlers($parameters) as $handlerData) {
+            try {
+                $this->container->get($handlerData['handler'])->handleFileNotFound($file, $handlerData['parameters']);
+            } catch (FileException|StorageException|FileNotFoundException $e) {
+                // next handler
+            }
+        }
+
+        throw new FileException('No FileNotFound handler can handle file not found');
+    }
+
+    /**
+     * @return array of an array with key handler and parameters
+     * e.g.:
+     * [
+     *   ["handler" => "service", "parameters" => []],
+     *   ["handler" => "service2", "parameters" => []],
+     * ]
+     */
+    private function getHandlers(array $parameters): array
+    {
+        $handlers = [];
+        if (isset($parameters['handlers'])) {
+            foreach ($parameters['handlers'] as $key => $value) {
+                if (is_int($key)) {
+                    $handlers[] = [
+                        'handler' => $value,
+                        'parameters' => [],
+                    ];
+                } else {
+                    $handlers[] = [
+                        'handler' => $key,
+                        'parameters' => $value,
+                    ];
+                }
+            }
+        }
+        return $handlers;
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/RemoteFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/RemoteFileNotFoundHandler.php
@@ -42,7 +42,7 @@ class RemoteFileNotFoundHandler implements FileNotFoundHandlerInterface
         if ($file instanceof FileInterface) {
             $url = $serverUrl.$this->urlGenerator->generate($file);
         } else {
-            $url = $serverUrl.$this->urlGenerator->generate($file->getFile(), $file->getName());
+            $url = $serverUrl.$this->urlGenerator->generateFormat($file->getFile(), $file->getName());
         }
 
         $response = $this->client->request('GET', $url);

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
@@ -3,10 +3,18 @@ services:
 
     Enhavo\Bundle\MediaBundle\FileNotFound\RemoteFileNotFoundHandler:
         arguments:
-            - '@Enhavo\Bundle\MediaBundle\Routing\UrlGeneratorInterface'
+            - '@Enhavo\Bundle\MediaBundle\Routing\ThemeUrlGenerator'
             - '@http_client'
+        tags:
+            - { name: enhavo_media.file_not_found_handler }
 
     Enhavo\Bundle\MediaBundle\FileNotFound\CreateDummyFileNotFoundHandler:
         arguments:
             - '@filesystem'
             - '%kernel.project_dir%/var/media/dummy'
+        tags:
+            - { name: enhavo_media.file_not_found_handler }
+
+    Enhavo\Bundle\MediaBundle\FileNotFound\ChainFileNotFoundHandler:
+        tags:
+            - { name: enhavo_media.file_not_found_handler }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Add `ChainFileNotFoundHanlder` to allow chaining multiple file not found handlers
