### PR TITLE
[UserBundle] fix: enhavo_user_admin_api_user_batch to use grid

### DIFF
--- a/src/Enhavo/Bundle/UserBundle/Resources/config/routes/admin_api/user.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/routes/admin_api/user.yaml
@@ -63,7 +63,7 @@ enhavo_user_admin_api_user_batch:
         _describe: admin
         _endpoint:
             type: resource_batch
-            grid: enhavo_user.batch
+            grid: enhavo_user.user
 
 enhavo_user_admin_api_user_auto_complete:
     path: '/user/auto-complete'


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

enhavo_user_admin_api_user_batch to use grid: enhavo_user.user as enhavo_user.batch does not exist
