### PR TITLE
fix: [RoutingBundle] Fix route validator

### DIFF
--- a/src/Enhavo/Bundle/RoutingBundle/Validator/Constraints/RouteValidator.php
+++ b/src/Enhavo/Bundle/RoutingBundle/Validator/Constraints/RouteValidator.php
@@ -30,7 +30,7 @@ class RouteValidator extends ConstraintValidator
 
     public function validate($value, Constraint $constraint)
     {
-        if (!preg_match('#^/[/a-z0-9-_%]*#', $value->getStaticPrefix())) {
+        if (!preg_match('#^/[/a-z0-9-_%]*$#', $value->getStaticPrefix())) {
             $this->context->buildViolation($constraint->urlValidation)
                 ->setParameter('%string%', $value->getStaticPrefix())
                 ->addViolation();


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Fix missing end anchor in RouteValidator regex allowing invalid urls