### PR TITLE
[ResourceBundle] fix: get parent class for proxy objects

### DIFF
--- a/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
@@ -132,12 +132,8 @@ class ResourceManager
         return null;
     }
 
-    public function getClass(string|object $value): string
+    public function getClass(object $value): string
     {
-        if (is_string($value)) {
-            return $value;
-        }
-
         if ($value instanceof Proxy) {
             return get_parent_class($value);
         }

--- a/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
@@ -132,7 +132,7 @@ class ResourceManager
         return null;
     }
 
-    public function getClass(object $value): string
+    private function getClass(object $value): string
     {
         if ($value instanceof Proxy) {
             return get_parent_class($value);

--- a/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Resource/ResourceManager.php
@@ -13,6 +13,7 @@ namespace Enhavo\Bundle\ResourceBundle\Resource;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\Persistence\Proxy;
 use Enhavo\Bundle\ResourceBundle\Delete\DeleteHandlerInterface;
 use Enhavo\Bundle\ResourceBundle\Duplicate\DuplicateFactory;
 use Enhavo\Bundle\ResourceBundle\Event\ResourcePostCreateEvent;
@@ -122,13 +123,26 @@ class ResourceManager
         foreach ($this->resources as $key => $config) {
             if (is_string($value) && $key === $value
                 || is_string($value) && $config['classes']['model'] === $value
-                || is_object($value) && $config['classes']['model'] === get_class($value)
+                || is_object($value) && $config['classes']['model'] === $this->getClass($value)
             ) {
                 return new Metadata($key, $config);
             }
         }
 
         return null;
+    }
+
+    public function getClass(string|object $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Proxy) {
+            return get_parent_class($value);
+        }
+
+        return get_class($value);
     }
 
     public function getLabel(string|object $value): ?string


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

For objects loaded by Doctrine through a relation, the given value in ResourceManager->getMetadata is of type Proxy but we need the resource's class name.
Therefore a getClass function was introduced to check for parent_class in those cases. 
