### PR TITLE
feat: improve translation caching

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Repository/TranslationRouteRepository.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Repository/TranslationRouteRepository.php
@@ -22,43 +22,32 @@ use Enhavo\Bundle\TranslationBundle\Entity\TranslationRoute;
  */
 class TranslationRouteRepository extends EntityRepository
 {
-    public function findTranslationRoute($class, $id, $property, $locale): ?TranslationRoute
-    {
-        $translationRoute = $this->createQueryBuilder('tr')
-            ->join('tr.route', 'r')
-            ->andWhere('r.contentClass = :class')
-            ->andWhere('r.contentId = :id')
-            ->andWhere('tr.locale = :locale')
-            ->andWhere('tr.property = :property')
-            ->setParameter('class', $class)
-            ->setParameter('id', $id)
-            ->setParameter('property', $property)
-            ->setParameter('locale', $locale)
-            ->setMaxResults(1)
-            ->getQuery()
-            ->getResult();
-
-        if ($translationRoute) {
-            return $translationRoute[0];
-        }
-
-        return null;
-    }
-
     /**
      * @return array|TranslationRoute[]
      */
-    public function findTranslationRoutes($class, $id): array
+    public function findTranslationRoutes($class, $id, ?string $property = null, ?string $locale = null): array
     {
-        $translationRoutes = $this->createQueryBuilder('tr')
+        $qb = $this->createQueryBuilder('tr')
             ->join('tr.route', 'r')
             ->andWhere('r.contentClass = :class')
             ->andWhere('r.contentId = :id')
             ->setParameter('class', $class)
             ->setParameter('id', $id)
-            ->getQuery()
-            ->getResult();
+        ;
 
-        return $translationRoutes;
+        if ($locale !== null) {
+            $qb->andWhere('tr.locale = :locale');
+            $qb->setParameter('locale', $locale);
+        }
+
+        if ($property !== null) {
+            $qb->andWhere('tr.property = :property');
+            $qb->setParameter('property', $property);
+        }
+
+        return $qb
+            ->getQuery()
+            ->getResult()
+        ;
     }
 }

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Media/FileTranslatorTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Media/FileTranslatorTest.php
@@ -116,12 +116,12 @@ class FileTranslatorTest extends TestCase
         /** @var FileInterface|MockObject $file */
         $file = $this->getMockBuilder(FileInterface::class)->getMock();
 
-        $dependencies->repository->method('findOneBy')->willReturnCallback(function () use ($file) {
-            $translation = new TranslationFile();
-            $translation->setFile($file);
+        $translation = new TranslationFile();
+        $translation->setFile($file);
+        $translation->setProperty('file');
+        $translation->setLocale('fr');
 
-            return $translation;
-        });
+        $dependencies->repository->method('findBy')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
 

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Route/RouteTranslatorTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Route/RouteTranslatorTest.php
@@ -56,19 +56,22 @@ class RouteTranslatorTest extends TestCase
         $dependencies = $this->createDependencies();
         $translator = $this->createInstance($dependencies);
 
-        /** @var RouteInterface|MockObject $route */
-        $route = $this->getMockBuilder(RouteInterface::class)->getMock();
+        $route = new Route();
+        $route->setName('route-test');
+        $route->setStaticPrefix('/test');
 
         $entity = new TranslatableMock();
 
