### PR TITLE
feat: add form normalizer

### DIFF
--- a/src/Enhavo/Bundle/ResourceBundle/Batch/Type/FormBatchType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Batch/Type/FormBatchType.php
@@ -14,14 +14,14 @@ namespace Enhavo\Bundle\ResourceBundle\Batch\Type;
 use Enhavo\Bundle\ApiBundle\Data\Data;
 use Enhavo\Bundle\ResourceBundle\Batch\AbstractBatchType;
 use Enhavo\Bundle\ResourceBundle\ExpressionLanguage\ResourceExpressionLanguage;
-use Enhavo\Bundle\ResourceBundle\Form\FormNormalizer;
+use Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FormBatchType extends AbstractBatchType
 {
     public function __construct(
-        private readonly FormNormalizer $formNormalizer,
+        private readonly FormNormalizerInterface $formNormalizer,
         private readonly FormFactoryInterface $formFactory,
         private readonly ResourceExpressionLanguage $expressionLanguage,
     ) {

--- a/src/Enhavo/Bundle/ResourceBundle/Batch/Type/FormBatchType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Batch/Type/FormBatchType.php
@@ -14,14 +14,14 @@ namespace Enhavo\Bundle\ResourceBundle\Batch\Type;
 use Enhavo\Bundle\ApiBundle\Data\Data;
 use Enhavo\Bundle\ResourceBundle\Batch\AbstractBatchType;
 use Enhavo\Bundle\ResourceBundle\ExpressionLanguage\ResourceExpressionLanguage;
-use Enhavo\Bundle\VueFormBundle\Form\VueForm;
+use Enhavo\Bundle\ResourceBundle\Form\FormNormalizer;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FormBatchType extends AbstractBatchType
 {
     public function __construct(
-        private readonly VueForm $vueForm,
+        private readonly FormNormalizer $formNormalizer,
         private readonly FormFactoryInterface $formFactory,
         private readonly ResourceExpressionLanguage $expressionLanguage,
     ) {
@@ -34,7 +34,7 @@ class FormBatchType extends AbstractBatchType
             $this->expressionLanguage->evaluateArray($options['form_options']),
         );
 
-        $data['form'] = $this->vueForm->createData($form->createView());
+        $data['form'] = $this->formNormalizer->normalize($form);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Compiler/FormNormalizerCompilerPass.php
+++ b/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Compiler/FormNormalizerCompilerPass.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Enhavo\Bundle\ResourceBundle\DependencyInjection\Compiler;
+
+
+use Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Enhavo\Bundle\ResourceBundle\Form\VueFormNormalizer;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FormNormalizerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $this->addVueFormNormalizerDefinition($container);
+        $this->setAlias($container);
+    }
+
+    private function setAlias(ContainerBuilder $container)
+    {
+        $normalizerService = $container->getParameter('enhavo_resource.form.normalizer');
+        $container->setAlias(FormNormalizerInterface::class, $normalizerService);
+    }
+
+    private function addVueFormNormalizerDefinition(ContainerBuilder $container): void
+    {
+        if (class_exists('Enhavo\Bundle\VueFormBundle\Form\VueForm')) {
+            $definition = new Definition(VueFormNormalizer::class);
+            $definition->setClass(VueFormNormalizer::class);
+            $definition->addArgument(new Reference('Enhavo\Bundle\VueFormBundle\Form\VueForm'));
+            $container->addDefinitions([$definition]);
+        }
+    }
+}

--- a/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -12,6 +12,8 @@
 namespace Enhavo\Bundle\ResourceBundle\DependencyInjection;
 
 use Enhavo\Bundle\ResourceBundle\Delete\DoctrineDeleteHandler;
+use Enhavo\Bundle\ResourceBundle\Form\FormNormalizer;
+use Enhavo\Bundle\ResourceBundle\Form\VueFormNormalizer;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -27,6 +29,7 @@ class Configuration implements ConfigurationInterface
         $this->addDuplicateSection($rootNode);
         $this->addGridSection($rootNode);
         $this->addInputSection($rootNode);
+        $this->addFormSection($rootNode);
 
         return $treeBuilder;
     }
