### PR TITLE
fix: load translation buffer

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Media/FileTranslatorTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Media/FileTranslatorTest.php
@@ -124,6 +124,7 @@ class FileTranslatorTest extends TestCase
         $dependencies->repository->method('findBy')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
+        $entity->id = 1;
 
         $this->assertEquals($file,
             $translator->getTranslation($entity, 'file', 'fr')

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Route/RouteTranslatorTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Route/RouteTranslatorTest.php
@@ -129,6 +129,7 @@ class RouteTranslatorTest extends TestCase
         $dependencies->repository->method('findTranslationRoutes')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
+        $entity->id = 1;
 
         $this->assertEquals($route,
             $translator->getTranslation($entity, 'route', 'fr')

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Text/TextTranslatorTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/Text/TextTranslatorTest.php
@@ -78,6 +78,7 @@ class TextTranslatorTest extends TestCase
         $dependencies->repository->method('findBy')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
+        $entity->id = 1;
         $translator->getTranslation($entity, 'name', 'fr');
 
         $this->assertEquals('translated,,name,fr', $translator->getTranslation($entity, 'name', 'fr'));
@@ -95,6 +96,8 @@ class TextTranslatorTest extends TestCase
         $dependencies->repository->method('findBy')->willReturn([$translation]);
 
         $entity = new TranslatableMock();
+        $entity->id = 1;
+
         $translator->setTranslation($entity, 'name', 'fr', 'bingobongo');
 
         $this->assertEquals('translated,,name,fr', $translator->getTranslation($entity, 'name', 'fr'));

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/AbstractTranslator.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/AbstractTranslator.php
@@ -108,6 +108,10 @@ abstract class AbstractTranslator implements TranslatorInterface
 
     private function loadBuffer($entity): void
     {
+        if ($entity->getId() === null) {
+            return;
+        }
+
         if ($this->buffer->exists($entity)) {
             return;
         }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

fix loading entities for null id
