### PR TITLE
Fix roles structure

### DIFF
--- a/docs/book/bundles/api-bundle/endpoint-extensions.md
+++ b/docs/book/bundles/api-bundle/endpoint-extensions.md
@@ -19,7 +19,7 @@ use Enhavo\Bundle\ApiBundle\Data\Data;
 use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointType;
 use Enhavo\Bundle\ApiBundle\Endpoint\Context;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class SectionEndpointType extends AbstractEndpointType
 {
@@ -105,4 +105,3 @@ public function handleRequest($options, Request $request, Data $data, Context $c
 This is often useful if you retrieve an object from e.g. a repository and then normalize it. If you pass it also to the context,
 then the next extensions don't have to retrieve it again. This may increase performance as well. 
 :::
-

--- a/docs/book/bundles/api-bundle/endpoints.md
+++ b/docs/book/bundles/api-bundle/endpoints.md
@@ -14,7 +14,7 @@ use Enhavo\Bundle\ApiBundle\Data\Data;
 use Enhavo\Bundle\ApiBundle\Endpoint\AbstractEndpointType;
 use Enhavo\Bundle\ApiBundle\Endpoint\Context;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route(path: '/book/{slug}', name: 'app_book', defaults: ['_format' => 'html'])]
 class BookEndpointType extends AbstractEndpointType
@@ -170,5 +170,3 @@ app_other_book:
             type: App\Endpoint\BookEndpointType
             description: false
 ```
-
-

--- a/playground/app/src/Controller/ErrorController.php
+++ b/playground/app/src/Controller/ErrorController.php
@@ -12,7 +12,7 @@
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/error')]
 class ErrorController extends AbstractController
@@ -20,7 +20,7 @@ class ErrorController extends AbstractController
     #[Route('/default')]
     public function showDefaultAction()
     {
-        throw new RuntimeException();
+        throw new \RuntimeException();
     }
 
     #[Route('/404')]

--- a/playground/app/src/Controller/FormController.php
+++ b/playground/app/src/Controller/FormController.php
@@ -31,7 +31,7 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/form')]
 class FormController extends AbstractController

--- a/playground/app/src/Controller/PersonController.php
+++ b/playground/app/src/Controller/PersonController.php
@@ -15,7 +15,7 @@ use App\Form\Type\PersonType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/person')]
 class PersonController extends AbstractController

--- a/playground/app/src/Endpoint/Form/FormListEndpointType.php
+++ b/playground/app/src/Endpoint/Form/FormListEndpointType.php
@@ -15,7 +15,7 @@ use App\Form\Type\Form\ItemsType;
 use Enhavo\Bundle\FormBundle\Form\Type\ListType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/form/list', name: 'app_form_list')]
 class FormListEndpointType extends AbstractFormEndpointType

--- a/playground/app/src/Endpoint/HelloEndpoint.php
+++ b/playground/app/src/Endpoint/HelloEndpoint.php
@@ -19,7 +19,7 @@ use Enhavo\Bundle\ApiBundle\Endpoint\Context;
 use Enhavo\Bundle\FrameworkBundle\Endpoint\Type\ViewEndpointType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route(path: '/hello', name: 'app_theme_hello', defaults: ['_format' => 'html'])]
 #[Route(path: '/api/hello', defaults: ['_format' => 'json', '_describe' => true])]

--- a/playground/app/src/Endpoint/SettingEndpoint.php
+++ b/playground/app/src/Endpoint/SettingEndpoint.php
@@ -17,7 +17,7 @@ use Enhavo\Bundle\ApiBundle\Endpoint\Context;
 use Enhavo\Bundle\FrameworkBundle\Endpoint\Type\ViewEndpointType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route(path: '/setting', name: 'app_theme_setting', defaults: ['_format' => 'json'])]
 class SettingEndpoint extends AbstractEndpointType

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/app/config.yaml
@@ -115,18 +115,3 @@ enhavo_comment:
     subjects:
         Enhavo\Bundle\ArticleBundle\Entity\Article:
             title_property: title
-
-security:
-    role_hierarchy:
-        ROLE_ENHAVO_TAXONOMY_TAXONOMY_INDEX:
-            - ROLE_ENHAVO_ARTICLE_CATEGORY_INDEX
-            - ROLE_ENHAVO_ARTICLE_TAG_INDEX
-        ROLE_ENHAVO_TAXONOMY_TAXONOMY_CREATE:
-            - ROLE_ENHAVO_ARTICLE_CATEGORY_CREATE
-            - ROLE_ENHAVO_ARTICLE_TAG_CREATE
-        ROLE_ENHAVO_TAXONOMY_TAXONOMY_UPDATE:
-            - ROLE_ENHAVO_ARTICLE_CATEGORY_UPDATE
-            - ROLE_ENHAVO_ARTICLE_TAG_UPDATE
-        ROLE_ENHAVO_TAXONOMY_TAXONOMY_DELETE:
-            - ROLE_ENHAVO_ARTICLE_CATEGORY_DELETE
-            - ROLE_ENHAVO_ARTICLE_TAG_DELETE

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/app/config.yaml
@@ -39,20 +39,55 @@ enhavo_app:
     roles:
         enhavo_article_article_index:
             role: ROLE_ENHAVO_ARTICLE_ARTICLE_INDEX
-            label: article.role.label.index
+            label: article.role.article.label.index
             translation_domain: EnhavoArticleBundle
         enhavo_article_article_create:
             role: ROLE_ENHAVO_ARTICLE_ARTICLE_CREATE
-            label: article.role.label.create
+            label: article.role.article.label.create
             translation_domain: EnhavoArticleBundle
         enhavo_article_article_update:
             role: ROLE_ENHAVO_ARTICLE_ARTICLE_UPDATE
-            label: article.role.label.update
+            label: article.role.article.label.update
             translation_domain: EnhavoArticleBundle
         enhavo_article_article_delete:
             role: ROLE_ENHAVO_ARTICLE_ARTICLE_DELETE
-            label: article.role.label.delete
+            label: article.role.article.label.delete
             translation_domain: EnhavoArticleBundle
+
+        enhavo_article_category_index:
+            role: ROLE_ENHAVO_ARTICLE_CATEGORY_INDEX
+            label: article.role.category.label.index
+            translation_domain: EnhavoArticleBundle
+        enhavo_article_category_create:
+            role: ROLE_ENHAVO_ARTICLE_CATEGORY_CREATE
+            label: article.role.category.label.create
+            translation_domain: EnhavoArticleBundle
+        enhavo_article_category_update:
+            role: ROLE_ENHAVO_ARTICLE_CATEGORY_UPDATE
+            label: article.role.category.label.update
+            translation_domain: EnhavoArticleBundle
+        enhavo_article_category_delete:
+            role: ROLE_ENHAVO_ARTICLE_CATEGORY_DELETE
+            label: article.role.category.label.delete
+            translation_domain: EnhavoArticleBundle
+
+        enhavo_article_tag_index:
+            role: ROLE_ENHAVO_ARTICLE_TAG_INDEX
+            label: article.role.tag.label.index
+            translation_domain: EnhavoArticleBundle
+        enhavo_article_tag_create:
+            role: ROLE_ENHAVO_ARTICLE_TAG_CREATE
+            label: article.role.tag.label.create
+            translation_domain: EnhavoArticleBundle
+        enhavo_article_tag_update:
+            role: ROLE_ENHAVO_ARTICLE_TAG_UPDATE
+            label: article.role.tag.label.update
+            translation_domain: EnhavoArticleBundle
+        enhavo_article_tag_delete:
+            role: ROLE_ENHAVO_ARTICLE_TAG_DELETE
+            label: article.role.tag.label.delete
+            translation_domain: EnhavoArticleBundle
+
 
 enhavo_taxonomy:
     taxonomies:
@@ -80,3 +115,18 @@ enhavo_comment:
     subjects:
         Enhavo\Bundle\ArticleBundle\Entity\Article:
             title_property: title
+
+security:
+    role_hierarchy:
+        ROLE_ENHAVO_TAXONOMY_TAXONOMY_INDEX:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_INDEX
+            - ROLE_ENHAVO_ARTICLE_TAG_INDEX
+        ROLE_ENHAVO_TAXONOMY_TAXONOMY_CREATE:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_CREATE
+            - ROLE_ENHAVO_ARTICLE_TAG_CREATE
+        ROLE_ENHAVO_TAXONOMY_TAXONOMY_UPDATE:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_UPDATE
+            - ROLE_ENHAVO_ARTICLE_TAG_UPDATE
+        ROLE_ENHAVO_TAXONOMY_TAXONOMY_DELETE:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_DELETE
+            - ROLE_ENHAVO_ARTICLE_TAG_DELETE

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/article.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/article.yaml
@@ -14,7 +14,7 @@ enhavo_resource:
             actions:
                 create:
                     type: create
-                    permission: 'expr:permission("enhavo_article.article", "create")'
+                    permission: ROLE_ENHAVO_ARTICLE_ARTICLE_CREATE
                     route: 'expr:resolve_route("create", {api: false})'
             filters:
                 title:
@@ -61,10 +61,10 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
-                    permission: 'expr:permission("enhavo_article.article", "delete")'
+                    permission: ROLE_ENHAVO_ARTICLE_ARTICLE_DELETE
                 publish:
                     type: publish
-                    permission: 'expr:permission("enhavo_article.article", "update")'
+                    permission: ROLE_ENHAVO_ARTICLE_ARTICLE_UPDATE
 
     inputs:
         enhavo_article.article:

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/category.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/category.yaml
@@ -5,9 +5,20 @@ enhavo_resource:
             collection:
                 repository_arguments:
                     - 'article_category'
+            permission: ROLE_ENHAVO_ARTICLE_CATEGORY_INDEX
 
     inputs:
         enhavo_article.category:
             extends: enhavo_taxonomy.term
             factory_arguments:
                 - 'article_category'
+            permission: ROLE_ENHAVO_ARTICLE_CATEGORY_UPDATE
+            actions:
+                save:
+                    type: save
+                    permission: ROLE_ENHAVO_ARTICLE_CATEGORY_CREATE
+            actions_secondary:
+                delete:
+                    type: delete
+                    enabled: expr:resource && resource.getId()
+                    permission: expr:permission("enhavo_article.category", "delete")

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/category.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/category.yaml
@@ -9,14 +9,14 @@ enhavo_resource:
             actions:
                 create:
                     type: create
-                    permission: 'expr:permission("enhavo_article.category", "create")'
+                    permission: ROLE_ENHAVO_ARTICLE_CATEGORY_CREATE
                     route: 'expr:resolve_route("create", {api: false})'
     inputs:
         enhavo_article.category:
             extends: enhavo_taxonomy.term
             factory_arguments:
                 - 'article_category'
-            permission: ROLE_ENHAVO_ARTICLE_CATEGORY_UPDATE
+            permission: ROLE_ENHAVO_ARTICLE_CATEGORY_INDEX
             actions:
                 save:
                     type: save
@@ -25,4 +25,4 @@ enhavo_resource:
                 delete:
                     type: delete
                     enabled: expr:resource && resource.getId()
-                    permission: expr:permission("enhavo_article.category", "delete")
+                    permission: ROLE_ENHAVO_ARTICLE_CATEGORY_DELETE

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/category.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/category.yaml
@@ -6,7 +6,11 @@ enhavo_resource:
                 repository_arguments:
                     - 'article_category'
             permission: ROLE_ENHAVO_ARTICLE_CATEGORY_INDEX
-
+            actions:
+                create:
+                    type: create
+                    permission: 'expr:permission("enhavo_article.category", "create")'
+                    route: 'expr:resolve_route("create", {api: false})'
     inputs:
         enhavo_article.category:
             extends: enhavo_taxonomy.term

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/tag.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/tag.yaml
@@ -6,7 +6,11 @@ enhavo_resource:
                 repository_arguments:
                     - 'article_tag'
             permission: ROLE_ENHAVO_ARTICLE_TAG_INDEX
-
+            actions:
+                create:
+                    type: create
+                    permission: 'expr:permission("enhavo_article.tag", "create")'
+                    route: 'expr:resolve_route("create", {api: false})'
     inputs:
         enhavo_article.tag:
             extends: enhavo_taxonomy.term

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/tag.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/tag.yaml
@@ -9,14 +9,14 @@ enhavo_resource:
             actions:
                 create:
                     type: create
-                    permission: 'expr:permission("enhavo_article.tag", "create")'
+                    permission: ROLE_ENHAVO_ARTICLE_TAG_CREATE
                     route: 'expr:resolve_route("create", {api: false})'
     inputs:
         enhavo_article.tag:
             extends: enhavo_taxonomy.term
             factory_arguments:
                 - 'article_tag'
-            permission: ROLE_ENHAVO_ARTICLE_TAG_UPDATE
+            permission: ROLE_ENHAVO_ARTICLE_TAG_INDEX
             actions:
                 save:
                     type: save
@@ -25,4 +25,4 @@ enhavo_resource:
                 delete:
                     type: delete
                     enabled: expr:resource && resource.getId()
-                    permission: expr:permission("enhavo_article.tag", "delete")
+                    permission: ROLE_ENHAVO_ARTICLE_TAG_DELETE

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/tag.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/resources/tag.yaml
@@ -5,10 +5,20 @@ enhavo_resource:
             collection:
                 repository_arguments:
                     - 'article_tag'
-
+            permission: ROLE_ENHAVO_ARTICLE_TAG_INDEX
 
     inputs:
         enhavo_article.tag:
             extends: enhavo_taxonomy.term
             factory_arguments:
                 - 'article_tag'
+            permission: ROLE_ENHAVO_ARTICLE_TAG_UPDATE
+            actions:
+                save:
+                    type: save
+                    permission: ROLE_ENHAVO_ARTICLE_TAG_CREATE
+            actions_secondary:
+                delete:
+                    type: delete
+                    enabled: expr:resource && resource.getId()
+                    permission: expr:permission("enhavo_article.tag", "delete")

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/translations/EnhavoArticleBundle.de.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/translations/EnhavoArticleBundle.de.yaml
@@ -1,44 +1,57 @@
 article:
-  role:
+    role:
+        article:
+            label:
+                index: 'Artikel anzeigen'
+                update: 'Artikel bearbeiten'
+                create: 'Artikel erstellen'
+                delete: 'Artikel löschen'
+        category:
+            label:
+                index: 'Artikel-Kategorie anzeigen'
+                update: 'Artikel-Kategorie bearbeiten'
+                create: 'Artikel-Kategorie erstellen'
+                delete: 'Artikel-Kategorie löschen'
+        tag:
+            label:
+                index: 'Artikel-Tag anzeigen'
+                update: 'Artikel-Tag bearbeiten'
+                create: 'Artikel-Tag erstellen'
+                delete: 'Artikel-Tag löschen'
+    form:
+        label:
+            page_title: 'Seitentitel'
+            public: 'Öffentlich'
+            social_media: 'Social Media'
+            priority: 'Priorität'
+            change_frequency: 'Änderungsfrequenz'
+            publication_date: 'Erscheinungsdatum'
+            create_tag: 'Tag erstellen'
+            text_left: 'Position'
+            text_left_left: 'Text|Bild'
+            text_left_right: 'Bild|Text'
+            layout: 'Layout'
     label:
-      index: 'Artikel anzeigen'
-      update: 'Artikel bearbeiten'
-      create: 'Artikel erstellen'
-      delete: 'Artikel löschen'
-  form:
-    label:
-      page_title: 'Seitentitel'
-      public: 'Öffentlich'
-      social_media: 'Social Media'
-      priority: 'Priorität'
-      change_frequency: 'Änderungsfrequenz'
-      publication_date: 'Erscheinungsdatum'
-      create_tag: 'Tag erstellen'
-      text_left: 'Position'
-      text_left_left: 'Text|Bild'
-      text_left_right: 'Bild|Text'
-      layout: 'Layout'
-  label:
-    article: 'Artikel'
-    article_list: 'Artikel Liste'
-    article_teaser: 'Artikel Teaser'
-    comments: 'Kommentare'
-    pagination: 'Seiten'
-    limit: 'Anzahl pro Seite'
-    category: 'Kategorie'
-    tag: 'Tag'
-    teaser: 'Teaser'
-    content: 'Inhalt'
-    meta: 'Meta'
-    preview: 'Vorschau'
-    id: 'ID'
-    title: 'Titel'
-    assigned: 'Zugeordnet'
-    public: 'Öffentlich'
-    publicationDate: 'Erscheinungsdatum'
-  batch:
-    action:
-      publish: 'Veröffentlichen'
-    message:
-      confirm:
-        publish: 'Wollen sie wirklich alle ausgewählten Artikel veröffentlichen?'
+        article: 'Artikel'
+        article_list: 'Artikel Liste'
+        article_teaser: 'Artikel Teaser'
+        comments: 'Kommentare'
+        pagination: 'Seiten'
+        limit: 'Anzahl pro Seite'
+        category: 'Kategorie'
+        tag: 'Tag'
+        teaser: 'Teaser'
+        content: 'Inhalt'
+        meta: 'Meta'
+        preview: 'Vorschau'
+        id: 'ID'
+        title: 'Titel'
+        assigned: 'Zugeordnet'
+        public: 'Öffentlich'
+        publicationDate: 'Erscheinungsdatum'
+    batch:
+        action:
+            publish: 'Veröffentlichen'
+        message:
+            confirm:
+                publish: 'Wollen sie wirklich alle ausgewählten Artikel veröffentlichen?'

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/translations/EnhavoArticleBundle.en.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/translations/EnhavoArticleBundle.en.yaml
@@ -1,44 +1,57 @@
 article:
-  role:
+    role:
+        article:
+            label:
+                index: 'Article list'
+                update: 'Article update'
+                create: 'Article create'
+                delete: 'Article delete'
+        category:
+            label:
+                index: 'Article-Category list'
+                update: 'Article-Category update'
+                create: 'Article-Category create'
+                delete: 'Article-Category delete'
+        tag:
+            label:
+                index: 'Article-Tag list'
+                update: 'Article-Tag update'
+                create: 'Article-Tag create'
+                delete: 'Article-Tag delete'
+    form:
+        label:
+            page_title: 'Pagetitle'
+            public: 'Public'
+            social_media: 'Social Media'
+            priority: 'Priority'
+            change_frequency: 'Change frequency'
+            publication_date: 'Publication date'
+            create_tag: 'Create tag'
+            text_left: 'Position'
+            text_left_left: 'Text|Picture'
+            text_left_right: 'Picture|Text'
+            layout: 'Layout'
     label:
-      index: 'Article list'
-      update: 'Article update'
-      create: 'Article create'
-      delete: 'Article delete'
-  form:
-    label:
-      page_title: 'Pagetitle'
-      public: 'Public'
-      social_media: 'Social Media'
-      priority: 'Priority'
-      change_frequency: 'Change frequency'
-      publication_date: 'Publication date'
-      create_tag: 'Create tag'
-      text_left: 'Position'
-      text_left_left: 'Text|Picture'
-      text_left_right: 'Picture|Text'
-      layout: 'Layout'
-  label:
-    article: 'Article'
-    article_list: 'Article List'
-    article_teaser: 'Article Teaser'
-    comments: 'Comments'
-    pagination: 'Pagination'
-    limit: 'Limit per Page'
-    category: 'Category'
-    tag: 'Tag'
-    teaser: 'Teaser'
-    content: 'Content'
-    meta: 'Meta'
-    preview: 'Preview'
-    id: 'ID'
-    title: 'Title'
-    assigned: 'Assigned'
-    public: 'Public'
-    publicationDate: 'Publication date'
-  batch:
-    action:
-      publish: 'Publish'
-    message:
-      confirm:
-        publish: 'Do you really want to publish all selected articles?'
+        article: 'Article'
+        article_list: 'Article List'
+        article_teaser: 'Article Teaser'
+        comments: 'Comments'
+        pagination: 'Pagination'
+        limit: 'Limit per Page'
+        category: 'Category'
+        tag: 'Tag'
+        teaser: 'Teaser'
+        content: 'Content'
+        meta: 'Meta'
+        preview: 'Preview'
+        id: 'ID'
+        title: 'Title'
+        assigned: 'Assigned'
+        public: 'Public'
+        publicationDate: 'Publication date'
+    batch:
+        action:
+            publish: 'Publish'
+        message:
+            confirm:
+                publish: 'Do you really want to publish all selected articles?'

--- a/src/Enhavo/Bundle/CalendarBundle/Resources/config/resources/appointment.yaml
+++ b/src/Enhavo/Bundle/CalendarBundle/Resources/config/resources/appointment.yaml
@@ -9,6 +9,11 @@ enhavo_resource:
         enhavo_calendar.appointment:
             extends: enhavo_resource.grid
             resource: enhavo_calendar.appointment
+            actions:
+                create:
+                    type: create
+                    permission: ROLE_ENHAVO_CALENDAR_APPOINTMENT_CREATE
+                    route: 'expr:resolve_route("create", {api: false})'
             filters:
                 title:
                     type: text
@@ -31,6 +36,7 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_CALENDAR_APPOINTMENT_DELETE
     inputs:
         enhavo_calendar.appointment:
             extends: enhavo_resource.input

--- a/src/Enhavo/Bundle/MediaBundle/Endpoint/Type/FileEndpointType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Endpoint/Type/FileEndpointType.php
@@ -67,7 +67,7 @@ class FileEndpointType extends AbstractEndpointType
         $resolver->setDefaults([
             'repository_method' => 'findFileBy',
             'repository_arguments' => [
-                ['token' => 'expr:request.get("token")'],
+                ['token' => 'expr:request.query.get("token")'],
             ],
             'permission' => 'ROLE_ENHAVO_MEDIA_FILE_SHOW',
         ]);

--- a/src/Enhavo/Bundle/MediaBundle/Endpoint/Type/FormatEndpointType.php
+++ b/src/Enhavo/Bundle/MediaBundle/Endpoint/Type/FormatEndpointType.php
@@ -72,7 +72,7 @@ class FormatEndpointType extends AbstractEndpointType
         $resolver->setDefaults([
             'repository_method' => 'findFileBy',
             'repository_arguments' => [
-                ['token' => 'expr:request.get("token")'],
+                ['token' => 'expr:request.query.get("token")'],
             ],
             'filename_test' => true,
             'permission' => 'ROLE_ENHAVO_MEDIA_FILE_SHOW',

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/app/config.yaml
@@ -35,3 +35,14 @@ enhavo_media:
                     type: media_download
                 format:
                     type: media_format
+
+enhavo_app:
+    roles:
+        enhavo_media_file_show:
+            role: ROLE_ENHAVO_MEDIA_FILE_SHOW
+            label: media.role.file.label.show
+            translation_domain: EnhavoMediaBundle
+        enhavo_media_file_create:
+            role: ROLE_ENHAVO_MEDIA_FILE_CREATE
+            label: media.role.file.label.create
+            translation_domain: EnhavoMediaBundle

--- a/src/Enhavo/Bundle/MediaBundle/Resources/config/routes/theme/format.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/config/routes/theme/format.yaml
@@ -10,6 +10,6 @@ enhavo_media_theme_format:
             type: media_format
             permission: ~
             repository_arguments:
-                - token: expr:request.get("token")
-                  filename: 'expr:pathinfo(request.get("basename"),8)'
-                  shortChecksum: expr:request.get("shortChecksum")
+                - token: expr:request.query.get("token")
+                  filename: 'expr:pathinfo(request.query.get("basename"),8)'
+                  shortChecksum: expr:request.query.get("shortChecksum")

--- a/src/Enhavo/Bundle/MediaBundle/Resources/translations/EnhavoMediaBundle.de.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/translations/EnhavoMediaBundle.de.yaml
@@ -1,33 +1,38 @@
 file:
-  label:
-    file: "Datei"
+    label:
+        file: "Datei"
 
 media:
-  label:
-    drop_hint: "Ziehen Sie Dateien aus Ihrem Datei-Explorer / Finder auf diese Fläche."
-  form:
     label:
-      title: "Titel"
-      alt_tag: "Alt-Tag"
-      filename: "Dateiname"
-      slug: "Slug"
-      download: "Herunterladen"
-    message:
-      upload_error: "Fehler beim hochladen der Datei"
-    action:
-        format: 'Format'
-        download: 'Download'
-        upload: 'Upload'
-  image_cropper:
-    action:
-      open_image_cropper: "Bild bearbeiten"
-      submit: "Anwenden"
-    label:
-      image_cropper: "Bild zuschneiden"
-      tooltip_move: "Bild bewegen"
-      tooltip_cropframe: "Rahmen ziehen"
-      tooltip_zoom_in: "Einzoomen"
-      tooltip_zoom_out: "Auszoomen"
-      tooltip_reset: "Zurücksetzen"
-    message:
-      save: 'Erfolgreich gespeichert'
+        drop_hint: "Ziehen Sie Dateien aus Ihrem Datei-Explorer / Finder auf diese Fläche."
+    form:
+        label:
+            title: "Titel"
+            alt_tag: "Alt-Tag"
+            filename: "Dateiname"
+            slug: "Slug"
+            download: "Herunterladen"
+        message:
+            upload_error: "Fehler beim hochladen der Datei"
+        action:
+            format: 'Format'
+            download: 'Download'
+            upload: 'Upload'
+    image_cropper:
+        action:
+            open_image_cropper: "Bild bearbeiten"
+            submit: "Anwenden"
+        label:
+            image_cropper: "Bild zuschneiden"
+            tooltip_move: "Bild bewegen"
+            tooltip_cropframe: "Rahmen ziehen"
+            tooltip_zoom_in: "Einzoomen"
+            tooltip_zoom_out: "Auszoomen"
+            tooltip_reset: "Zurücksetzen"
+        message:
+            save: 'Erfolgreich gespeichert'
+        role:
+            file:
+                label:
+                    show: 'Datei anzeigen'
+                    create: 'Datei erstellen'

--- a/src/Enhavo/Bundle/MediaBundle/Resources/translations/EnhavoMediaBundle.en.yaml
+++ b/src/Enhavo/Bundle/MediaBundle/Resources/translations/EnhavoMediaBundle.en.yaml
@@ -1,33 +1,38 @@
 file:
-  label:
-    file: "File"
+    label:
+        file: "File"
 
 media:
-  label:
-    drop_hint: "Drag files from your file explorer onto this area."
-  form:
     label:
-      title: "Title"
-      alt_tag: "Alt-Tag"
-      filename: "Filename"
-      slug: "Slug"
-      download: "Download"
-    message:
-      upload_error: "Error with file upload"
-    action:
-        format: 'Format'
-        download: 'Download'
-        upload: 'Upload'
-  image_cropper:
-    action:
-      open_image_cropper: "Edit image"
-      submit: "Apply"
-    label:
-      image_cropper: "Image cropper"
-      tooltip_move: "Move"
-      tooltip_cropframe: "Crop"
-      tooltip_zoom_in: "Zoom in"
-      tooltip_zoom_out: "Zoom out"
-      tooltip_reset: "Reset"
-    message:
-      save: 'Save successful'
+        drop_hint: "Drag files from your file explorer onto this area."
+    form:
+        label:
+            title: "Title"
+            alt_tag: "Alt-Tag"
+            filename: "Filename"
+            slug: "Slug"
+            download: "Download"
+        message:
+            upload_error: "Error with file upload"
+        action:
+            format: 'Format'
+            download: 'Download'
+            upload: 'Upload'
+    image_cropper:
+        action:
+            open_image_cropper: "Edit image"
+            submit: "Apply"
+        label:
+            image_cropper: "Image cropper"
+            tooltip_move: "Move"
+            tooltip_cropframe: "Crop"
+            tooltip_zoom_in: "Zoom in"
+            tooltip_zoom_out: "Zoom out"
+            tooltip_reset: "Reset"
+        message:
+            save: 'Save successful'
+    role:
+        file:
+            label:
+                show: 'File show'
+                create: 'File create'

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Endpoint/MediaLibraryApplyEndpointType.php
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Endpoint/MediaLibraryApplyEndpointType.php
@@ -43,7 +43,7 @@ class MediaLibraryApplyEndpointType extends AbstractEndpointType
             throw $this->createNotFoundException();
         }
 
-        $this->denyAccessUnlessGranted(new Permission($input->getResourceName(), $options['permission']), $resource);
+        $this->denyAccessUnlessGranted($input->getPermission($options['permission']), $resource);
 
         /** @var LibraryFileInterface $file */
         $file = $resource->getFile();

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/item.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/item.yaml
@@ -11,7 +11,7 @@ enhavo_resource:
             actions:
                 select:
                     type: media_library_select
-                    enabled: "expr:request.get('mode') === 'select'"
+                    enabled: "expr:request.query.get('mode') === 'select'"
                 upload:
                     type: media_library_upload
             collection:
@@ -44,10 +44,10 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
-                    enabled: "expr:request.get('mode') !== 'select'"
+                    enabled: "expr:request.query.get('mode') !== 'select'"
                 select:
                     type: Enhavo\Bundle\MediaLibraryBundle\Batch\Type\MediaLibrarySelectBatchType
-                    enabled: "expr:request.get('mode') === 'select'"
+                    enabled: "expr:request.query.get('mode') === 'select'"
             columns:
                 name:
                     type: multiple_property

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/item.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/item.yaml
@@ -45,6 +45,7 @@ enhavo_resource:
                 delete:
                     type: delete
                     enabled: "expr:request.query.get('mode') !== 'select'"
+                    permission: ROLE_ENHAVO_MEDIA_LIBRARY_ITEM_DELETE
                 select:
                     type: Enhavo\Bundle\MediaLibraryBundle\Batch\Type\MediaLibrarySelectBatchType
                     enabled: "expr:request.query.get('mode') === 'select'"

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/tag.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/tag.yaml
@@ -9,15 +9,18 @@ enhavo_resource:
             actions:
                 create:
                     type: create
-                    permission: 'expr:permission("enhavo_media_library.tag", "create")'
+                    permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_CREATE
                     route: 'expr:resolve_route("create", {api: false})'
-
+            batches:
+                delete:
+                    type: delete
+                    permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_DELETE
     inputs:
         enhavo_media_library.tag:
             extends: enhavo_taxonomy.term
             factory_arguments:
                 - 'media_library_tag'
-            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_UPDATE
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_INDEX
             actions:
                 save:
                     type: save
@@ -26,4 +29,4 @@ enhavo_resource:
                 delete:
                     type: delete
                     enabled: expr:resource && resource.getId()
-                    permission: expr:permission("enhavo_media_library.tag", "delete")
+                    permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_DELETE

--- a/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/tag.yaml
+++ b/src/Enhavo/Bundle/MediaLibraryBundle/Resources/config/resources/tag.yaml
@@ -5,10 +5,25 @@ enhavo_resource:
             collection:
                 repository_arguments:
                     - 'media_library_tag'
-
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_INDEX
+            actions:
+                create:
+                    type: create
+                    permission: 'expr:permission("enhavo_media_library.tag", "create")'
+                    route: 'expr:resolve_route("create", {api: false})'
 
     inputs:
         enhavo_media_library.tag:
             extends: enhavo_taxonomy.term
             factory_arguments:
                 - 'media_library_tag'
+            permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_UPDATE
+            actions:
+                save:
+                    type: save
+                    permission: ROLE_ENHAVO_MEDIA_LIBRARY_TAG_CREATE
+            actions_secondary:
+                delete:
+                    type: delete
+                    enabled: expr:resource && resource.getId()
+                    permission: expr:permission("enhavo_media_library.tag", "delete")

--- a/src/Enhavo/Bundle/NavigationBundle/Resources/config/resources/navigation.yaml
+++ b/src/Enhavo/Bundle/NavigationBundle/Resources/config/resources/navigation.yaml
@@ -10,6 +10,11 @@ enhavo_resource:
         enhavo_navigation.navigation:
             extends: enhavo_resource.grid
             resource: enhavo_navigation.navigation
+            actions:
+                create:
+                    type: create
+                    permission: ROLE_ENHAVO_NAVIGATION_NAVIGATION_CREATE
+                    route: 'expr:resolve_route("create", {api: false})'
             columns:
                 name:
                     type: text
@@ -17,6 +22,10 @@ enhavo_resource:
                     label: navigation.label.name
                     translation_domain: EnhavoNavigationBundle
                     width: 10
+            batches:
+                delete:
+                    type: delete
+                    permission: ROLE_ENHAVO_NAVIGATION_NAVIGATION_DELETE
     inputs:
         enhavo_navigation.navigation:
             extends: enhavo_resource.input

--- a/src/Enhavo/Bundle/NewsletterBundle/Resources/config/resources/group.yaml
+++ b/src/Enhavo/Bundle/NewsletterBundle/Resources/config/resources/group.yaml
@@ -13,7 +13,7 @@ enhavo_resource:
             actions:
                 create:
                     type: create
-                    permission: 'expr:permission("enhavo_newsletter.group", "create")'
+                    permission: ROLE_ENHAVO_NEWSLETTER_GROUP_CREATE
                     route: 'expr:resolve_route("create", {api: false})'
             columns:
                 name:
@@ -35,6 +35,7 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_NEWSLETTER_GROUP_DELETE
     inputs:
         enhavo_newsletter.group:
             extends: enhavo_resource.input

--- a/src/Enhavo/Bundle/NewsletterBundle/Resources/config/resources/newsletter.yaml
+++ b/src/Enhavo/Bundle/NewsletterBundle/Resources/config/resources/newsletter.yaml
@@ -9,7 +9,11 @@ enhavo_resource:
         enhavo_newsletter.newsletter:
             extends: enhavo_resource.grid
             resource: enhavo_newsletter.newsletter
-            actions: {  }
+            actions:
+                create:
+                    type: create
+                    permission: ROLE_ENHAVO_NEWSLETTER_NEWSLETTER_CREATE
+                    route: 'expr:resolve_route("create", {api: false})'
             filters:
                 subject:
                     type: text
@@ -39,6 +43,7 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_NEWSLETTER_NEWSLETTER_DELETE
                 newsletter_send:
                     type: newsletter_send
                 newsletter_send_test:

--- a/src/Enhavo/Bundle/NewsletterBundle/Resources/config/resources/pending_subscriber.yaml
+++ b/src/Enhavo/Bundle/NewsletterBundle/Resources/config/resources/pending_subscriber.yaml
@@ -43,6 +43,7 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_NEWSLETTER_PENDING_SUBSCRIBER_DELETE
     inputs:
         enhavo_newsletter.pending_subscriber:
             extends: enhavo_resource.input

--- a/src/Enhavo/Bundle/PageBundle/Resources/config/resources/page.yaml
+++ b/src/Enhavo/Bundle/PageBundle/Resources/config/resources/page.yaml
@@ -12,7 +12,7 @@ enhavo_resource:
             actions:
                 create:
                     type: create
-                    permission: 'expr:permission("enhavo_page.page", "create")'
+                    permission: ROLE_ENHAVO_PAGE_PAGE_CREATE
                     route: 'expr:resolve_route("create", {api: false})'
             resource: enhavo_page.page
             collection:
@@ -61,10 +61,10 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
-                    permission: 'expr:permission("enhavo_page.page", "delete")'
+                    permission: ROLE_ENHAVO_PAGE_PAGE_DELETE
                 publish:
                     type: publish
-                    permission: 'expr:permission("enhavo_page.page", "delete")'
+                    permission: ROLE_ENHAVO_PAGE_PAGE_UPDATE
 
     inputs:
         enhavo_page.page:

--- a/src/Enhavo/Bundle/RedirectBundle/Resources/config/resources/redirect.yaml
+++ b/src/Enhavo/Bundle/RedirectBundle/Resources/config/resources/redirect.yaml
@@ -10,7 +10,11 @@ enhavo_resource:
         enhavo_redirect.redirect:
             extends: enhavo_resource.grid
             resource: enhavo_redirect.redirect
-            actions: {  }
+            actions:
+                create:
+                    type: create
+                    permission: ROLE_ENHAVO_REDIRECT_REDIRECT_CREATE
+                    route: 'expr:resolve_route("create", {api: false})'
             filters:
                 from:
                     type: text
@@ -52,6 +56,7 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_REDIRECT_REDIRECT_DELETE
     inputs:
         enhavo_redirect.redirect:
             extends: enhavo_resource.input

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceCreateEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceCreateEndpointType.php
@@ -45,7 +45,7 @@ class ResourceCreateEndpointType extends AbstractEndpointType
         /** @var Input $input */
         $input = $this->inputFactory->create($options['input']);
 
-        $this->denyAccessUnlessGranted(new Permission($input->getResourceName(), $options['permission']));
+        $this->denyAccessUnlessGranted($input->getPermission($options['permission']));
 
         $resource = $input->createResource();
 

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceDeleteEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceDeleteEndpointType.php
@@ -41,7 +41,7 @@ class ResourceDeleteEndpointType extends AbstractEndpointType
         $input = $this->inputFactory->create($options['input']);
         $resource = $input->getResource();
 
-        $this->denyAccessUnlessGranted(new Permission($input->getResourceName(), $options['permission']), $resource);
+        $this->denyAccessUnlessGranted($input->getPermission($options['permission']), $resource);
 
         if (null === $resource) {
             throw $this->createNotFoundException();

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceDuplicateEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceDuplicateEndpointType.php
@@ -47,7 +47,7 @@ class ResourceDuplicateEndpointType extends AbstractEndpointType
             throw $this->createNotFoundException();
         }
 
-        $this->denyAccessUnlessGranted(new Permission($input->getResourceName(), $options['permission']), $resource);
+        $this->denyAccessUnlessGranted($input->getPermission($options['permission']), $resource);
 
         if ($this->csrfChecker->isEnabled() && !$this->csrfTokenManager->isTokenValid(new CsrfToken('resource_duplicate', $request->getPayload()->get('token')))) {
             $context->setStatusCode(400);

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceIndexEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceIndexEndpointType.php
@@ -33,7 +33,7 @@ class ResourceIndexEndpointType extends AbstractEndpointType
         /** @var Grid $grid */
         $grid = $this->gridFactory->create($options['grid']);
 
-        $this->denyAccessUnlessGranted(new Permission($grid->getResourceName(), $options['permission']));
+        $this->denyAccessUnlessGranted($grid->getPermission($options['permission']));
 
         $viewData = $grid->getViewData();
         $data->add($viewData);

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceListEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceListEndpointType.php
@@ -35,7 +35,7 @@ class ResourceListEndpointType extends AbstractEndpointType
         /** @var Grid $grid */
         $grid = $this->gridFactory->create($options['grid']);
 
-        $this->denyAccessUnlessGranted(new Permission($grid->getResourceName(), $options['permission']));
+        $this->denyAccessUnlessGranted($grid->getPermission($options['permission']));
 
         if ($request->isMethod(Request::METHOD_POST) && $this->hasAction($request)) {
             $grid->handleAction($request->getPayload()->get('action'), $request->getPayload()->all());

--- a/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceUpdateEndpointType.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Endpoint/Type/ResourceUpdateEndpointType.php
@@ -21,7 +21,6 @@ use Enhavo\Bundle\ResourceBundle\Form\FormNormalizerInterface;
 use Enhavo\Bundle\ResourceBundle\Input\Input;
 use Enhavo\Bundle\ResourceBundle\Input\InputFactory;
 use Enhavo\Bundle\ResourceBundle\Resource\ResourceManager;
-use Enhavo\Bundle\VueFormBundle\Form\VueForm;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -48,7 +47,7 @@ class ResourceUpdateEndpointType extends AbstractEndpointType
             throw $this->createNotFoundException();
         }
 
-        $this->denyAccessUnlessGranted(new Permission($input->getResourceName(), $options['permission']), $resource);
+        $this->denyAccessUnlessGranted($input->getPermission($options['permission']), $resource);
 
         $form = $input->createForm($resource);
         if ($form) {

--- a/src/Enhavo/Bundle/ResourceBundle/Grid/Grid.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Grid/Grid.php
@@ -11,6 +11,7 @@
 
 namespace Enhavo\Bundle\ResourceBundle\Grid;
 
+use Enhavo\Bundle\ResourceBundle\Authorization\Permission;
 use Enhavo\Bundle\ResourceBundle\Batch\Batch;
 use Enhavo\Bundle\ResourceBundle\Collection\CollectionInterface;
 use Enhavo\Bundle\ResourceBundle\Collection\ResourceItems;
@@ -41,8 +42,8 @@ class Grid extends AbstractGrid implements ConfigMergeInterface
                 'class' => TableCollection::class,
             ],
             'component' => 'grid-grid',
+            'permission' => null,
         ]);
-
 
         $resolver->setOptions('routes', function (OptionsResolver $routesResolver): void {
             $routesResolver->setDefaults([
@@ -220,6 +221,17 @@ class Grid extends AbstractGrid implements ConfigMergeInterface
     public function getResourceName(): string
     {
         return $this->options['resource'];
+    }
+
+    public function getPermission(string $action): mixed
+    {
+        if ($this->options['permission']) {
+            return $this->evaluate($this->options['permission'], [
+                'action' => $action,
+                'grid' => $this,
+            ]);
+        }
+        return new Permission($this->getResourceName(), $action);
     }
 
     public function getItems(array $context = []): ResourceItems

--- a/src/Enhavo/Bundle/ResourceBundle/Input/Input.php
+++ b/src/Enhavo/Bundle/ResourceBundle/Input/Input.php
@@ -12,6 +12,7 @@
 namespace Enhavo\Bundle\ResourceBundle\Input;
 
 use Enhavo\Bundle\ResourceBundle\Action\Action;
+use Enhavo\Bundle\ResourceBundle\Authorization\Permission;
 use Enhavo\Bundle\ResourceBundle\DependencyInjection\Merge\ConfigMergeInterface;
 use Enhavo\Bundle\ResourceBundle\Tab\Tab;
 use Symfony\Component\Form\FormInterface;
@@ -42,6 +43,7 @@ class Input extends AbstractInput implements ConfigMergeInterface
             ],
             'serialization_groups' => ['endpoint', 'endpoint.admin'],
             'validation_groups' => ['default'],
+            'permission' => null,
         ]);
 
         $resolver->setRequired('resource');
@@ -126,6 +128,17 @@ class Input extends AbstractInput implements ConfigMergeInterface
     public function getResourceName(): string
     {
         return $this->options['resource'];
+    }
+
+    public function getPermission(string $action): mixed
+    {
+        if ($this->options['permission']) {
+            return $this->evaluate($this->options['permission'], [
+                'action' => $action,
+                'input' => $this,
+            ]);
+        }
+        return new Permission($this->getResourceName(), $action);
     }
 
     public function getResource(array $context = []): ?object

--- a/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/app/config.yaml
@@ -8,22 +8,52 @@ enhavo_app:
     roles:
         enhavo_taxonomy_taxonomy_index:
             role: ROLE_ENHAVO_TAXONOMY_TAXONOMY_INDEX
-            label: taxonomy.role.label.index
+            label: taxonomy.role.taxonomy.label.index
             translation_domain: EnhavoTaxonomyBundle
         enhavo_taxonomy_taxonomy_create:
             role: ROLE_ENHAVO_TAXONOMY_TAXONOMY_CREATE
-            label: taxonomy.role.label.create
+            label: taxonomy.role.taxonomy.label.create
             translation_domain: EnhavoTaxonomyBundle
         enhavo_taxonomy_taxonomy_update:
             role: ROLE_ENHAVO_TAXONOMY_TAXONOMY_UPDATE
-            label: taxonomy.role.label.update
+            label: taxonomy.role.taxonomy.label.update
             translation_domain: EnhavoTaxonomyBundle
         enhavo_taxonomy_taxonomy_delete:
             role: ROLE_ENHAVO_TAXONOMY_TAXONOMY_DELETE
-            label: taxonomy.role.label.delete
+            label: taxonomy.role.taxonomy.label.delete
+            translation_domain: EnhavoTaxonomyBundle
+        enhavo_taxonomy_term_index:
+            role: ROLE_ENHAVO_TAXONOMY_TERM_INDEX
+            label: taxonomy.role.term.label.index
+            translation_domain: EnhavoTaxonomyBundle
+        enhavo_taxonomy_term_create:
+            role: ROLE_ENHAVO_TAXONOMY_TERM_CREATE
+            label: taxonomy.role.term.label.create
+            translation_domain: EnhavoTaxonomyBundle
+        enhavo_taxonomy_term_update:
+            role: ROLE_ENHAVO_TAXONOMY_TERM_UPDATE
+            label: taxonomy.role.term.label.update
+            translation_domain: EnhavoTaxonomyBundle
+        enhavo_taxonomy_term_delete:
+            role: ROLE_ENHAVO_TAXONOMY_TERM_DELETE
+            label: taxonomy.role.term.label.delete
             translation_domain: EnhavoTaxonomyBundle
 
-security:
+security: # this was added for BC. it does only matter if there are user_groups for users with taxonomy taxonomy permission enabled
     role_hierarchy:
+        ROLE_ENHAVO_TAXONOMY_TAXONOMY_INDEX:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_INDEX
+            - ROLE_ENHAVO_ARTICLE_TAG_INDEX
+            - ROLE_ENHAVO_TAXONOMY_TERM_INDEX
+        ROLE_ENHAVO_TAXONOMY_TAXONOMY_CREATE:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_CREATE
+            - ROLE_ENHAVO_ARTICLE_TAG_CREATE
+            - ROLE_ENHAVO_TAXONOMY_TERM_CREATE
         ROLE_ENHAVO_TAXONOMY_TAXONOMY_UPDATE:
-            ROLE_ENHAVO_TAXONOMY_COLLECTION_UPDATE:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_UPDATE
+            - ROLE_ENHAVO_ARTICLE_TAG_UPDATE
+            - ROLE_ENHAVO_TAXONOMY_TERM_UPDATE
+        ROLE_ENHAVO_TAXONOMY_TAXONOMY_DELETE:
+            - ROLE_ENHAVO_ARTICLE_CATEGORY_DELETE
+            - ROLE_ENHAVO_ARTICLE_TAG_DELETE
+            - ROLE_ENHAVO_TAXONOMY_TERM_DELETE

--- a/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/app/config.yaml
@@ -6,6 +6,7 @@ doctrine:
 
 enhavo_app:
     roles:
+        # this is deprecated as permissions are now assigned with intended use (such as article_tag/category.
         enhavo_taxonomy_taxonomy_index:
             role: ROLE_ENHAVO_TAXONOMY_TAXONOMY_INDEX
             label: taxonomy.role.taxonomy.label.index
@@ -22,6 +23,7 @@ enhavo_app:
             role: ROLE_ENHAVO_TAXONOMY_TAXONOMY_DELETE
             label: taxonomy.role.taxonomy.label.delete
             translation_domain: EnhavoTaxonomyBundle
+        # here instead of the former taxonomy_taxonomy (so that project based term usage can be handled via "Taxonomy-Term")
         enhavo_taxonomy_term_index:
             role: ROLE_ENHAVO_TAXONOMY_TERM_INDEX
             label: taxonomy.role.term.label.index

--- a/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/resources/term.yaml
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/resources/term.yaml
@@ -13,7 +13,7 @@ enhavo_resource:
             actions:
                 create:
                     type: create
-                    permission: 'expr:permission("enhavo_taxonomy.term", "create")'
+                    permission: ROLE_ENHAVO_TAXONOMY_TERM_CREATE
                     route: 'expr:resolve_route("create", {api: false})'
             filters:
                 name:

--- a/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/resources/term.yaml
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Resources/config/resources/term.yaml
@@ -10,6 +10,11 @@ enhavo_resource:
         enhavo_taxonomy.term_table:
             extends: enhavo_resource.grid
             resource: enhavo_taxonomy.term
+            actions:
+                create:
+                    type: create
+                    permission: 'expr:permission("enhavo_taxonomy.term", "create")'
+                    route: 'expr:resolve_route("create", {api: false})'
             filters:
                 name:
                     type: text

--- a/src/Enhavo/Bundle/TaxonomyBundle/Resources/translations/EnhavoTaxonomyBundle.de.yaml
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Resources/translations/EnhavoTaxonomyBundle.de.yaml
@@ -1,13 +1,20 @@
 taxonomy:
-  role:
+    role:
+        taxonomy:
+            label:
+                index: 'Taxonomy anzeigen'
+                update: 'Taxonomy bearbeiten'
+                create: 'Taxonomy erstellen'
+                delete: 'Taxonomy löschen'
+        term:
+            label:
+                index: 'Taxonomy-Term anzeigen'
+                update: 'Taxonomy-Term bearbeiten'
+                create: 'Taxonomy-Term erstellen'
+                delete: 'Taxonomy-Term löschen'
     label:
-      index: 'Taxonomy anzeigen'
-      update: 'Taxonomy bearbeiten'
-      create: 'Taxonomy erstellen'
-      delete: 'Taxonomy löschen'
-  label:
-    id: 'ID'
-    taxonomy: 'Kategorie'
+        id: 'ID'
+        taxonomy: 'Kategorie'
 term:
     label:
         name: 'Name'

--- a/src/Enhavo/Bundle/TaxonomyBundle/Resources/translations/EnhavoTaxonomyBundle.en.yaml
+++ b/src/Enhavo/Bundle/TaxonomyBundle/Resources/translations/EnhavoTaxonomyBundle.en.yaml
@@ -1,16 +1,23 @@
 taxonomy:
-  role:
+    role:
+        taxonomy:
+            label:
+                index: 'Taxonomy list'
+                update: 'Taxonomy update'
+                create: 'Taxonomy create'
+                delete: 'Taxonomy delete'
+        term:
+            label:
+                index: 'Taxonomy-Term list'
+                update: 'Taxonomy-Term update'
+                create: 'Taxonomy-Term create'
+                delete: 'Taxonomy-Term delete'
     label:
-      index: 'Taxonomy list'
-      update: 'Taxonomy update'
-      create: 'Taxonomy create'
-      delete: 'Taxonomy delete'
-  label:
-    id: 'ID'
-    taxonomy: 'Taxonomy'
+        id: 'ID'
+        taxonomy: 'Taxonomy'
 term:
-  label:
-    name: 'Name'
-    validation:
-      term_unique:
-        message: 'An element with this name already exists.'
+    label:
+        name: 'Name'
+        validation:
+            term_unique:
+                message: 'An element with this name already exists.'

--- a/src/Enhavo/Bundle/TemplateBundle/Resources/config/resources/template.yaml
+++ b/src/Enhavo/Bundle/TemplateBundle/Resources/config/resources/template.yaml
@@ -32,13 +32,14 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_TEMPLATE_TEMPLATE_DELETE
     inputs:
         enhavo_template.template:
             extends: enhavo_resource.input
             resource: enhavo_template.template
             form: Enhavo\Bundle\TemplateBundle\Form\Type\TemplateType
-            form_options: {  }
-            actions: {  }
+            form_options: { }
+            actions: { }
             tabs:
                 main:
                     label: template.label.template

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/resources/group.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/resources/group.yaml
@@ -10,7 +10,11 @@ enhavo_resource:
         enhavo_user.group:
             extends: enhavo_resource.grid
             resource: enhavo_user.group
-            actions: {  }
+            actions:
+                create:
+                    type: create
+                    permission: ROLE_ENHAVO_USER_GROUP_CREATE
+                    route: 'expr:resolve_route("create", {api: false})'
             filters:
                 title:
                     type: text
@@ -27,6 +31,7 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_USER_GROUP_DELETE
 
     inputs:
         enhavo_user.group:

--- a/src/Enhavo/Bundle/UserBundle/Resources/config/resources/user.yaml
+++ b/src/Enhavo/Bundle/UserBundle/Resources/config/resources/user.yaml
@@ -11,6 +11,11 @@ enhavo_resource:
         enhavo_user.user:
             extends: enhavo_resource.grid
             resource: enhavo_user.user
+            actions:
+                create:
+                    type: create
+                    permission: ROLE_ENHAVO_USER_USER_CREATE
+                    route: 'expr:resolve_route("create", {api: false})'
             filters:
                 username:
                     type: text
@@ -42,6 +47,7 @@ enhavo_resource:
             batches:
                 delete:
                     type: delete
+                    permission: ROLE_ENHAVO_USER_USER_DELETE
 
     inputs:
         enhavo_user.user.create:


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15 <!-- choose version where this PR should apply as well -->
| License      | MIT

Since the big refactoring, roles and regarding permissions were not consistent anymore.
Also some features could not be disabled/enabled by the particular role.
This update aims to restore roles and permissions so that it can be used with existing enhavo 0.15 versions.
