### PR TITLE
fix: fix unable to overwrite router with same name

### DIFF
--- a/src/Enhavo/Bundle/RoutingBundle/Metadata/Metadata.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Metadata/Metadata.php
@@ -48,7 +48,7 @@ class Metadata extends \Enhavo\Component\Metadata\Metadata
      */
     public function getRouter()
     {
-        return $this->router;
+        return array_values($this->router);
     }
 
     public function addRouter(Router $router)

--- a/src/Enhavo/Bundle/RoutingBundle/Metadata/Metadata.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Metadata/Metadata.php
@@ -53,6 +53,6 @@ class Metadata extends \Enhavo\Component\Metadata\Metadata
 
     public function addRouter(Router $router)
     {
-        $this->router[] = $router;
+        $this->router[$router->getName()] = $router;
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Fix not being able to overwrite router configuration with same name
