### PR TITLE
[BlockBundle] CleanUpCommand can't find revision resources

### DIFF
--- a/src/Enhavo/Bundle/BlockBundle/Command/CleanUpCommand.php
+++ b/src/Enhavo/Bundle/BlockBundle/Command/CleanUpCommand.php
@@ -11,6 +11,7 @@
 
 namespace Enhavo\Bundle\BlockBundle\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Enhavo\Bundle\AppBundle\Output\CliOutputLogger;
 use Enhavo\Bundle\BlockBundle\Block\BlockManager;
 use Symfony\Component\Console\Command\Command;
@@ -22,20 +23,17 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class CleanUpCommand extends Command
 {
     /**
-     * @var BlockManager
-     */
-    private $blockManager;
-
-    /**
      * CleanUpCommand constructor.
      */
-    public function __construct(BlockManager $blockManager)
-    {
+    public function __construct(
+        private BlockManager $blockManager,
+        private EntityManagerInterface $entityManager,
+    ) {
         $this->blockManager = $blockManager;
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('enhavo:block:clean-up')
@@ -44,14 +42,15 @@ class CleanUpCommand extends Command
         ;
     }
 
-    /**
-     * @throws \Exception
-     *
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $isDryRun = $input->getOption('dry-run');
+
+        // TODO: this is a workaround. in the future we need an interface to take care about the activated filters so that every such command can take care about which filters can stay active and which not
+        $filters = $this->entityManager->getFilters();
+        if ($filters->isEnabled('revision')) {
+            $filters->disable('revision');
+        }
 
         $this->blockManager->cleanUp(new CliOutputLogger(new SymfonyStyle($input, $output)), $isDryRun);
 

--- a/src/Enhavo/Bundle/BlockBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/config/app/config.yaml
@@ -91,7 +91,7 @@ enhavo_resource:
 
         Enhavo\Bundle\BlockBundle\Model\Block\BlockquoteBlock:
             properties:
-                title:
+                blockquote:
                     type: property
                     groups: [ 'duplicate', 'revision', 'restore' ]
                 author:

--- a/src/Enhavo/Bundle/BlockBundle/Resources/config/services/command.yaml
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/config/services/command.yaml
@@ -2,6 +2,7 @@ services:
     Enhavo\Bundle\BlockBundle\Command\CleanUpCommand:
         arguments:
             - '@Enhavo\Bundle\BlockBundle\Block\BlockManager'
+            - '@Doctrine\ORM\EntityManagerInterface'
         tags:
             - { name: console.command }
 


### PR DESCRIPTION
fix: inexistent field in BlockQuoteBlock duplicate config

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Revision doctrine filter avoided the command to find certain datasets what resultet in an error as Node entities were still found, but not their owning resources. Therefore the revision filter is now disabled during cleanup so that it has all data at hand to work with.
Also the inexistent "title" property config for revision-duplicate function was fixed to address the right property "blockquote"