### PR TITLE
[MediaBundle] Fix error in FileFactory createFromUri if no filen…

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/Factory/FileFactory.php
+++ b/src/Enhavo/Bundle/MediaBundle/Factory/FileFactory.php
@@ -140,7 +140,7 @@ class FileFactory extends Factory
         }
 
         if (null === $filename) {
-            $contentDisposition = $headers['content-disposition'];
+            $contentDisposition = $headers['content-disposition'] ?? null;
             if (!empty($contentDisposition)) {
                 if (preg_match('/.*?filename="(.+?)"/', $contentDisposition[0], $matches)) {
                     $filename = $matches[1];


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

[MediaBundle] Fix error in FileFactory createFromUri if no filename is set and remote doesn't send header content-disposition