-        $dependencies->repository->method('findTranslationRoute')->willReturnCallback(function ($class, $id, $property, $locale) use ($route) {
+        $dependencies->repository->method('findTranslationRoutes')->willReturnCallback(function ($class, $id, $property = null, $locale = null) use ($route) {
             if (null === $id) {
-                return null;
+                return [];
             }
             $translation = new TranslationRoute();
             $translation->setRoute($route);
+            $translation->setProperty('route');
+            $translation->setLocale('fr');
 
-            return $translation;
+            return [$translation];
         });
 
         $translator->setTranslation($entity, 'route', 'fr', $route);
@@ -85,16 +88,13 @@ class RouteTranslatorTest extends TestCase
         /** @var RouteInterface|MockObject $route */
         $route = new Route();
         $route->setName('route-a');
+        $route->setStaticPrefix('/route-a');
         /** @var RouteInterface|MockObject $route */
         $route2 = new Route();
         $route2->setName('route-b');
+        $route2->setStaticPrefix('/route-b');
 
-        $dependencies->repository->method('findTranslationRoute')->willReturnCallback(function ($entity, $property, $locale) use ($route) {
-            $translation = new TranslationRoute();
-            $translation->setRoute($route);
-
-            return $translation;
-        });
+        $dependencies->repository->method('findTranslationRoutes')->willReturn([]);
 
         $entity = new TranslatableMock();
 
@@ -121,12 +121,12 @@ class RouteTranslatorTest extends TestCase
         /** @var RouteInterface|MockObject $route */
         $route = $this->getMockBuilder(RouteInterface::class)->getMock();
 
-        $dependencies->repository->method('findTranslationRoute')->willReturnCallback(function ($entity, $property, $locale) use ($route) {
-            $translation = new TranslationRoute();
-            $translation->setRoute($route);
+        $translation = new TranslationRoute();
+        $translation->setRoute($route);
+        $translation->setProperty('route');
+        $translation->setLocale('fr');
 
-            return $translation;
-        });
+        $dependencies->repository->method('findTranslationRoutes')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
 

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Text/TextTranslatorTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Text/TextTranslatorTest.php
@@ -71,14 +71,11 @@ class TextTranslatorTest extends TestCase
         $dependencies = $this->createDependencies();
         $translator = $this->createInstance($dependencies);
         $translation = $this->getMockBuilder(Translation::class)->getMock();
+        $translation->method('getProperty')->willReturn('name');
+        $translation->method('getLocale')->willReturn('fr');
+        $translation->method('getTranslation')->willReturn('translated,,name,fr');
 
-        $dependencies->repository->method('findOneBy')->willReturnCallback(function (array $params) use ($translation) {
-            $params['class'] = 'translated';
-            $paramstring = implode(',', $params);
-            $translation->method('getTranslation')->willReturn($paramstring);
-
-            return $translation;
-        });
+        $dependencies->repository->method('findBy')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
         $translator->getTranslation($entity, 'name', 'fr');
@@ -91,14 +88,11 @@ class TextTranslatorTest extends TestCase
         $dependencies = $this->createDependencies();
         $translator = $this->createInstance($dependencies);
         $translation = $this->getMockBuilder(Translation::class)->getMock();
+        $translation->method('getProperty')->willReturn('name');
+        $translation->method('getLocale')->willReturn('fr');
+        $translation->method('getTranslation')->willReturn('translated,,name,fr');
 
-        $dependencies->repository->method('findOneBy')->willReturnCallback(function (array $params) use ($translation) {
-            $params['class'] = 'translated';
-            $paramstring = implode(',', $params);
-            $translation->method('getTranslation')->willReturn($paramstring);
-
-            return $translation;
-        });
+        $dependencies->repository->method('findBy')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
         $translator->setTranslation($entity, 'name', 'fr', 'bingobongo');

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/AbstractTranslator.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/AbstractTranslator.php
@@ -12,35 +12,64 @@
 namespace Enhavo\Bundle\TranslationBundle\Translator;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 use Enhavo\Bundle\DoctrineExtensionBundle\EntityResolver\EntityResolverInterface;
 use Enhavo\Bundle\TranslationBundle\Locale\LocaleProviderInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 abstract class AbstractTranslator implements TranslatorInterface
 {
-    /** @var EntityManagerInterface */
-    protected $entityManager;
+    protected DataMap $buffer;
+    protected DataMap $originalData;
 
-    /** @var EntityResolverInterface */
-    protected $entityResolver;
+    /** @var array<string, array> */
+    protected array $translationCache = [];
 
-    /** @var DataMap */
-    protected $buffer;
-
-    /** @var DataMap */
-    protected $originalData;
-
-    /** @var LocaleProviderInterface */
-    protected $localeProvider;
-
-    public function __construct(EntityManagerInterface $entityManager, EntityResolverInterface $entityResolver, LocaleProviderInterface $localeProvider)
+    public function __construct(
+        protected EntityManagerInterface $entityManager,
+        protected EntityResolverInterface $entityResolver,
+        protected LocaleProviderInterface $localeProvider
+    )
     {
-        $this->entityManager = $entityManager;
-        $this->localeProvider = $localeProvider;
-        $this->entityResolver = $entityResolver;
-
         $this->buffer = new DataMap();
         $this->originalData = new DataMap();
+    }
+
+    public function setTranslation($entity, $property, $locale, $value): void
+    {
+        if ($locale == $this->localeProvider->getDefaultLocale()) {
+            return;
+        }
+
+        $this->loadBuffer($entity);
+
+        $translation = $this->buffer->load($entity, $property, $locale);
+
+        if ($translation === null) {
+            $translation = $this->createTranslation($entity, $property, $locale, $value);
+            if ($translation) {
+                $this->buffer->store($entity, $property, $locale, $translation);
+            }
+        } else {
+            $this->updateTranslation($translation, $value);
+        }
+    }
+
+    public function getTranslation($entity, $property, $locale): mixed
+    {
+        if ($locale == $this->localeProvider->getDefaultLocale()) {
+            return null;
+        }
+
+        $this->loadBuffer($entity);
+
+        $translation = $this->buffer->load($entity, $property, $locale);
+
+        if ($translation === null) {
+            return null;
+        }
+
+        return $this->getTranslationValue($translation);
     }
 
     public function detach($entity, string $property, string $locale, array $options)
@@ -68,16 +97,35 @@ abstract class AbstractTranslator implements TranslatorInterface
         return $originalValue;
     }
 
-    public function delete($entity, string $property)
+    public function delete($entity, string $property): void
     {
-        $translations = $this->getRepository()->findBy([
-            'class' => $this->entityResolver->getName($entity),
-            'property' => $property,
-            'refId' => $entity->getId(),
-        ]);
+        $translations = $this->findTranslations($entity, $property);
 
         foreach ($translations as $translation) {
             $this->entityManager->remove($translation);
         }
     }
+
+    private function loadBuffer($entity): void
+    {
+        if ($this->buffer->exists($entity)) {
+            return;
+        }
+
+        $translations = $this->findTranslations($entity);
+
+        foreach ($translations as $translation) {
+            $this->buffer->store($entity, $translation->getProperty(), $translation->getLocale(), $translation);
+        }
+    }
+
+    abstract public function getRepository(): EntityRepository;
+
+    abstract protected function createTranslation($entity, $property, $locale, $value): ?object;
+
+    abstract protected function updateTranslation($translation, $value);
+
+    abstract protected function getTranslationValue($translation);
+
+    abstract protected function findTranslations($entity, ?string $property = null): iterable;
 }

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/DataMap.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/DataMap.php
@@ -15,6 +15,12 @@ class DataMap
 {
     private $map = [];
 
+    public function exists($entity)
+    {
+        $oid = spl_object_hash($entity);
+        return array_key_exists($oid, $this->map);
+    }
+
     public function store($entity, $property, $locale, $data)
     {
         $oid = spl_object_hash($entity);

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/Media/FileTranslator.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/Media/FileTranslator.php
@@ -12,7 +12,6 @@
 namespace Enhavo\Bundle\TranslationBundle\Translator\Media;
 
 use Doctrine\ORM\EntityRepository;
-use Enhavo\Bundle\MediaBundle\Model\FileInterface;
 use Enhavo\Bundle\TranslationBundle\Entity\TranslationFile;
 use Enhavo\Bundle\TranslationBundle\Translator\AbstractTranslator;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -22,50 +21,6 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  */
 class FileTranslator extends AbstractTranslator
 {
-    public function setTranslation($entity, $property, $locale, $value): void
-    {
-        if ($locale == $this->localeProvider->getDefaultLocale()) {
-            return;
-        }
-
-        $translation = $this->buffer->load($entity, $property, $locale);
-        if ($translation instanceof TranslationFile) {
-            $translation->setFile($value);
-
-            return;
-        }
-
-        $translation = $this->load($entity, $property, $locale);
-        if (null === $translation) {
-            $translation = $this->createTranslationFile($entity, $property, $locale, $value);
-        } else {
-            $translation->setFile($value);
-        }
-
-        $this->buffer->store($entity, $property, $locale, $translation);
-    }
-
-    public function getTranslation($entity, $property, $locale): ?FileInterface
-    {
-        if ($locale == $this->localeProvider->getDefaultLocale()) {
-            return null;
-        }
-
-        $translation = $this->buffer->load($entity, $property, $locale);
-        if (null !== $translation) {
-            return $translation->getFile();
-        }
-
-        $translation = $this->load($entity, $property, $locale);
-        if (null !== $translation) {
-            $this->buffer->store($entity, $property, $locale, $translation);
-
-            return $translation->getFile();
-        }
-
-        return null;
-    }
-
     public function translate($entity, string $property, string $locale, array $options)
     {
         // translation data is stored inside the object
@@ -95,29 +50,49 @@ class FileTranslator extends AbstractTranslator
         parent::detach($entity, $property, $locale, $options);
     }
 
-    private function createTranslationFile($entity, $property, $locale, $data): TranslationFile
+    protected function createTranslation($entity, $property, $locale, $value): ?object
     {
         $translation = new TranslationFile();
         $translation->setObject($entity);
         $translation->setProperty($property);
         $translation->setLocale($locale);
-        $translation->setFile($data);
+        $translation->setFile($value);
         $this->entityManager->persist($translation);
 
         return $translation;
     }
 
-    private function load($entity, $property, $locale): ?TranslationFile
+    protected function updateTranslation($translation, $value): void
     {
-        /** @var TranslationFile $translation */
-        $translation = $this->getRepository()->findOneBy([
+        if ($translation instanceof TranslationFile) {
+            $translation->setFile($value);
+            return;
+        }
+
+        throw new \InvalidArgumentException('Must be of type: ' . TranslationFile::class);
+    }
+
+    protected function getTranslationValue($translation)
+    {
+        if ($translation instanceof TranslationFile) {
+            return $translation->getFile();
+        }
+
+        throw new \InvalidArgumentException('Must be of type: ' . TranslationFile::class);
+    }
+
+    public function findTranslations($entity, ?string $property = null): array
+    {
+        $parameters = [
             'class' => $this->entityResolver->getName($entity),
             'refId' => $entity->getId(),
-            'property' => $property,
-            'locale' => $locale,
-        ]);
+        ];
 
-        return $translation;
+        if ($property !== null) {
+            $parameters['property'] = $property;
+        }
+
+        return $this->getRepository()->findBy($parameters);
     }
 
     public function getRepository(): EntityRepository

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/Route/RouteTranslator.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/Route/RouteTranslator.php
@@ -13,6 +13,7 @@ namespace Enhavo\Bundle\TranslationBundle\Translator\Route;
 
 use Doctrine\ORM\EntityRepository;
 use Enhavo\Bundle\RoutingBundle\Model\RouteInterface;
+use Enhavo\Bundle\TranslationBundle\Entity\Translation;
 use Enhavo\Bundle\TranslationBundle\Entity\TranslationRoute;
 use Enhavo\Bundle\TranslationBundle\Translator\AbstractTranslator;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -22,74 +23,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  */
 class RouteTranslator extends AbstractTranslator
 {
-    public function setTranslation($entity, $property, $locale, $value): void
-    {
-        if ($locale == $this->localeProvider->getDefaultLocale()) {
-            return;
-        }
-
-        $translationRoute = $this->buffer->load($entity, $property, $locale)
-            ?? $this->load($entity, $property, $locale);
-
-        if (null === $translationRoute) {
-            $translationRoute = $this->createTranslationRoute($entity, $property, $locale, $value);
-        } else {
-            if ($translationRoute->getRoute() !== $value) {
-                $route = $translationRoute->getRoute();
-                $this->entityManager->remove($route);
-                $translationRoute->setRoute($value);
-            }
-        }
-
-        $this->buffer->store($entity, $property, $locale, $translationRoute);
-    }
-
-    public function getTranslation($entity, $property, $locale): ?RouteInterface
-    {
-        if ($locale == $this->localeProvider->getDefaultLocale()) {
-            return null;
-        }
-
-        $translationRoute = $this->buffer->load($entity, $property, $locale);
-        if (null !== $translationRoute) {
-            return $translationRoute->getRoute();
-        }
-
-        $translationRoute = $this->load($entity, $property, $locale);
-        if (null !== $translationRoute) {
-            $this->buffer->store($entity, $property, $locale, $translationRoute);
-
-            return $translationRoute->getRoute();
-        }
-
-        return null;
-    }
-
-    public function delete($entity, string $property)
-    {
-        $this->deleteTranslationData($entity);
-    }
-
-    private function createTranslationRoute($entity, $property, $locale, ?RouteInterface $route): ?TranslationRoute
-    {
-        if (null === $route || empty($route->getStaticPrefix())) {
-            return null;
-        }
-
-        $route->setContent($entity);
-        $route->generateRouteName();
-
-        $translationRoute = new TranslationRoute();
-        $translationRoute->setLocale($locale);
-        $translationRoute->setProperty($property);
-        $translationRoute->setRoute($route);
-
-        $this->entityManager->persist($translationRoute);
-
-        return $translationRoute;
-    }
-
-    private function deleteTranslationData($entity)
+    public function delete($entity, string $property): void
     {
         $repository = $this->getRepository();
 
@@ -101,23 +35,6 @@ class RouteTranslator extends AbstractTranslator
         foreach ($translationRoutes as $translationRoute) {
             $this->entityManager->remove($translationRoute);
         }
-    }
-
-    private function load($entity, $property, $locale): ?TranslationRoute
-    {
-        $repository = $this->getRepository();
-
-        return $repository->findTranslationRoute(
-            $this->entityResolver->getName($entity),
-            $entity->getId(),
-            $property,
-            $locale
-        );
-    }
-
-    public function getRepository(): EntityRepository
-    {
-        return $this->entityManager->getRepository(TranslationRoute::class);
     }
 
     public function translate($entity, string $property, string $locale, array $options)
@@ -146,5 +63,70 @@ class RouteTranslator extends AbstractTranslator
         }
 
         parent::detach($entity, $property, $locale, $options);
+    }
+
+    protected function createTranslation($entity, $property, $locale, $value): ?object
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!$value instanceof RouteInterface) {
+            throw new \InvalidArgumentException('Value must be of type: ' . RouteInterface::class);
+        }
+
+        if (empty($value->getStaticPrefix())) {
+            return null;
+        }
+
+        $value->setContent($entity);
+        $value->generateRouteName();
+
+        $translationRoute = new TranslationRoute();
+        $translationRoute->setLocale($locale);
+        $translationRoute->setProperty($property);
+        $translationRoute->setRoute($value);
+
+        $this->entityManager->persist($translationRoute);
+
+        return $translationRoute;
+    }
+
+
+    public function getRepository(): EntityRepository
+    {
+        return $this->entityManager->getRepository(TranslationRoute::class);
+    }
+
+    protected function updateTranslation($translation, $value)
+    {
+        if (!$value instanceof RouteInterface) {
+            throw new \InvalidArgumentException('Value must be of type: ' . RouteInterface::class);
+        }
+
+        if ($translation instanceof TranslationRoute) {
+            $translation->setRoute($value);
+            return;
+        }
+
+        throw new \InvalidArgumentException('Must be of type: ' . TranslationRoute::class);
+    }
+
+    protected function getTranslationValue($translation)
+    {
+        if ($translation instanceof TranslationRoute) {
+            return $translation->getRoute();
+        }
+
+        throw new \InvalidArgumentException('Must be of type: ' . TranslationRoute::class);
+    }
+
+    function findTranslations($entity, ?string $property = null): iterable
+    {
+        return $this->getRepository()->findTranslationRoutes(
+            $this->entityResolver->getName($entity),
+            $entity->getId(),
+            $property
+        );
     }
 }

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/Text/TextTranslator.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/Text/TextTranslator.php
@@ -21,50 +21,6 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  */
 class TextTranslator extends AbstractTranslator
 {
-    public function setTranslation($entity, $property, $locale, $value): void
-    {
-        if ($locale == $this->localeProvider->getDefaultLocale()) {
-            return;
-        }
-
-        $translation = $this->buffer->load($entity, $property, $locale);
-        if ($translation instanceof Translation) {
-            $translation->setTranslation($value);
-
-            return;
-        }
-
-        $translation = $this->load($entity, $property, $locale);
-        if (null === $translation) {
-            $translation = $this->createTranslation($entity, $property, $locale, $value);
-        } else {
-            $translation->setTranslation($value);
-        }
-
-        $this->buffer->store($entity, $property, $locale, $translation);
-    }
-
-    public function getTranslation($entity, $property, $locale): ?string
-    {
-        if ($locale == $this->localeProvider->getDefaultLocale()) {
-            return null;
-        }
-
-        $translation = $this->buffer->load($entity, $property, $locale);
-        if (null !== $translation) {
-            return $translation->getTranslation();
-        }
-
-        $translation = $this->load($entity, $property, $locale);
-        if (null !== $translation) {
-            $this->buffer->store($entity, $property, $locale, $translation);
-
-            return $translation->getTranslation();
-        }
-
-        return null;
-    }
-
     public function translate($entity, string $property, string $locale, array $options)
     {
         // translation data is stored inside the object
@@ -94,33 +50,53 @@ class TextTranslator extends AbstractTranslator
         parent::detach($entity, $property, $locale, $options);
     }
 
-    private function createTranslation($entity, $property, $locale, $data): Translation
+    protected function createTranslation($entity, $property, $locale, $value): Translation
     {
         $translation = new Translation();
         $translation->setObject($entity);
         $translation->setProperty($property);
         $translation->setLocale($locale);
-        $translation->setTranslation($data);
+        $translation->setTranslation($value);
         $this->entityManager->persist($translation);
 
         return $translation;
     }
 
-    private function load($entity, $property, $locale): ?Translation
+    protected function updateTranslation($translation, $value): void
     {
-        /** @var Translation $translation */
-        $translation = $this->getRepository()->findOneBy([
+        if ($translation instanceof Translation) {
+            $translation->setTranslation($value);
+            return;
+        }
+
+        throw new \InvalidArgumentException('Must be of type: ' . Translation::class);
+    }
+
+    public function findTranslations($entity, ?string $property = null): array
+    {
+        $parameters = [
             'class' => $this->entityResolver->getName($entity),
             'refId' => $entity->getId(),
-            'property' => $property,
-            'locale' => $locale,
-        ]);
+        ];
 
-        return $translation;
+        if ($property !== null) {
+            $parameters['property'] = $property;
+        }
+
+        return $this->getRepository()->findBy($parameters);
     }
 
     public function getRepository(): EntityRepository
     {
         return $this->entityManager->getRepository(Translation::class);
+    }
+
+    protected function getTranslationValue($translation)
+    {
+        if ($translation instanceof Translation) {
+            return $translation->getTranslation();
+        }
+
+        throw new \InvalidArgumentException('Must be of type: ' . Translation::class);
     }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Improve translation caching by loading all properties and locales on first access of an entity and maintain writing operations to reduce reading operations on database.
