### PR TITLE
[AppBundle] 0.14: Fix drag/drop order not saving for child items in list view

### DIFF
--- a/assets/node_modules/@enhavo/app/list/components/ItemComponent.vue
+++ b/assets/node_modules/@enhavo/app/list/components/ItemComponent.vue
@@ -21,7 +21,7 @@
                 v-model="data.children"
                 group="list"
                 item-key="id"
-                v-on:change="save($event, null)"
+                v-on:change="save($event, data)"
                 @start="data.dragging = true"
                 @end="data.dragging = false"
                 :class="{'dragging':data.dragging == true}"

--- a/src/Enhavo/Bundle/PageBundle/Resources/config/doctrine/Page.orm.xml
+++ b/src/Enhavo/Bundle/PageBundle/Resources/config/doctrine/Page.orm.xml
@@ -8,7 +8,11 @@
             <join-column on-delete="SET NULL" />
         </many-to-one>
 
-        <one-to-many field="children" target-entity="Enhavo\Bundle\PageBundle\Model\PageInterface" mapped-by="parent" />
+        <one-to-many field="children" target-entity="Enhavo\Bundle\PageBundle\Model\PageInterface" mapped-by="parent">
+            <order-by>
+                <order-by-field name="position" direction="ASC" />
+            </order-by>
+        </one-to-many>
 
         <one-to-one field="content" target-entity="Enhavo\Bundle\BlockBundle\Model\NodeInterface">
             <cascade>


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| License      | MIT

- fix drag/drop order not saving for child items in list view
- fix Page children ignoring order
