### PR TITLE
feat!: add url translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     "symfony/mime": "^6.4",
     "symfony/monolog-bundle": "^3.1",
     "symfony/orm-pack": "^1.0",
+    "symfony/options-resolver": "^6.4",
     "symfony/password-hasher": "^6.4",
     "symfony/process": "^6.4",
     "symfony/property-info": "^6.4",

--- a/src/Enhavo/Bundle/TranslationBundle/Client/ChainTranslationClient.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Client/ChainTranslationClient.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Enhavo\Bundle\TranslationBundle\Client;
+
+class ChainTranslationClient implements TranslationClientInterface
+{
+    /** @var TranslationClientInterface[] */
+    private array $clients = [];
+
+    public function translate(string $text, string $sourceLanguage, string $targetLanguage, array $options = []): ?string
+    {
+        if (count($this->clients) === 0) {
+            return null;
+        }
+
+        foreach ($this->clients as $client) {
+            $text = $client->translate($text, $sourceLanguage, $targetLanguage, $options);
+            if ($text === null) {
+                return null;
+            }
+        }
+
+        return $text;
+    }
+
+    public function addClient(TranslationClientInterface $client): void
+    {
+        $this->clients[] = $client;
+    }
+}

--- a/src/Enhavo/Bundle/TranslationBundle/Client/DeeplTranslationClient.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Client/DeeplTranslationClient.php
@@ -15,7 +15,7 @@ class DeeplTranslationClient implements TranslationClientInterface
     {
     }
 
-    public function translate(string $text, string $sourceLanguage, string $targetLanguage, array $options = []): string
+    public function translate(string $text, string $sourceLanguage, string $targetLanguage, array $options = []): ?string
     {
         $options = $this->getOptions($options);
 

--- a/src/Enhavo/Bundle/TranslationBundle/Client/TranslationClientInterface.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Client/TranslationClientInterface.php
@@ -4,5 +4,5 @@ namespace Enhavo\Bundle\TranslationBundle\Client;
 
 interface TranslationClientInterface
 {
-    public function translate(string $text, string $sourceLanguage, string $targetLanguage, array $options = []): string;
+    public function translate(string $text, string $sourceLanguage, string $targetLanguage, array $options = []): ?string;
 }

--- a/src/Enhavo/Bundle/TranslationBundle/Client/UrlTranslationClient.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Client/UrlTranslationClient.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Enhavo\Bundle\TranslationBundle\Client;
+
+
+use Doctrine\ORM\EntityRepository;
+use Enhavo\Bundle\TranslationBundle\Translation\TranslationManager;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UrlTranslationClient implements TranslationClientInterface
+{
+    public function __construct(
+        private readonly EntityRepository $routeRepository,
+        private readonly TranslationManager $translationManager,
+        private readonly array $domains,
+    ) {
+    }
+
+    public function translate(string $text, string $sourceLanguage, string $targetLanguage, array $options = []): ?string
+    {
+        $options = $this->getOptions($options);
+
+        if ($options['ignore_urls']) {
+            return $text;
+        }
+
+        $pattern = '~<a\s+[^>]*href=["\']([^"\']+)["\'][^>]*>.*?</a>~i';
+
+        return preg_replace_callback($pattern, function ($matches) use ($targetLanguage) {
+            $url = $matches[1];
+
+            if (str_starts_with($url, '/') || $this->containsDomain($url)) {
+                $path = $this->getPath($url);
+
+                $routes = $this->routeRepository->findBy(['staticPrefix' => $path], null, 1);
+                if (count($routes) > 0) {
+                    $route = $routes[0];
+                    $content = $route->getContent();
+                    $newPath = $this->translationManager->getProperty($content, 'route', $targetLanguage);
+                    if ($newPath != null) {
+                        return str_replace($matches[1], $newPath->getStaticPrefix(), $matches[0]);
+                    }
+                }
+            }
+
+            return $matches[0];
+        }, $text);
+    }
+
+    private function getPath(string $link): string
+    {
+        if (str_starts_with($link, '/')) {
+            return $link;
+        }
+
+        $pattern = '~https?://[^/]+(/[^"]*)~i';
+        preg_match($pattern, $link, $matches);
+        return $matches[1];
+    }
+
+    private function containsDomain($url): bool
+    {
+        foreach ($this->domains as $domain) {
+            $host = parse_url($url, PHP_URL_HOST);
+            if ($host === $domain) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function getOptions($options): array
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setIgnoreUndefined();
+        $resolver->setDefaults([
+            'ignore_urls' => false
+        ]);
+        return $resolver->resolve($options);
+    }
+}

--- a/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/Compiler/ChainTranslationClientCompilerPass.php
+++ b/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/Compiler/ChainTranslationClientCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\TranslationBundle\DependencyInjection\Compiler;
+
+use Enhavo\Bundle\TranslationBundle\Client\ChainTranslationClient;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ChainTranslationClientCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $clients = $container->getParameter('enhavo_translation.translation_client.chain.clients');
+        $chain = $container->getDefinition(ChainTranslationClient::class);
+
+        foreach ($clients as $client) {
+            $definition = $container->getDefinition($client);
+            $chain->addMethodCall('addClient', [$definition]);
+        }
+    }
+}