@@ -104,6 +107,22 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('inputs')
                     ->useAttributeAsKey('name')
                     ->variablePrototype()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addFormSection(ArrayNodeDefinition $node): void
+    {
+        $normalizerService = class_exists('Enhavo\Bundle\VueFormBundle\Form\VueForm') ? VueFormNormalizer::class : FormNormalizer::class;
+
+        $node
+            ->children()
+                ->arrayNode('form')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('normalizer')->defaultValue($normalizerService)->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/EnhavoResourceExtension.php
+++ b/src/Enhavo/Bundle/ResourceBundle/DependencyInjection/EnhavoResourceExtension.php
@@ -44,6 +44,7 @@ class EnhavoResourceExtension extends Extension implements PrependExtensionInter
         $container->setParameter('enhavo_resource.duplicate', $config['duplicate']);
         $container->setParameter('enhavo_resource.resources', $config['resources']);
         $container->setParameter('enhavo_resource.delete.handler', $config['delete']['handler']);
+        $container->setParameter('enhavo_resource.form.normalizer', $config['form']['normalizer']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceCreateEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceCreateEndpointType.php
@@ -16,11 +16,11 @@ use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointType;
 use Enhavo\Bundle\ApiBundle\Endpoint\Context;
 use Enhavo\Bundle\ResourceBundle\Authorization\Permission;
 use Enhavo\Bundle\ResourceBundle\ExpressionLanguage\ResourceExpressionLanguage;
+use Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface;
 use Enhavo\Bundle\ResourceBundle\Input\Input;
 use Enhavo\Bundle\ResourceBundle\Input\InputFactory;
 use Enhavo\Bundle\ResourceBundle\Resource\ResourceManager;
 use Enhavo\Bundle\ResourceBundle\RouteResolver\RouteResolverInterface;
-use Enhavo\Bundle\VueFormBundle\Form\VueForm;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,7 +29,7 @@ class ResourceCreateEndpointType extends AbstractEndpointType
     public function __construct(
         private readonly InputFactory $inputFactory,
         private readonly ResourceManager $resourceManager,
-        private readonly VueForm $vueForm,
+        private readonly FormNormalizerInterface $formNormalizer,
         private readonly RouteResolverInterface $routeResolver,
         private readonly ResourceExpressionLanguage $expressionLanguage,
     ) {
@@ -84,7 +84,7 @@ class ResourceCreateEndpointType extends AbstractEndpointType
             }
 
             $formFields = $request->query->get('form-fields') ? explode(',', $request->query->get('form-fields')) : null;
-            $data->set('form', $this->vueForm->createData($form->createView(), $formFields));
+            $data->set('form', $this->formNormalizer->createData($form->createView(), $formFields));
         }
 
         $viewData = $input->getViewData($resource);

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceUpdateEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceUpdateEndpointType.php
@@ -15,6 +15,7 @@ use Enhavo\Bundle\ApiBundle\Data\Data;
 use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointType;
 use Enhavo\Bundle\ApiBundle\Endpoint\Context;
 use Enhavo\Bundle\ResourceBundle\Authorization\Permission;
+use Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface;
 use Enhavo\Bundle\ResourceBundle\Input\Input;
 use Enhavo\Bundle\ResourceBundle\Input\InputFactory;
 use Enhavo\Bundle\ResourceBundle\Resource\ResourceManager;
@@ -27,7 +28,7 @@ class ResourceUpdateEndpointType extends AbstractEndpointType
     public function __construct(
         private readonly InputFactory $inputFactory,
         private readonly ResourceManager $resourceManager,
-        private readonly VueForm $vueForm,
+        private readonly FormNormalizerInterface $formNormalizer,
     ) {
     }
 
@@ -62,7 +63,7 @@ class ResourceUpdateEndpointType extends AbstractEndpointType
             }
 
             $formFields = $request->query->get('form-fields') ? explode(',', $request->query->get('form-fields')) : null;
-            $data->set('form', $this->vueForm->createData($form->createView(), $formFields));
+            $data->set('form', $this->formNormalizer->normalize($form, ['fields' => $formFields]));
             $data->set('url', $request->getPathInfo());
         }
 

