### PR TITLE
[PageBundle] fix: finding specials with empty special property

### DIFF
--- a/src/Enhavo/Bundle/PageBundle/Repository/PageRepository.php
+++ b/src/Enhavo/Bundle/PageBundle/Repository/PageRepository.php
@@ -27,6 +27,7 @@ class PageRepository extends ContentRepository
             ->andWhere('p.publicationDate <= :currentDate')
             ->andWhere('p.publishedUntil >= :currentDate OR p.publishedUntil IS NULL')
             ->andWhere('p.special IS NOT NULL')
+            ->andWhere('p.special <> \'\'')
             ->setParameter('currentDate', new \DateTime())
         ;
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

PageRepository searched for pages with nullish special but did not also consider empty as invalid.