--- a/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/Configuration.php
@@ -11,7 +11,9 @@
 
 namespace Enhavo\Bundle\TranslationBundle\DependencyInjection;
 
+use Enhavo\Bundle\TranslationBundle\Client\ChainTranslationClient;
 use Enhavo\Bundle\TranslationBundle\Client\DeeplTranslationClient;
+use Enhavo\Bundle\TranslationBundle\Client\UrlTranslationClient;
 use Enhavo\Bundle\TranslationBundle\Locale\ConfigurationLocaleProvider;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -75,11 +77,25 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('translation_client')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('client')->defaultValue(DeeplTranslationClient::class)->end()
+                        ->scalarNode('client')->defaultValue(ChainTranslationClient::class)->end()
                         ->arrayNode('deepl')
                             ->children()
                                 ->scalarNode('api_key')->end()
                                 ->scalarNode('glossary_id')->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('url')
+                            ->children()
+                                ->arrayNode('domains')
+                                    ->scalarPrototype()->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('chain')
+                            ->children()
+                                ->arrayNode('clients')
+                                    ->scalarPrototype()->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/EnhavoTranslationExtension.php
+++ b/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/EnhavoTranslationExtension.php
@@ -39,6 +39,8 @@ class EnhavoTranslationExtension extends Extension implements PrependExtensionIn
         $container->setParameter('enhavo_translation.translation_client.client', $config['translation_client']['client']);
         $container->setParameter('enhavo_translation.translation_client.deepl.api_key', $config['translation_client']['deepl']['api_key'] ?? null);
         $container->setParameter('enhavo_translation.translation_client.deepl.glossary_id', $config['translation_client']['deepl']['glossary_id'] ?? null);
+        $container->setParameter('enhavo_translation.translation_client.url.domains', $config['translation_client']['url']['domains'] ?? []);
+        $container->setParameter('enhavo_translation.translation_client.chain.clients', $config['translation_client']['chain']['clients'] ?? []);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services/translator.yaml');

--- a/src/Enhavo/Bundle/TranslationBundle/EnhavoTranslationBundle.php
+++ b/src/Enhavo/Bundle/TranslationBundle/EnhavoTranslationBundle.php
@@ -12,6 +12,7 @@
 namespace Enhavo\Bundle\TranslationBundle;
 
 use Enhavo\Bundle\AppBundle\Type\TypeCompilerPass;
+use Enhavo\Bundle\TranslationBundle\DependencyInjection\Compiler\ChainTranslationClientCompilerPass;
 use Enhavo\Bundle\TranslationBundle\DependencyInjection\Compiler\LocaleProviderAliasCompilerPass;
 use Enhavo\Bundle\TranslationBundle\DependencyInjection\Compiler\TranslationClientAliasCompilerPass;
 use Enhavo\Bundle\TranslationBundle\Translation\Translation;
