### PR TITLE
fix: Ensure that LocalChecksumFileStorage always returns PathContent

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Storage/LocalChecksumFileStorage.php
+++ b/src/Enhavo/Bundle/MediaBundle/Storage/LocalChecksumFileStorage.php
@@ -61,7 +61,7 @@ class LocalChecksumFileStorage implements StorageInterface, StorageChecksumInter
 
         if ($file instanceof FileInterface) {
             if ($this->filesystem->exists($path)) {
-                return $file->getContent();
+                return new PathContent($path);
             }
         }
 


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

Ensure that LocalChecksumFileStorage always returns PathContent