### PR TITLE
fix: insert entities that are not computed yet

### DIFF
--- a/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
+++ b/src/Enhavo/Bundle/DoctrineExtensionBundle/EventListener/ReferenceSubscriber.php
@@ -151,8 +151,13 @@ class ReferenceSubscriber implements EventSubscriber
                     ) {
                         $uow->persist($targetEntity);
                         if ($this->isFlush) {
-                            $metadata = $args->getObjectManager()->getClassMetadata(get_class($targetEntity));
-                            $uow->computeChangeSet($metadata, $targetEntity);
+                            // check insert entities that are not computed yet
+                            foreach ($uow->getScheduledEntityInsertions() as $object) {
+                                if (is_countable($uow->getEntityChangeSet($object)) && count($uow->getEntityChangeSet($object)) === 0) {
+                                    $metadata = $args->getObjectManager()->getClassMetadata(get_class($object));
+                                    $uow->computeChangeSet($metadata, $object);
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Fix insert entities that are not computed yet
