### PR TITLE
fix: keeping query string on input redirect

### DIFF
--- a/packages/app/manager/ResourceInputManager.ts
+++ b/packages/app/manager/ResourceInputManager.ts
@@ -178,13 +178,20 @@ export class ResourceInputManager
 
     public async redirect(url: string)
     {
+        const activeTab = this.getActiveTab()?.key;
+        const targetUrl = new URL(url, window.location.origin);
+
+        if (activeTab) {
+            targetUrl.searchParams.set('tab', activeTab);
+        }
+
         await this.vueRouterFactory.getRouter().push({
-            path: url,
-            query: {tab: this.getActiveTab().key}
+            path: targetUrl.pathname,
+            query: Object.fromEntries(targetUrl.searchParams.entries()),
         });
 
         const frame = await this.frameManager.getFrame();
-        frame.url = url;
+        frame.url = targetUrl.toString();
         this.frameManager.save();
     }
 
@@ -255,7 +262,7 @@ export class ResourceInputManager
 
     private updateTabs()
     {
-        for(let tab of this.tabs) {
+        for (let tab of this.tabs) {
             tab.update({
                 form: this.form,
             });


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Fix: keep query string on input redirect. Checking also the active tab query string parameter.
