### PR TITLE
fix: not refreshing csrf token on login

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Form/EventListener/CredentialsEventSubscriber.php
+++ b/src/Enhavo/Bundle/UserBundle/Form/EventListener/CredentialsEventSubscriber.php
@@ -22,7 +22,6 @@ class CredentialsEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private RequestStack $requestStack,
-        private CsrfTokenManager $tokenManager,
     ) {
     }
 
@@ -30,6 +29,7 @@ class CredentialsEventSubscriber implements EventSubscriberInterface
     {
         return [
             FormEvents::PRE_SET_DATA => 'onPreSetData',
+            FormEvents::PRE_SUBMIT=> ['onPreSubmit', 100], // must be called before CsrfValidationListener
         ];
     }
 
@@ -44,11 +44,20 @@ class CredentialsEventSubscriber implements EventSubscriberInterface
             $credentials = new $dataClass();
         }
 
-        $credentials->setCsrfToken($this->getCsrfToken());
         $credentials->setUserIdentifier($this->getUserIdentifier());
         $credentials->setRememberMe($this->isRememberMe());
 
         $event->setData($credentials);
+    }
+
+    public function onPreSubmit(FormEvent $event): void
+    {
+        // map token to data
+        $data = $event->getForm()->getData();
+        $submittedData = $event->getData();
+        if (isset($submittedData['csrfToken']) && $data) {
+            $data->setCsrfToken($submittedData['csrfToken']);
+        }
     }
 
     private function getUserIdentifier(): string
@@ -65,10 +74,5 @@ class CredentialsEventSubscriber implements EventSubscriberInterface
         $credentials = $this->requestStack->getSession()->get('_security.credentials', null);
 
         return null !== $credentials && $credentials->isRememberMe();
-    }
-
-    private function getCsrfToken(): string
-    {
-        return $this->tokenManager->getToken('authenticate')->getValue();
     }
 }

--- a/src/Enhavo/Bundle/UserBundle/Form/Type/LoginType.php
+++ b/src/Enhavo/Bundle/UserBundle/Form/Type/LoginType.php
@@ -41,8 +41,6 @@ class LoginType extends AbstractType
             'translation_domain' => 'EnhavoUserBundle',
         ]);
 
-        $builder->add('csrfToken', HiddenType::class);
-
         $builder->add('rememberMe', CheckboxType::class, [
             'label' => 'security.login.remember_me',
             'translation_domain' => 'EnhavoUserBundle',
@@ -58,7 +56,9 @@ class LoginType extends AbstractType
             'identifier_label' => 'security.login.email',
             'identifier_translation_domain' => 'EnhavoUserBundle',
             'data_class' => Credentials::class,
-            'csrf_protection' => false,
+            'csrf_protection' => true,
+            'csrf_token_id' => 'authenticate',
+            'csrf_field_name' => 'csrfToken',
             'constraints' => [new CredentialsValid()],
         ]);
     }

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/services/form.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/services/form.yaml
@@ -56,7 +56,6 @@ services:
     Enhavo\Bundle\UserBundle\Form\EventListener\CredentialsEventSubscriber:
         arguments:
             - '@request_stack'
-            - '@security.csrf.token_manager'
 
     Enhavo\Bundle\UserBundle\Form\Extension\CsrfDisableFormTypeExtension:
         arguments:

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/services/security.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/services/security.yaml
@@ -64,6 +64,7 @@ services:
             - '@event_dispatcher'
             - '@form.factory'
             - '@Enhavo\Component\Type\FactoryInterface[Endpoint]'
+            - '@security.token_storage'
             - '%enhavo_user.user.model.class%'
 
     Enhavo\Bundle\UserBundle\Security\Authentication\ApiTokenAuthenticator:

--- a/src/Enhavo/Bundle/UserBundle/Security/Authentication/FormLoginAuthenticator.php
+++ b/src/Enhavo/Bundle/UserBundle/Security/Authentication/FormLoginAuthenticator.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
@@ -33,6 +34,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
@@ -49,6 +51,7 @@ class FormLoginAuthenticator extends AbstractAuthenticator
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly FormFactoryInterface $formFactory,
         private readonly FactoryInterface $endpointFactory,
+        private readonly TokenStorageInterface $tokenStorage,
         string $className,
     ) {
     }
@@ -73,6 +76,12 @@ class FormLoginAuthenticator extends AbstractAuthenticator
 
         $rememberMeBadge = new RememberMeBadge();
         $credentials->isRememberMe() ? $rememberMeBadge->enable() : $rememberMeBadge->disable();
+
+        // check if user is already authenticated
+        $user = $this->tokenStorage->getToken()?->getUser();
+        if ($user instanceof UserInterface && $user->getUserIdentifier() === $credentials->getUserIdentifier()) {
+            return new SelfValidatingPassport(new UserBadge($user->getUserIdentifier()), [$rememberMeBadge]);
+        }
 
         $tokenBadge = new CsrfTokenBadge('authenticate', $credentials->getCsrfToken());
 

--- a/src/Enhavo/Bundle/UserBundle/Tests/Security/Authentication/FormLoginAuthenticatorTest.php
+++ b/src/Enhavo/Bundle/UserBundle/Tests/Security/Authentication/FormLoginAuthenticatorTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
@@ -51,6 +52,7 @@ class FormLoginAuthenticatorTest extends TestCase
             $dependencies->eventDispatcher,
             $dependencies->formFactory,
             $dependencies->endpointFactory,
+            $dependencies->tokenStorage,
             $className,
         );
     }
@@ -78,6 +80,7 @@ class FormLoginAuthenticatorTest extends TestCase
         $dependencies->request->method('getSession')->willReturn($dependencies->session);
         $dependencies->formFactory = $this->getMockBuilder(FormFactoryInterface::class)->getMock();
         $dependencies->form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
+        $dependencies->tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
 
         return $dependencies;
     }
@@ -277,4 +280,7 @@ class FormLoginAuthenticatorTestDependencies
 
     /** @var Form|MockObject */
     public $form;
+
+    /** @var TokenStorageInterface|MockObject */
+    public $tokenStorage;
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Check if user is already authenticated on authentication and skip further checks like password and csrf token.
Use native symfony csrf token protection on form, but map the token to data, so it can be checked during authentication.
The native csrf protection is responsible to put and refresh the token, while the mapping and validation is part of the authentication.

Drawback: If csrf validation fails, the native csrf protection and the authentication process will trigger a form error.
