### PR TITLE
Add possibility to enable/disable NavItems.

### DIFF
--- a/src/Enhavo/Bundle/NavigationBundle/NavItem/AbstractNavItemType.php
+++ b/src/Enhavo/Bundle/NavigationBundle/NavItem/AbstractNavItemType.php
@@ -65,6 +65,11 @@ abstract class AbstractNavItemType extends AbstractType implements NavItemTypeIn
         return $this->parent->render($options);
     }
 
+    public function isEnabled(array $options): bool
+    {
+        return $this->parent->isEnabled($options);
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
     }

--- a/src/Enhavo/Bundle/NavigationBundle/NavItem/NavItem.php
+++ b/src/Enhavo/Bundle/NavigationBundle/NavItem/NavItem.php
@@ -57,4 +57,9 @@ class NavItem extends AbstractContainerType
     {
         return $this->type->getTranslationDomain($this->options);
     }
+
+    public function isEnabled(): bool
+    {
+        return $this->type->isEnabled($this->options);
+    }
 }

--- a/src/Enhavo/Bundle/NavigationBundle/NavItem/NavItemManager.php
+++ b/src/Enhavo/Bundle/NavigationBundle/NavItem/NavItemManager.php
@@ -33,7 +33,13 @@ class NavItemManager
 
     public function getNavItems()
     {
-        return $this->items;
+        $enabledItems = [];
+        foreach ($this->items as $item) {
+            if ($item->isEnabled()) {
+                $enabledItems[] = $item;
+            }
+        }
+        return $enabledItems;
     }
 
     public function getNavItem($name)

--- a/src/Enhavo/Bundle/NavigationBundle/NavItem/NavItemTypeInterface.php
+++ b/src/Enhavo/Bundle/NavigationBundle/NavItem/NavItemTypeInterface.php
@@ -32,4 +32,6 @@ interface NavItemTypeInterface extends TypeInterface
     public function getComponent($options);
 
     public function render($options);
+
+    public function isEnabled(array $options): bool;
 }

--- a/src/Enhavo/Bundle/NavigationBundle/NavItem/Type/NavItemType.php
+++ b/src/Enhavo/Bundle/NavigationBundle/NavItem/Type/NavItemType.php
@@ -68,6 +68,11 @@ class NavItemType extends AbstractType implements NavItemTypeInterface
         return '';
     }
 
+    public function isEnabled(array $options): bool
+    {
+        return $options['enabled'];
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -75,6 +80,7 @@ class NavItemType extends AbstractType implements NavItemTypeInterface
             'template' => null,
             'component' => null,
             'form_options' => [],
+            'enabled' => true,
         ]);
 
         $resolver->setRequired([


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| License      | MIT

Adds the ability to enable or disable navigation items. You can now use the “enabled” option in the configuration (default: “true”) to disable specific items.
