### PR TITLE
feat: inject translation data on normalization

### DIFF
--- a/playground/app/config/packages/enhavo_routing.yaml
+++ b/playground/app/config/packages/enhavo_routing.yaml
@@ -1,0 +1,6 @@
+enhavo_routing:
+    classes:
+        Enhavo\Bundle\PageBundle\Entity\Page:
+            router:
+                default:
+                    type: translation_route

--- a/playground/app/config/packages/enhavo_translation.yaml
+++ b/playground/app/config/packages/enhavo_translation.yaml
@@ -1,5 +1,7 @@
 enhavo_translation:
     enable: '%env(bool:TRANSLATION_ENABLED)%'
+    enable_doctrine: false
+    enable_serialization: true
     default_locale: '%locale%'
     locales:
         - 'en'

--- a/src/Enhavo/Bundle/BlockBundle/Resources/config/app/translation.yaml
+++ b/src/Enhavo/Bundle/BlockBundle/Resources/config/app/translation.yaml
@@ -14,6 +14,8 @@ enhavo_translation:
             properties:
                 title:
                     type: text
+                file:
+                    type: file
                 caption:
                     type: text
 

--- a/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/Configuration.php
+++ b/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/Configuration.php
@@ -35,6 +35,8 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->children()
                 ->scalarNode('enable')->defaultValue(false)->end()
+                ->scalarNode('enable_serialization')->defaultValue(false)->end()
+                ->scalarNode('enable_doctrine')->defaultValue(true)->end()
                 ->arrayNode('translator')
                     ->children()
                         ->scalarNode('default_access')->defaultValue(true)->end()

--- a/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/EnhavoTranslationExtension.php
+++ b/src/Enhavo/Bundle/TranslationBundle/DependencyInjection/EnhavoTranslationExtension.php
@@ -28,6 +28,8 @@ class EnhavoTranslationExtension extends Extension implements PrependExtensionIn
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('enhavo_translation.enable', $config['enable']);
+        $container->setParameter('enhavo_translation.enable_serialization', $config['enable_serialization']);
+        $container->setParameter('enhavo_translation.enable_doctrine', $config['enable_doctrine']);
         $container->setParameter('enhavo_translation.default_locale', $config['default_locale']);
         $container->setParameter('enhavo_translation.locales', $config['locales']);
         $container->setParameter('enhavo_translation.metadata', $config['metadata']);

--- a/src/Enhavo/Bundle/TranslationBundle/EventListener/DoctrineTranslationSubscriber.php
+++ b/src/Enhavo/Bundle/TranslationBundle/EventListener/DoctrineTranslationSubscriber.php
@@ -39,6 +39,7 @@ class DoctrineTranslationSubscriber implements EventSubscriber
         private AccessControl $accessControl,
         private MetadataRepository $metadataRepository,
         private LocaleResolverInterface $localeResolver,
+        private bool $enabled,
     ) {
     }
 