--- a/src/Enhavo/Bundle/ResourceBundle/EnhavoResourceBundle.php
+++ b/src/Enhavo/Bundle/ResourceBundle/EnhavoResourceBundle.php
@@ -19,6 +19,7 @@ use Enhavo\Bundle\ResourceBundle\Column\Column;
 use Enhavo\Bundle\ResourceBundle\Column\ColumnTypeInterface;
 use Enhavo\Bundle\ResourceBundle\DependencyInjection\Compiler\CollectionCompilerPass;
 use Enhavo\Bundle\ResourceBundle\DependencyInjection\Compiler\DeleteHandlerCompilerPass;
+use Enhavo\Bundle\ResourceBundle\DependencyInjection\Compiler\FormNormalizerCompilerPass;
 use Enhavo\Bundle\ResourceBundle\DependencyInjection\Compiler\GridCompilerPass;
 use Enhavo\Bundle\ResourceBundle\DependencyInjection\Compiler\InputCompilerPass;
 use Enhavo\Bundle\ResourceBundle\DependencyInjection\Compiler\RequestHandlerCompilerPass;
@@ -49,6 +50,7 @@ class EnhavoResourceBundle extends Bundle
         $container->addCompilerPass(new ResourceExpressionCompilerPass());
         $container->addCompilerPass(new DeleteHandlerCompilerPass());
         $container->addCompilerPass(new RequestHandlerCompilerPass());
+        $container->addCompilerPass(new FormNormalizerCompilerPass());
 
         $container->addCompilerPass(new TypeCompilerPass('Action', 'enhavo_resource.action', Action::class));
         $container->addCompilerPass(new TypeCompilerPass('Batch', 'enhavo_resource.batch', Batch::class));

--- a/src/Enhavo/Bundle/ResourceBundle/Form/FormNormalizer.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Form/FormNormalizer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Enhavo\Bundle\ResourceBundle\Form;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class FormNormalizer implements FormNormalizerInterface
+{
+    public function __construct(
+        private readonly NormalizerInterface $normalizer,
+    )
+    {
+    }
+
+    public function normalize(FormInterface $form, array $options = []): array
+    {
+        return $this->normalizer->normalize($form, null, $options);
+    }
+}

--- a/src/Enhavo/Bundle/ResourceBundle/Form/FormNormalizerInterface.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Form/FormNormalizerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Enhavo\Bundle\ResourceBundle\Form;
+
+use Symfony\Component\Form\FormInterface;
+
+interface FormNormalizerInterface
+{
+    public function normalize(FormInterface $form, array $options = []): array;
+}

--- a/src/Enhavo/Bundle/ResourceBundle/Form/VueFormNormalizer.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Form/VueFormNormalizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Enhavo\Bundle\ResourceBundle\Form;
+
+use Enhavo\Bundle\VueFormBundle\Form\VueForm;
+use Symfony\Component\Form\FormInterface;
+
+class VueFormNormalizer implements FormNormalizerInterface
+{
+    public function __construct(
+        private readonly VueForm $vueForm,
+    )
+    {
+    }
+
+    public function normalize(FormInterface $form, array $options = []): array
+    {
+        $fields = $options['fields'] ?? null;
+        return $this->vueForm->createData($form->createView(), $fields);
+    }
+}

--- a/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/batch.yaml
+++ b/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/batch.yaml
@@ -30,7 +30,7 @@ services:
 
     Enhavo\Bundle\ResourceBundle\Batch\Type\FormBatchType:
         arguments:
-            - '@Enhavo\Bundle\VueFormBundle\Form\VueForm'
+            - '@Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface'
             - '@form.factory'
             - '@Enhavo\Bundle\ResourceBundle\ExpressionLanguage\ResourceExpressionLanguage'
         tags:

--- a/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/endpoint.yaml
+++ b/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/endpoint.yaml
@@ -21,7 +21,7 @@ services:
         arguments:
             - '@Enhavo\Bundle\ResourceBundle\Input\InputFactory'
             - '@Enhavo\Bundle\ResourceBundle\Resource\ResourceManager'
