### PR TITLE
[MultiTenancyBundle] Fix Tenantmanager.disableDoctrineFilter discarding the parameter…

### DIFF
--- a/src/Enhavo/Bundle/MultiTenancyBundle/Tenant/TenantManager.php
+++ b/src/Enhavo/Bundle/MultiTenancyBundle/Tenant/TenantManager.php
@@ -58,11 +58,11 @@ class TenantManager
 
     public function disableDoctrineFilter()
     {
-        $this->entityManager->getFilters()->disable('tenant');
+        $this->entityManager->getFilters()->suspend('tenant');
     }
 
     public function enableDoctrineFilter()
     {
-        $this->entityManager->getFilters()->enable('tenant');
+        $this->entityManager->getFilters()->restore('tenant');
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

 Fix Tenantmanager.disableDoctrineFilter discarding the parameters of the filter, making it unable to word if re-enabled
