### PR TITLE
Symlink enhanced storage

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Content/Content.php
+++ b/src/Enhavo/Bundle/MediaBundle/Content/Content.php
@@ -15,11 +15,14 @@ class Content extends AbstractContent
 {
     private $path;
 
-    public function __construct(?string $content = null)
+    public function __construct(?string $content = null, ?string $path = null)
     {
-        $tempPath = tempnam(sys_get_temp_dir(), 'Content');
-        file_put_contents($tempPath, $content ?? '');
-        $this->path = $tempPath;
+        if ($path === null) {
+            $path = tempnam(sys_get_temp_dir(), 'Content');
+        }
+
+        file_put_contents($path, $content ?? '');
+        $this->path = $path;
     }
 
     public function getContent()
@@ -30,12 +33,5 @@ class Content extends AbstractContent
     public function getFilePath()
     {
         return $this->path;
-    }
-
-    public function __destruct()
-    {
-        if (file_exists($this->path)) {
-            unlink($this->path);
-        }
     }
 }

--- a/src/Enhavo/Bundle/MediaBundle/Storage/SymlinkEnhancedFileStorage.php
+++ b/src/Enhavo/Bundle/MediaBundle/Storage/SymlinkEnhancedFileStorage.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Enhavo\Bundle\MediaBundle\Storage;
+
+use Enhavo\Bundle\MediaBundle\Content\ContentInterface;
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
+use Enhavo\Bundle\MediaBundle\Model\FormatInterface;
+use Enhavo\Bundle\MediaBundle\Routing\UrlGeneratorInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * The SymlinkEnhancedFileStorage acts as a wrapper around another storage service,
+ * delegating the actual file storage and retrieval operations to it while ensuring
+ * that files are also accessible through a symlink on a public path.
+ * This allows direct serving of media files through a web server without accessing php.
+ */
+class SymlinkEnhancedFileStorage implements StorageInterface
+{
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly string $publicDir,
+        private readonly StorageInterface $storage,
+        private readonly Filesystem $fs,
+    ) {
+    }
+
+    public function deleteContent(FormatInterface|FileInterface $file): void
+    {
+        $path = $this->getSymlinkPath($file);
+        if ($this->fs->exists($path)) {
+            $this->fs->remove($path);
+        }
+
+        $this->storage->deleteContent($file);
+    }
+
+    public function saveContent(FormatInterface|FileInterface $file): ContentInterface
+    {
+        $content = $this->storage->saveContent($file);
+
+        $path = $this->getSymlinkPath($file);
+
+        $dir = dirname($path);
+        if (!$this->fs->exists($dir)) {
+            $this->fs->mkdir($dir);
+        }
+
+        if (!$this->fs->exists($path)) {
+            $this->fs->symlink($content->getFilePath(), $path);
+        }
+
+        return $content;
+    }
+
+    public function getContent(FormatInterface|FileInterface $file): ContentInterface
+    {
+        return $this->storage->getContent($file);
+    }
+
+    private function getSymlinkPath(FormatInterface|FileInterface $file): string
+    {
+        if ($file instanceof FileInterface) {
+            $url = $this->urlGenerator->generate($file);
+        } else {
+            $url = $this->urlGenerator->generateFormat($file->getFile(), $file->getName());
+        }
+
+        return $this->publicDir . $url;
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Storage/SymlinkEnhancedFileStorage.php
+++ b/src/Enhavo/Bundle/MediaBundle/Storage/SymlinkEnhancedFileStorage.php
@@ -54,7 +54,19 @@ class SymlinkEnhancedFileStorage implements StorageInterface
 
     public function getContent(FormatInterface|FileInterface $file): ContentInterface
     {
-        return $this->storage->getContent($file);
+        $content = $this->storage->getContent($file);
+        $path = $this->getSymlinkPath($file);
+
+        $dir = dirname($path);
+        if (!$this->fs->exists($dir)) {
+            $this->fs->mkdir($dir);
+        }
+
+        if (!$this->fs->exists($path)) {
+            $this->fs->symlink($content->getFilePath(), $path);
+        }
+
+        return $content;
     }
 
     private function getSymlinkPath(FormatInterface|FileInterface $file): string

--- a/src/Enhavo/Bundle/MediaBundle/Tests/Storage/StorageMock.php
+++ b/src/Enhavo/Bundle/MediaBundle/Tests/Storage/StorageMock.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Enhavo\Bundle\MediaBundle\Tests\Storage;
+
+use Enhavo\Bundle\MediaBundle\Content\Content;
+use Enhavo\Bundle\MediaBundle\Content\ContentInterface;
+use Enhavo\Bundle\MediaBundle\Content\PathContent;
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
+use Enhavo\Bundle\MediaBundle\Model\FormatInterface;
+use Enhavo\Bundle\MediaBundle\Storage\StorageInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class StorageMock implements StorageInterface
+{
+    private Filesystem $fs;
+
+    public function __construct(
+        private readonly string $directory,
+    ) {
+        $this->fs = new Filesystem();
+    }
+
+    public function deleteContent(FormatInterface|FileInterface $file): void
+    {
+        $this->fs->remove($this->getPath($file));
+    }
+
+    public function saveContent(FormatInterface|FileInterface $file): ContentInterface
+    {
+        return new Content($file->getContent()->getContent(), $this->getPath($file));
+    }
+
+    public function getContent(FormatInterface|FileInterface $file): ContentInterface
+    {
+        return new PathContent($this->getPath($file));
+    }
+
+    protected function getPath(FormatInterface|FileInterface $file): string
+    {
+        return $this->directory.'/'.$file->getBasename();
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Tests/Storage/SymlinkEnhancedFileStorageTest.php
+++ b/src/Enhavo/Bundle/MediaBundle/Tests/Storage/SymlinkEnhancedFileStorageTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\MediaBundle\Tests\Storage;
+
+use Enhavo\Bundle\MediaBundle\Content\Content;
+use Enhavo\Bundle\MediaBundle\Entity\File;
+use Enhavo\Bundle\MediaBundle\Routing\UrlGeneratorInterface;
+use Enhavo\Bundle\MediaBundle\Storage\SymlinkEnhancedFileStorage;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Enhavo\Bundle\MediaBundle\Storage\StorageInterface;
+
+class SymlinkEnhancedFileStorageTest extends TestCase
+{
+    const STORAGE_DIR = __DIR__ . '/../fixtures/symlink-storage-test/storage';
+    const PUBLIC_DIR = __DIR__ . '/../fixtures/symlink-storage-test/public';
+
+    public function setUp(): void
+    {
+        $fs = new Filesystem();
+        if ($fs->exists(self::STORAGE_DIR)) {
+            $fs->remove(self::STORAGE_DIR);
+        }
+
+        if ($fs->exists(self::PUBLIC_DIR)) {
+            $fs->remove(self::PUBLIC_DIR);
+        }
+
+        $fs->mkdir(self::STORAGE_DIR);
+        $fs->mkdir(self::PUBLIC_DIR);
+    }
+
+    public function createDependencies()
+    {
+        $dependencies = new SymlinkEnhancedFileStorageDependencies();
+        $dependencies->urlGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->disableOriginalConstructor()->getMock();
+        $dependencies->publicDir = self::PUBLIC_DIR;
+        $dependencies->storage = new StorageMock(self::STORAGE_DIR);
+        $dependencies->fs = new Filesystem();
+
+        return $dependencies;
+    }
+
+    public function createInstance(SymlinkEnhancedFileStorageDependencies $dependencies)
+    {
+        $instance = new SymlinkEnhancedFileStorage(
+            $dependencies->urlGenerator,
+            $dependencies->publicDir,
+            $dependencies->storage,
+            $dependencies->fs,
+        );
+
+        return $instance;
+    }
+
+    public function testSaveContent()
+    {
+        $dependencies = $this->createDependencies();
+        $dependencies->urlGenerator->method('generate')->willReturn('/foobar');
+
+        $instance = $this->createInstance($dependencies);
+
+        $file = new File();
+        $file->setBasename('hello.txt');
+        $file->setContent(new Content('1'));
+
+        $instance->saveContent($file);
+
+        $this->assertEquals('1', file_get_contents(self::PUBLIC_DIR . '/foobar'));
+    }
+
+    public function testDeleteContent()
+    {
+        $dependencies = $this->createDependencies();
+        $dependencies->urlGenerator->method('generate')->willReturn('/foobar');
+
+        $instance = $this->createInstance($dependencies);
+
+        $file = new File();
+        $file->setBasename('hello.txt');
+        $file->setContent(new Content());
+
+        $instance->saveContent($file);
+
+        $this->assertTrue(file_exists(self::PUBLIC_DIR . '/foobar'));
+
+        $instance->deleteContent($file);
+
+        $this->assertFalse(file_exists(self::PUBLIC_DIR . '/foobar'));
+    }
+}
+
+class SymlinkEnhancedFileStorageDependencies
+{
+    public UrlGeneratorInterface|MockObject $urlGenerator;
+    public string $publicDir;
+    public StorageInterface $storage;
+    public Filesystem $fs;
+}

--- a/src/Enhavo/Bundle/MediaBundle/Tests/Storage/SymlinkEnhancedFileStorageTest.php
+++ b/src/Enhavo/Bundle/MediaBundle/Tests/Storage/SymlinkEnhancedFileStorageTest.php
@@ -79,6 +79,27 @@ class SymlinkEnhancedFileStorageTest extends TestCase
         $this->assertEquals('1', file_get_contents(self::PUBLIC_DIR . '/foobar'));
     }
 
+    public function testGetContent()
+    {
+        $dependencies = $this->createDependencies();
+        $dependencies->urlGenerator->method('generate')->willReturn('/foobar');
+
+        $instance = $this->createInstance($dependencies);
+
+        $file = new File();
+        $file->setBasename('hello.txt');
+        $file->setContent(new Content('1'));
+
+        $dependencies->storage->saveContent($file);
+
+        $this->assertFalse(file_exists(self::PUBLIC_DIR . '/foobar'));
+
+        $instance->getContent($file);
+
+        $this->assertTrue(file_exists(self::PUBLIC_DIR . '/foobar'));
+        $this->assertEquals('1', file_get_contents(self::PUBLIC_DIR . '/foobar'));
+    }
+
     public function testDeleteContent()
     {
         $dependencies = $this->createDependencies();

--- a/src/Enhavo/Bundle/MediaBundle/Tests/fixtures/.gitignore
+++ b/src/Enhavo/Bundle/MediaBundle/Tests/fixtures/.gitignore
@@ -1,0 +1,1 @@
+./symlink-storage-test


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| License      | MIT

Add `SymlinkEnhancedFileStorage` to wrap an existing storage and add symlinks to a public dir to have direct access to the file from a webserver without using php.
