### PR TITLE
fix: Fix translation bundle preFlush detach mechanism for translated …

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/EventListener/DoctrineTranslationSubscriber.php
+++ b/src/Enhavo/Bundle/TranslationBundle/EventListener/DoctrineTranslationSubscriber.php
@@ -78,7 +78,7 @@ class DoctrineTranslationSubscriber implements EventSubscriber
         foreach ($uow->getIdentityMap() as $class => $entities) {
             if ($this->metadataRepository->hasMetadata($class)) {
                 foreach ($entities as $entity) {
-                    if (!($entity instanceof Proxy)) {
+                    if (!($entity instanceof Proxy) || ($entity->__isInitialized())) {
                         $this->getTranslationManager()->detach($entity);
                     }
                 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Fix translation bundle preFlush detach mechanism for translated proxy objects
