### PR TITLE
[TranslationBundle] Fix translation form replace changing the order of form fields

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Form/EventListener/ReplaceTranslationTypeListener.php
@@ -77,12 +77,9 @@ class ReplaceTranslationTypeListener implements EventSubscriberInterface
         }
 
         foreach ($form->all() as $property => $child) {
-            // prevent reapply
-            if (TranslationType::class === get_class($child->getConfig()->getType()->getInnerType())) {
-                continue;
-            }
-
-            if ($this->translationManager->isFormTranslatable($data, $property)) {
+            if ($this->translationManager->isFormTranslatable($data, $property)
+                && !(TranslationType::class === get_class($child->getConfig()->getType()->getInnerType()))
+            ) {
                 $this->replaceWithTranslationField($data, $property, $form, $child);
 
             } else { // replace all children to keep order as defined in the parent form type


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Fix translation form replace changing the order of form fields