@@ -64,7 +65,7 @@ class DoctrineTranslationSubscriber implements EventSubscriber
      */
     public function preFlush(PreFlushEventArgs $event)
     {
-        if (!$this->accessControl->isAccess()) {
+        if (!$this->enabled || !$this->accessControl->isAccess()) {
             return;
         }
 
@@ -93,7 +94,7 @@ class DoctrineTranslationSubscriber implements EventSubscriber
      */
     public function postFlush(PostFlushEventArgs $args)
     {
-        if (!$this->accessControl->isAccess()) {
+        if (!$this->enabled || !$this->accessControl->isAccess()) {
             return;
         }
 
@@ -127,7 +128,7 @@ class DoctrineTranslationSubscriber implements EventSubscriber
      */
     public function postLoad(LifecycleEventArgs $args)
     {
-        if (!$this->accessControl->isAccess()) {
+        if (!$this->enabled || !$this->accessControl->isAccess()) {
             return;
         }
 

--- a/src/Enhavo/Bundle/TranslationBundle/Normalizer/TranslationNormalizer.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Normalizer/TranslationNormalizer.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\TranslationBundle\Normalizer;
+
+use Enhavo\Bundle\FrameworkBundle\Locale\LocaleResolverInterface;
+use Enhavo\Bundle\MediaBundle\Model\FileInterface;
+use Enhavo\Bundle\RoutingBundle\Entity\Route;
+use Enhavo\Bundle\TranslationBundle\EventListener\AccessControl;
+use Enhavo\Bundle\TranslationBundle\Translation\TranslationManager;
+use Enhavo\Component\Metadata\MetadataRepository;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class TranslationNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    public function __construct(
+        private AccessControl $accessControl,
+        private MetadataRepository $metadataRepository,
+        private LocaleResolverInterface $localeResolver,
+        private TranslationManager $translationManager,
+        private bool $enabled,
+    ) {
+    }
+
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    {
+        $context[self::class] = true;
+
+        $data = $this->normalizer->normalize($object, $format, $context);
+
+        $locale = $this->localeResolver->resolve();
+
+        $metadata = $this->metadataRepository->getMetadata($object);
+        foreach ($metadata->getProperties() ?? [] as $key => $property) {
+            if (array_key_exists($key, $data)) {
+                $this->translationManager->getTranslations($object, $key);
+                $type = $this->translationManager->getTranslation($object, $key);
+                $value = $type->getTranslation($object, $key, $locale);
+                if (is_string($value)) {
+                    $data[$key] = $value;
+                } elseif ($value instanceof FileInterface) {
+                    $data[$key] = $this->normalizer->normalize($value, $format, $context);
+                } elseif ($value instanceof Route) {
+                    $data[$key] = $this->normalizer->normalize($value, $format, $context);
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        if ($context[self::class] ?? false) {
+            return false;
+        }
+
+        if (!$this->accessControl->isAccess()) {
+            return false;
+        }
+
+        return is_object($data) && $this->metadataRepository->hasMetadata($data);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            '*' => false,
+        ];
+    }
+}

--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/general.yaml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/general.yaml
@@ -77,3 +77,23 @@ services:
     Enhavo\Bundle\TranslationBundle\Client\ContextNormalizer:
         arguments:
             - '@serializer'
+
+    Enhavo\Bundle\TranslationBundle\Router\TranslationRouteStrategy:
+        public: true
+        arguments:
+            - '@router'
+            - '@Enhavo\Bundle\TranslationBundle\Translation\TranslationManager'
+            - '@enhavo_translation.translation.access_control'
+            - '@enhavo_framework.locale_resolver'
+        tags:
+            - { name: 'enhavo_route.strategy', alias: 'translation_route' }
+
+    Enhavo\Bundle\TranslationBundle\Normalizer\TranslationNormalizer:
+        arguments:
+            - '@enhavo_translation.translation.access_control'
+            - '@Enhavo\Component\Metadata\MetadataRepository[Translation]'
+            - '@enhavo_framework.locale_resolver'
+            - '@Enhavo\Bundle\TranslationBundle\Translation\TranslationManager'
+            - '%enhavo_translation.enable_serialization%'
+        tags:
+            - { name: serializer.normalizer }

--- a/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/translator.yaml
+++ b/src/Enhavo/Bundle/TranslationBundle/Resources/config/services/translator.yaml
@@ -18,6 +18,7 @@ services:
             - '@enhavo_translation.translation.access_control'
             - '@Enhavo\Component\Metadata\MetadataRepository[Translation]'
             - '@enhavo_framework.locale_resolver'
+            - '%enhavo_translation.enable_doctrine%'
         calls:
             - [setContainer, ['@service_container']]
         tags:

--- a/src/Enhavo/Bundle/TranslationBundle/Router/TranslationRouteStrategy.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Router/TranslationRouteStrategy.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the enhavo package.
+ *
+ * (c) WE ARE INDEED GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enhavo\Bundle\TranslationBundle\Router;
+
+use Enhavo\Bundle\FrameworkBundle\Locale\LocaleResolverInterface;
+use Enhavo\Bundle\RoutingBundle\Router\AbstractStrategy;
+use Enhavo\Bundle\TranslationBundle\EventListener\AccessControl;
+use Enhavo\Bundle\TranslationBundle\Translation\TranslationManager;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class TranslationRouteStrategy extends AbstractStrategy
+{
+    public function __construct(
+        private RouterInterface $router,
+        private TranslationManager $translationManager,
+        private AccessControl $accessControl,
+        private LocaleResolverInterface $localeResolver,
+    )
+    {
+    }
+
+    public function generate($resource, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH, $options = []): string
+    {
+        if (!$this->accessControl->isAccess()) {
+            return $this->router->generate($resource->getRoute()->getName(), $parameters, $referenceType);
+        }
+
+        $locale = $this->localeResolver->resolve();
+
+        $type = $this->translationManager->getTranslation($resource, 'route');
+        $value = $type->getTranslation($resource, 'route', $locale);
+
+        if ($value !== null) {
+            return $this->router->generate($value->getName(), $parameters, $referenceType);
+        }
+
+        return $this->router->generate($resource->getRoute()->getName(), $parameters, $referenceType);
+    }
+
+    public function getType()
+    {
+        return 'translation_route';
+    }
+}

--- a/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/DoctrineTranslationSubscriberTest.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Tests/EventListener/DoctrineTranslationSubscriberTest.php
@@ -48,6 +48,7 @@ class DoctrineTranslationSubscriberTest extends TestCase
             $dependencies->accessControl,
             $dependencies->metadataRepository,
             $dependencies->localeResolver,
+            true,
         );
 
         /** @var ContainerInterface|MockObject $container */

--- a/src/Enhavo/Bundle/TranslationBundle/Translation/TranslationManager.php
+++ b/src/Enhavo/Bundle/TranslationBundle/Translation/TranslationManager.php
@@ -236,7 +236,7 @@ class TranslationManager
     /**
      * @return Translation
      */
-    private function getTranslation($data, $propertyName)
+    public function getTranslation($data, $propertyName)
     {
         /** @var Metadata $metadata */
         $metadata = $this->metadataRepository->getMetadata($data);


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Add options `enable_doctrine` and `enable_serialization` to the TranslationBundle. On serialization, the translation data is injected instead of the original data. Unlike the Doctrine listener approach, entities are no longer filled with translation data, so the bugs that prevented restoring the original data on flush (and could wipe data entirely) should disappear.
