### PR TITLE
[MediaBundle] fix: path can't be empty

### DIFF
--- a/src/Enhavo/Bundle/MediaBundle/FileNotFound/EmptyFileNotFoundHandler.php
+++ b/src/Enhavo/Bundle/MediaBundle/FileNotFound/EmptyFileNotFoundHandler.php
@@ -26,7 +26,7 @@ class EmptyFileNotFoundHandler implements FileNotFoundHandlerInterface
 
     public function handleLoad(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void
     {
-        $file->setContent(new Content('', ''));
+        $file->setContent(new Content('', null));
     }
 
     public function handleDelete(FormatInterface|FileInterface $file, StorageInterface $storage, FileNotFoundException $exception, array $parameters = []): void


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

'' was wrong. it has to be NULL.
