### PR TITLE
[TranslationBundle] Test translation field order

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
@@ -20,8 +20,7 @@ use Symfony\Component\Form\FormInterface;
 
 class ReplaceTranslationTypeListener implements EventSubscriberInterface
 {
-    /** @var TranslationManager */
-    private $translationManager;
+    private TranslationManager $translationManager;
 
     /**
      * ResizeTranslationListener constructor.
@@ -31,14 +30,14 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
         $this->translationManager = $translationManager;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::POST_SET_DATA => 'postSetData',
         ];
     }
 
-    public function postSetData(FormEvent $event)
+    public function postSetData(FormEvent $event): void
     {
         $form = $event->getForm();
         $data = $event->getData();
@@ -74,12 +73,15 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
             }
 
             if ($this->translationManager->isTranslatable($data, $property)) {
-                $this->replaceChild($data, $property, $form, $child);
+                $this->replaceWithTranslationField($data, $property, $form, $child);
+
+            } else { // replace all children to keep order as defined in the parent form type
+                $this->replaceWithRegularField($property, $form, $child);
             }
         }
     }
 
-    private function replaceChild($data, string $property, FormInterface $form, FormInterface $child)
+    private function replaceWithTranslationField($data, string $property, FormInterface $form, FormInterface $child): void
     {
         $options = $child->getConfig()->getOptions();
 
@@ -92,5 +94,12 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
             'label' => $options['label'],
             'translation_domain' => $options['translation_domain'],
         ]);
+    }
+
+
+    private function replaceWithRegularField(string $property, FormInterface $form, FormInterface $child): void
+    {
+        $form->remove($property);
+        $form->add($property, get_class($child->getConfig()->getType()->getInnerType()), $child->getConfig()->getOptions());
     }
 }

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/ReplaceTranslationTypeListenerTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/ReplaceTranslationTypeListenerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\TranslationBundle\Tests\EventListener;
+
+use Enhavo\Bundle\TranslationBundle\Entity\Translation;
+use Enhavo\Bundle\TranslationBundle\Form\EventListener\ReplaceTranslationTypeListener;
+use Enhavo\Bundle\TranslationBundle\Form\Type\TranslationType;
+use Enhavo\Bundle\TranslationBundle\Tests\Mocks\TranslatableMock;
+use Enhavo\Bundle\TranslationBundle\Translation\TranslationManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ReplaceTranslationTypeListenerTest extends TypeTestCase
+{
+    private ReplaceTranslationTypeListener $listener;
+    private ReplaceTranslationTypeListenerTestDependencies $dependencies;
+
+    protected function setUp(): void
+    {
+        $this->dependencies = $this->createDependencies();
+        $this->listener = $this->createInstance($this->dependencies);
+
+        parent::setUp();
+    }
+
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension([
+                new TranslatableMockFormType($this->listener),
+                new TranslationType($this->dependencies->translationManager),
+            ], []),
+        ];
+    }
+
+    protected function createDependencies(): ReplaceTranslationTypeListenerTestDependencies
+    {
+        $dependencies = new ReplaceTranslationTypeListenerTestDependencies();
+        $dependencies->translationManager = $this->getMockBuilder(TranslationManager::class)->disableOriginalConstructor()->getMock();
+
+        return $dependencies;
+    }
+
+    protected function createInstance($dependencies): ReplaceTranslationTypeListener
+    {
+        return new ReplaceTranslationTypeListener(
+            $dependencies->translationManager
+        );
+    }
+
+    public function testSubscribedEvents(): void
+    {
+        $subscriber = $this->createInstance($this->createDependencies());
+
+        $this->assertEquals([
+            FormEvents::POST_SET_DATA => 'postSetData',
+        ], $subscriber->getSubscribedEvents());
+    }
+
+    public function testPostSetDataTranslatable()
+    {
+        $this->dependencies->translationManager->expects($this->exactly(3))->method('isTranslatable')->willReturnCallback(function ($data, $property) {
+            if (!$property) {
+                return true;
+            }
+
+            return 'name' === $property;
+        });
+        $this->dependencies->translationManager->method('getLocales')->willReturn([
+            'de', 'en',
+        ]);
+        $this->dependencies->translationManager->method('getTranslations')->willReturnCallback(function ($data, $property) {
+            if ($property === 'name') {
+                return [
+                    'de' => new Translation(),
+                    'en' => new Translation(),
+                ];
+            }
+
+            return [];
+        });
+
+        $data = new TranslatableMock();
+        $form = $this->factory->create(TranslatableMockFormType::class, $data);
+
+        $fields = $form->all();
+        $keys = array_keys($fields);
+
+        $this->assertEquals([
+            'name',
+            'slug',
+        ], $keys);
+    }
+}
+
+class ReplaceTranslationTypeListenerTestDependencies
+{
+    public TranslationManager|MockObject $translationManager;
+}
+
+class TranslatableMockFormType extends AbstractType
+{
+    public function __construct(
+        private ReplaceTranslationTypeListener $listener,
+    ) {
+
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class);
+        $builder->add('slug', TextType::class);
+        $builder->addEventSubscriber($this->listener);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('data_class', TranslatableMock::class);
+    }
+}


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | no
| BC-Break?    | no
| License      | MIT

Add a UnitTest to enshure the correct order of form fields after replacement.