@@ -32,5 +33,6 @@ class EnhavoTranslationBundle extends Bundle
 
         $container->addCompilerPass(new LocaleProviderAliasCompilerPass());
         $container->addCompilerPass(new TranslationClientAliasCompilerPass());
+        $container->addCompilerPass(new ChainTranslationClientCompilerPass());
     }
 }

--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/app/config.yaml
@@ -8,6 +8,11 @@ enhavo_translation:
         default_access: true
         access_control:
             - '#^/admin/.+#'
+    translation_client:
+        chain:
+            clients:
+                - Enhavo\Bundle\TranslationBundle\Client\DeeplTranslationClient
+                - Enhavo\Bundle\TranslationBundle\Client\UrlTranslationClient
 
 enhavo_app:
     locale_resolver: Enhavo\Bundle\TranslationBundle\Locale\LocalePathResolver

--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/general.yaml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/general.yaml
@@ -32,6 +32,16 @@ services:
             - '%enhavo_translation.translation_client.deepl.api_key%'
             - '%enhavo_translation.translation_client.deepl.glossary_id%'
 
+    Enhavo\Bundle\TranslationBundle\Client\ChainTranslationClient:
+        arguments:
+            - '%enhavo_translation.translation_client.chain.clients%'
+
+    Enhavo\Bundle\TranslationBundle\Client\UrlTranslationClient:
+        arguments:
+            - '@enhavo_routing.route.repository'
+            - '@Enhavo\Bundle\TranslationBundle\Translation\TranslationManager'
+            - '%enhavo_translation.translation_client.url.domains%'
+
     Enhavo\Bundle\TranslationBundle\Action\TranslateActionType:
         tags:
             - { name: enhavo_resource.action }

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Client/UrlTranslationClientTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Client/UrlTranslationClientTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\TranslationBundle\Tests\Client;
+
+use Doctrine\ORM\EntityRepository;
+use Enhavo\Bundle\RoutingBundle\Entity\Route;
+use Enhavo\Bundle\TranslationBundle\Client\UrlTranslationClient;
+use Enhavo\Bundle\TranslationBundle\Client\TranslationClientInterface;
+use Enhavo\Bundle\TranslationBundle\Translation\TranslationManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UrlTranslationClientTest extends TestCase
+{
+    public function createDependencies()
+    {
+        $dependencies = new UrlTranslationClientDependencies();
+        $dependencies->routeRepository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
+        $dependencies->translationManager = $this->getMockBuilder(TranslationManager::class)->disableOriginalConstructor()->getMock();
+        $dependencies->domains = [];
+
+        return $dependencies;
+    }
+
+    public function createInstance(UrlTranslationClientDependencies $dependencies)
+    {
+        $instance = new UrlTranslationClient(
+            $dependencies->routeRepository,
+            $dependencies->translationManager,
+            $dependencies->domains,
+        );
+
+        return $instance;
+    }
+
+    private function configureDependencies(UrlTranslationClientDependencies $dependencies)
+    {
+        $dependencies->routeRepository->method('findBy')->willReturnCallback(function ($parameters) {
+            if ($parameters['staticPrefix'] === '/test') {
+                return [(new Route())
+                    ->setStaticPrefix('/test')
+                    ->setContent(new \stdClass())
+                ];
+            }
+            return [];
+        });
+
+        $dependencies->translationManager->method('getProperty')->willReturnCallback(function ($content, $property, $targetLang) {
+            if ($content instanceof \stdClass && $property === 'route' && $targetLang === 'en') {
+                return (new Route())
+                    ->setStaticPrefix('/en/test');
+            }
+            return null;
+        });
+
+        $dependencies->domains = ['domain.tld'];
+    }
+
+    public function testTranslateWithDomain()
+    {
+        $dependencies = $this->createDependencies();
+        $this->configureDependencies($dependencies);
+        $instance = $this->createInstance($dependencies);
+
+        $text = 'Lorem ipsum dolor sit amet, <a href="http://domain.tld/test">consectetur</a> adipiscing elit';
+        $translatedText = $instance->translate($text, 'de', 'en');
+
+        $this->assertEquals('Lorem ipsum dolor sit amet, <a href="/en/test">consectetur</a> adipiscing elit', $translatedText);
+    }
+
+    public function testTranslateWithoutDomain()
+    {
+        $dependencies = $this->createDependencies();
+        $this->configureDependencies($dependencies);
+        $instance = $this->createInstance($dependencies);
+
+        $text = 'Lorem ipsum dolor sit amet, <a href="/test">consectetur</a> adipiscing elit';
+        $translatedText = $instance->translate($text, 'de', 'en');
+
+        $this->assertEquals('Lorem ipsum dolor sit amet, <a href="/en/test">consectetur</a> adipiscing elit', $translatedText);
+    }
+
+    public function testPreventTranslationWithDomain()
+    {
+        $dependencies = $this->createDependencies();
+        $this->configureDependencies($dependencies);
+        $instance = $this->createInstance($dependencies);
+
+        $text = 'Lorem ipsum dolor sit amet, <a href="http://domain.tld2/test">consectetur</a> adipiscing elit';
+        $translatedText = $instance->translate($text, 'de', 'en');
+
+        $this->assertEquals('Lorem ipsum dolor sit amet, <a href="http://domain.tld2/test">consectetur</a> adipiscing elit', $translatedText);
+    }
+
+    public function testTranslationMultiple()
+    {
+        $dependencies = $this->createDependencies();
+        $this->configureDependencies($dependencies);
+        $instance = $this->createInstance($dependencies);
+
+        $text = 'Lorem ipsum dolor sit amet, <a href="http://domain.tld/test">consectetur</a> adipiscing elit' .
+            'Lorem ipsum dolor sit amet, <a href="http://domain.tld/test">consectetur</a> adipiscing elit' .
+            'Lorem ipsum dolor sit amet, <a href="http://domain.tld/test">consectetur</a> adipiscing elit';
+
+        $translatedText = $instance->translate($text, 'de', 'en');
+
+        $expectedText = 'Lorem ipsum dolor sit amet, <a href="/en/test">consectetur</a> adipiscing elit' .
+            'Lorem ipsum dolor sit amet, <a href="/en/test">consectetur</a> adipiscing elit' .
+            'Lorem ipsum dolor sit amet, <a href="/en/test">consectetur</a> adipiscing elit';
+
+        $this->assertEquals($expectedText, $translatedText);
+    }
+}
+
+class UrlTranslationClientDependencies
+{
+    public EntityRepository|MockObject $routeRepository;
+    public TranslationManager|MockObject $translationManager;
+    public array $domains;
+}

