### PR TITLE
[TranslationBundle] Fix translation routes not getting deleted when the resource gets deleted

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/doctrine/TranslationRoute.orm.xml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/doctrine/TranslationRoute.orm.xml
@@ -12,6 +12,7 @@
             <cascade>
                 <cascade-persist />
                 <cascade-refresh />
+                <cascade-remove />
             </cascade>
             <join-column on-delete="CASCADE" />
         </many-to-one>


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Fix translation routes not getting deleted when the resource gets deleted