### PR TITLE
[SearchBundle] add missing serialization config for search results

### DIFF
--- a/src/Enhavo/Bundle/SearchBundle/Resources/config/serialization.yaml
+++ b/src/Enhavo/Bundle/SearchBundle/Resources/config/serialization.yaml
@@ -1,0 +1,8 @@
+Enhavo\Bundle\SearchBundle\Result\Result:
+    attributes:
+        title:
+            groups: ['endpoint', 'endpoint.block']
+        text:
+            groups: ['endpoint', 'endpoint.block']
+        subject:
+            groups: ['endpoint', 'endpoint.block']


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Search Result must be serializable by default.
