### PR TITLE
[MediaBundle] feat: Add empty file not found handler

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/EmptyFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/EmptyFileNotFoundHandler.php
@@ -17,7 +17,7 @@ use Enhavo\Bundle\MediaBundle\Model\FileInterface;
 use Enhavo\Bundle\MediaBundle\Model\FormatInterface;
 use Enhavo\Bundle\MediaBundle\Storage\StorageInterface;
 
-class ReturnEmptyFileNotFoundHandler implements FileNotFoundHandlerInterface
+class EmptyFileNotFoundHandler implements FileNotFoundHandlerInterface
 {
     public function handleSave(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {

--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/ReturnEmptyFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/ReturnEmptyFileNotFoundHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\MediaBundle\FileNotFound;
+
+use Enhavo\Bundle\MediaBundle\Content\Content;
+use Enhavo\Bundle\MediaBundle\Exception\FileNotFoundException;
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
+use Enhavo\Bundle\MediaBundle\Model\FormatInterface;
+use Enhavo\Bundle\MediaBundle\Storage\StorageInterface;
+
+class ReturnEmptyFileNotFoundHandler implements FileNotFoundHandlerInterface
+{
+    public function handleSave(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
+    {
+        // do nothing
+    }
+
+    public function handleLoad(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
+    {
+        $file->setContent(new Content('', ''));
+    }
+
+    public function handleDelete(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
+    {
+        // do nothing
+    }
+}

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
@@ -15,7 +15,7 @@ services:
         tags:
             - { name: enhavo_media.file_not_found_handler }
 
-    Enhavo\Bundle\MediaBundle\FileNotFound\ReturnEmptyFileNotFoundHandler:
+    Enhavo\Bundle\MediaBundle\FileNotFound\EmptyFileNotFoundHandler:
         tags:
             - { name: enhavo_media.file_not_found_handler }
 

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/services/file_not_found.yaml
@@ -15,6 +15,10 @@ services:
         tags:
             - { name: enhavo_media.file_not_found_handler }
 
+    Enhavo\Bundle\MediaBundle\FileNotFound\ReturnEmptyFileNotFoundHandler:
+        tags:
+            - { name: enhavo_media.file_not_found_handler }
+
     Enhavo\Bundle\MediaBundle\FileNotFound\ChainFileNotFoundHandler:
         tags:
             - { name: enhavo_media.file_not_found_handler }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

In order to let developers execute commands and test things where no files are involved, but an existing database is required, add the possibility to just return empty content if files are not found.
