### PR TITLE
chore: add auto translate to app playground

### DIFF
--- a/playground/app/config/packages/enhavo_translation.yaml
+++ b/playground/app/config/packages/enhavo_translation.yaml
@@ -8,3 +8,9 @@ enhavo_translation:
     translation_client:
         deepl:
             api_key: '%env(DEEPL_API_KEY)%'
+        claude:
+            api_key: '%env(CLAUDE_API_KEY)%'
+        chain:
+            clients:
+                - Enhavo\Bundle\TranslationBundle\Client\ClaudeTranslationClient
+                - Enhavo\Bundle\TranslationBundle\Client\UrlTranslationClient

--- a/playground/app/config/reference.php
+++ b/playground/app/config/reference.php
@@ -1527,14 +1527,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     }>
  * @psalm-type EnhavoApiConfig = array{
  *     documentation?: array{
- *         section?: array<string, array{ // Default: []
- *             version?: scalar|Param|null, // Default: "3.0.0"
- *             info?: array{
- *                 title?: scalar|Param|null, // Default: null
- *                 description?: scalar|Param|null, // Default: null
- *                 version?: scalar|Param|null, // Default: null
- *             },
- *         }>,
+ *         section?: array<string, array<string, list<mixed>>>,
  *     },
  * }
  * @psalm-type EnhavoAppConfig = array{
@@ -2134,6 +2127,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         deepl?: array{
  *             api_key?: scalar|Param|null,
  *             glossary_id?: scalar|Param|null,
+ *             context?: scalar|Param|null,
+ *         },
+ *         claude?: array{
+ *             api_key?: scalar|Param|null,
+ *             version?: scalar|Param|null,
+ *             context?: scalar|Param|null,
  *         },
  *         url?: array{
  *             domains?: list<scalar|Param|null>,

--- a/playground/app/config/resources/article.yaml
+++ b/playground/app/config/resources/article.yaml
@@ -1,0 +1,7 @@
+enhavo_resource:
+    inputs:
+        enhavo_article.article:
+            actions:
+                translate:
+                    type: translate
+                    route: enhavo_article_admin_api_article_translate_resource

--- a/playground/app/config/routes/admin_api/article.yaml
+++ b/playground/app/config/routes/admin_api/article.yaml
@@ -1,0 +1,7 @@
+enhavo_article_admin_api_article_translate_resource:
+    path: /article/translate/resource
+    defaults:
+        _expose: admin_api
+        _endpoint:
+            type: translate_resource
+            resource: enhavo_article.article

--- a/src/Enhavo/Bundle/ArticleBundle/Resources/config/app/config.yaml
+++ b/src/Enhavo/Bundle/ArticleBundle/Resources/config/app/config.yaml
@@ -15,8 +15,7 @@ enhavo_routing:
         Enhavo\Bundle\ArticleBundle\Entity\Article:
             router:
                 default:
-                    type: template
-                    template: article
+                    type: routable
                 view:
                     type: id
                     route: enhavo_article_article_update

--- a/src/Enhavo/Bundle/TranslationBundle/Translation/Type/TextTranslationType.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translation/Type/TextTranslationType.php
@@ -17,7 +17,6 @@ use Enhavo\Bundle\TranslationBundle\Translator\TranslatorInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class TextTranslationType extends AbstractTranslationType
 {


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | no
| BC-Break?    | no
| License      | MIT

Add auto translate to app playground and use claude client as default
