### PR TITLE
[TranslationBundle] perf: avoid form field replacement for subordinate forms/entities

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
@@ -58,9 +58,18 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
             $data = new $dataClass();
         }
 
-        if (!$this->translationManager->isTranslatable($data)) {
+        $isTranslatable = false;
+        foreach ($form->all() as $property => $child) {
+            if ($this->translationManager->isFormTranslatable($data, $property)) {
+                $isTranslatable = true;
+                break;
+            }
+        }
+
+        if (!$isTranslatable) {
             return;
         }
+
 
         // To prevent side effects we only setData in the form if necessary
         if ($setData) {

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/ReplaceTranslationTypeListenerTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/ReplaceTranslationTypeListenerTest.php
@@ -77,10 +77,8 @@ class ReplaceTranslationTypeListenerTest extends TypeTestCase
 
     public function testPostSetDataTranslatable()
     {
-        $this->dependencies->translationManager->expects($this->exactly(1))->method('isTranslatable')->willReturnCallback(function ($data, $property) {
-            return true;
-        });
-        $this->dependencies->translationManager->expects($this->exactly(2))->method('isFormTranslatable')->willReturnCallback(function ($data, $property) {
+        $this->dependencies->translationManager->expects($this->never())->method('isTranslatable');
+        $this->dependencies->translationManager->expects($this->exactly(3))->method('isFormTranslatable')->willReturnCallback(function ($data, $property) {
             if (!$property) {
                 return true;
             }
@@ -91,7 +89,7 @@ class ReplaceTranslationTypeListenerTest extends TypeTestCase
             'de', 'en',
         ]);
         $this->dependencies->translationManager->method('getTranslations')->willReturnCallback(function ($data, $property) {
-            if ($property === 'name') {
+            if ('name' === $property) {
                 return [
                     'de' => new Translation(),
                     'en' => new Translation(),
@@ -125,7 +123,6 @@ class TranslatableMockFormType extends AbstractType
     public function __construct(
         private ReplaceTranslationTypeListener $listener,
     ) {
-
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

As  the MetadataRepository used in TranslationManager returns true for "hasMetadata" of an entity no matter if the metadata is translation metadata, TranslationManager->isTranslatable, will always return true.
Consequently, all form fields of all entities will always replace ALL form fields if the data_class has any metadata.
This is now avoided by checking for translatability of each incoming form and form field.