-            - '@Enhavo\Bundle\VueFormBundle\Form\VueForm'
+            - '@Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface'
             - '@Enhavo\Bundle\ResourceBundle\RouteResolver\RouteResolverInterface'
             - '@Enhavo\Bundle\ResourceBundle\ExpressionLanguage\ResourceExpressionLanguage'
         calls:
@@ -34,7 +34,7 @@ services:
         arguments:
             - '@Enhavo\Bundle\ResourceBundle\Input\InputFactory'
             - '@Enhavo\Bundle\ResourceBundle\Resource\ResourceManager'
-            - '@Enhavo\Bundle\VueFormBundle\Form\VueForm'
+            - '@Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface'
         calls:
             - [setContainer, ['@Psr\Container\ContainerInterface']]
         tags:

--- a/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/services.yaml
+++ b/src/Enhavo/Bundle/ResourceBundle/Resources/config/services/services.yaml
@@ -102,3 +102,7 @@ services:
     Enhavo\Bundle\ResourceBundle\Security\CsrfChecker:
         arguments:
             - '%form.type_extension.csrf.enabled%'
+
+    Enhavo\Bundle\ResourceBundle\Form\FormNormalizer:
+        arguments:
+            - '@serializer'

--- a/src/Enhavo/Bundle/ResourceBundle/Tests/Batch/Type/FormBatchTypeTest.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Tests/Batch/Type/FormBatchTypeTest.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\EntityRepository;
 use Enhavo\Bundle\ResourceBundle\Batch\Batch;
 use Enhavo\Bundle\ResourceBundle\Batch\Type\FormBatchType;
 use Enhavo\Bundle\ResourceBundle\ExpressionLanguage\ResourceExpressionLanguage;
-use Enhavo\Bundle\VueFormBundle\Form\VueForm;
+use Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -27,7 +27,7 @@ class FormBatchTypeTest extends TestCase
         $dependencies = new FormBatchTypeDependencies();
         $dependencies->formFactory = $this->getMockBuilder(FormFactoryInterface::class)->getMock();
         $dependencies->repository = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->getMock();
-        $dependencies->vueForm = $this->getMockBuilder(VueForm::class)->disableOriginalConstructor()->getMock();
+        $dependencies->formNormalizer = $this->getMockBuilder(FormNormalizerInterface::class)->getMock();
         $dependencies->expressionLanguage = new ResourceExpressionLanguage();
 
         return $dependencies;
@@ -36,7 +36,7 @@ class FormBatchTypeTest extends TestCase
     private function createInstance(FormBatchTypeDependencies $dependencies): FormBatchType
     {
         return new FormBatchType(
-            $dependencies->vueForm,
+            $dependencies->formNormalizer,
             $dependencies->formFactory,
             $dependencies->expressionLanguage,
         );
@@ -45,7 +45,7 @@ class FormBatchTypeTest extends TestCase
     public function testViewData()
     {
         $dependencies = $this->createDependencies();
-        $dependencies->vueForm->method('createData')->willReturn(['form' => 'data']);
+        $dependencies->formNormalizer->method('normalize')->willReturn(['form' => 'data']);
 
         $type = $this->createInstance($dependencies);
 
@@ -62,7 +62,7 @@ class FormBatchTypeTest extends TestCase
 class FormBatchTypeDependencies
 {
     public EntityRepository|MockObject $repository;
-    public VueForm|MockObject $vueForm;
+    public FormNormalizerInterface|MockObject $formNormalizer;
     public FormFactoryInterface|MockObject $formFactory;
     public ResourceExpressionLanguage|MockObject $expressionLanguage;
 }

--- a/src/Enhavo/Bundle/ResourceBundle/composer.json
+++ b/src/Enhavo/Bundle/ResourceBundle/composer.json
@@ -14,6 +14,7 @@
   "require": {
     "php": "^8.4",
     "enhavo/api-bundle": "^0.16",
+    "symfony/security-csrf": "^7.4",
     "pagerfanta/doctrine-orm-adapter": "^4.2",
     "winzou/state-machine-bundle": "^0.6.2"
   },


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Add `FormNormalizerInterface` to abstract how a form get normalize to remove the dependency to vue form bundle, but still use the `VueForm` automatically if the vue form bundle was added.