--- a/src/Enhavo/Bundle/TranslationBundle/Translation/Type/TextTranslationType.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translation/Type/TextTranslationType.php
@@ -66,7 +66,8 @@ class TextTranslationType extends AbstractTranslationType
         $value = $this->propertyAccessor->getValue($object, $property);
         $translatedValue = $this->translator->getTranslation($object, $property, $locale);
 
-        if ($value && (empty($translatedValue) || $options['overwrite'])) {
+        $isEmpty = $options['html'] ? empty(strip_tags($translatedValue)) : empty($translatedValue);
+        if ($value && $isEmpty || $options['overwrite']) {
             $translatedValue = $this->translationClient->translate($value, $this->defaultLanguage, $locale, [
                 'html' => $options['html'],
             ]);

--- a/src/Enhavo/Bundle/TranslationBundle/composer.json
+++ b/src/Enhavo/Bundle/TranslationBundle/composer.json
@@ -18,7 +18,8 @@
     "enhavo/form-bundle": "^0.15",
     "enhavo/metadata": "^0.15",
     "enhavo/routing-bundle": "^0.15",
-    "league/uri-components": "^2.4"
+    "league/uri-components": "^2.4",
+    "symfony/options-resolver": "^6.4"
   },
   "autoload": {
     "psr-4": { "Enhavo\\Bundle\\TranslationBundle\\": "" }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | yes
| Backport     | 0.15
| License      | MIT

* [BC Break] change return statement of `Enhavo\Bundle\TranslationBundle\Client\TranslationClientInterface::translate`
* add chain translation client
* add url translation client to translate url
* use chain with deepl and url translation as default
