### PR TITLE
[MediaBundle] Show svg images in media form instead of file icon

### DIFF
--- a/packages/media/components/FormMediaItem.vue
+++ b/packages/media/components/FormMediaItem.vue
@@ -2,7 +2,10 @@
     <div class="form-media-item" :class="{ 'edit-show': form.editOpen }" :ref="(el) => form.setElement(el as HTMLElement)">
         <div class="thumb" :class="{ 'drag-button' : sortable }" @click="toggleEdit" data-drag-thumb>
             <img v-if="isImage(form.file)" :src="form.path('enhavoPreviewThumb')" draggable="false" />
-            <div v-else><span class="icon" :class="'icon-'+getIcon(form.file)"></span></div>
+            <template v-else>
+                <img v-if="isSvg(form.file)" :src="form.path()" draggable="false" />
+                <div v-else><span class="icon" :class="'icon-'+getIcon(form.file)"></span></div>
+            </template>
         </div>
         <div v-if="deletable" class="delete-button" @click="$emit('delete', form)"><i class="icon icon-close"></i></div>
         <div class="edit-container" ref="editContainer"
@@ -64,6 +67,11 @@ function updateEditContainerSize()
 function isImage(file: File): boolean
 {
     return MediaUtil.isImage(props.form.file);
+}
+
+function isSvg(file: File): boolean
+{
+    return MediaUtil.isSvg(props.form.file);
 }
 
 function getIcon(file: File): string

--- a/packages/media/form/MediaUtil.ts
+++ b/packages/media/form/MediaUtil.ts
@@ -16,6 +16,11 @@ export class MediaUtil
         return false;
     }
 
+    static isSvg(file: File): boolean
+    {
+        return file.mimeType === 'image/svg+xml';
+    }
+
     static getIcon(file: File): string
     {
         switch (file.mimeType) {


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Show svg images in media form instead of file icon
