### PR TITLE
[ContentBundle] fix: subselected property as it renders field invisible with TranslationBundle

### DIFF
--- a/src/Enhavo/Bundle/ContentBundle/Form/Type/ContentType.php
+++ b/src/Enhavo/Bundle/ContentBundle/Form/Type/ContentType.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('title', TextType::class, [
             'label' => 'form.label.title',
@@ -90,15 +90,15 @@ class ContentType extends AbstractType
         ]);
 
         if ($options['slugable']) {
-            $builder->add('slug', SlugType::class, []);
+            $builder->add('slug', SlugType::class);
         }
 
         if ($options['routable']) {
-            $builder->add('route', RouteType::class, []);
+            $builder->add('route', RouteType::class);
         }
 
         if ($options['router']) {
-            $builder->add('router_route', RouterType::class, []);
+            $builder->add('router_route', RouterType::class);
         }
     }
 
@@ -111,7 +111,7 @@ class ContentType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'enhavo_content_content';
     }

--- a/src/Enhavo/Bundle/ContentBundle/Tab/MetaTabType.php
+++ b/src/Enhavo/Bundle/ContentBundle/Tab/MetaTabType.php
@@ -25,7 +25,7 @@ class MetaTabType extends AbstractTabType
             'arrangement' => [
                 'page_title',
                 'slug',
-                'route.path',
+                'route',
                 'meta_description',
                 'canonicalUrl',
                 'noIndex',

--- a/src/Enhavo/Bundle/RoutingBundle/Form/Type/RouteType.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Form/Type/RouteType.php
@@ -20,12 +20,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RouteType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('path', TextType::class);
+        $builder->add('path', TextType::class, [
+            'label' => false,
+        ]);
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'label' => 'label.url',
@@ -45,7 +47,7 @@ class RouteType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'enhavo_route';
     }


### PR DESCRIPTION

| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

instead of adding route.path to circumvent duplicate stacked form field labels, just disable the label of the subordinate child.
