### PR TITLE
fix: Ensure that PathContent file path does not contain symlink

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Content/PathContent.php
+++ b/src/Enhavo/Bundle/MediaBundle/Content/PathContent.php
@@ -19,7 +19,7 @@ class PathContent extends AbstractContent
 
     public function __construct($path)
     {
-        $this->path = $path;
+        $this->path = realpath($path);
     }
 
     public function getContent()


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | yes
| License      | MIT

Ensure that PathContent file path does not contain symlink
