### PR TITLE
fix: translation detach

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/DataMapTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/Translator/DataMapTest.php
@@ -35,6 +35,31 @@ class DataMapTest extends TestCase
         $this->assertEquals('testPropValueFr2', $data);
     }
 
+    public function testDeleteMultipleProperties()
+    {
+        $map = $this->createInstance();
+
+        $entity = new \stdClass();
+        $map->store($entity, 'propertyA', 'fr', 'valueA-fr');
+        $map->store($entity, 'propertyA', 'de', 'valueA-de');
+        $map->store($entity, 'propertyB', 'fr', 'valueB-fr');
+
+        $map->delete($entity, 'propertyA', 'fr');
+        $this->assertNull($map->load($entity, 'propertyA', 'fr'));
+        $this->assertEquals('valueA-de', $map->load($entity, 'propertyA', 'de'));
+        $this->assertEquals('valueB-fr', $map->load($entity, 'propertyB', 'fr'));
+        $this->assertTrue($map->exists($entity));
+
+        $map->delete($entity, 'propertyA', 'de');
+        $this->assertNull($map->load($entity, 'propertyA', 'de'));
+        $this->assertEquals('valueB-fr', $map->load($entity, 'propertyB', 'fr'));
+        $this->assertTrue($map->exists($entity));
+
+        $map->delete($entity, 'propertyB', 'fr');
+        $this->assertNull($map->load($entity, 'propertyB', 'fr'));
+        $this->assertFalse($map->exists($entity));
+    }
+
     public function testNotFound()
     {
         $map = $this->createInstance();
@@ -47,3 +72,4 @@ class DataMapTest extends TestCase
         $this->assertNull($data);
     }
 }
+

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/AbstractTranslator.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/AbstractTranslator.php
@@ -81,7 +81,7 @@ abstract class AbstractTranslator implements TranslatorInterface
         $this->setTranslation($entity, $property, $locale, $translationValue);
         $accessor->setValue($entity, $property, $originalValue);
 
-        $this->originalData->delete($entity);
+        $this->originalData->delete($entity, $property, $locale);
     }
 
     public function getDefaultValue($entity, string $property)

--- a/src/Enhavo/Bundle/TranslationBundle/Translator/DataMap.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translator/DataMap.php
@@ -53,10 +53,26 @@ class DataMap
         return null;
     }
 
-    public function delete($entity)
+    public function delete($entity, $property, $locale)
     {
         $oid = spl_object_hash($entity);
-        if (isset($this->map[$oid])) {
+        if (!isset($this->map[$oid])) {
+            return null;
+        }
+
+        $deleteKey = null;
+        foreach ($this->map[$oid] as $key => $entry) {
+            if ($entry->getProperty() === $property && $entry->getLocale() === $locale) {
+                $deleteKey = $key;
+                break;
+            }
+        }
+
+        if ($deleteKey !== null) {
+            unset($this->map[$oid][$deleteKey]);
+        }
+
+        if (count($this->map[$oid]) === 0) {
             unset($this->map[$oid]);
         }
     }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15, 0.14
| License      | MIT

Fix detach translated objects. After detach the first property, the origin data was deleted.