### PR TITLE
fix: Add hasThread method to comment manager and check in article end…

### DIFF
--- a/src/Enhavo/Bundle/ArticleBundle/Endpoint/ArticleEndpointType.php
+++ b/src/Enhavo/Bundle/ArticleBundle/Endpoint/ArticleEndpointType.php
@@ -54,14 +54,17 @@ class ArticleEndpointType extends AbstractEndpointType
             throw $this->createNotFoundException();
         }
 
-        $commentContext = $this->commentManager->handleSubmitForm($request, $resource);
-        if ($commentContext->isInsert()) {
-            $context->setResponse(new RedirectResponse($request->getRequestUri()));
+        if ($this->commentManager->hasThread($resource)) {
+            $commentContext = $this->commentManager->handleSubmitForm($request, $resource);
+            if ($commentContext->isInsert()) {
+                $context->setResponse(new RedirectResponse($request->getRequestUri()));
+            }
+
+            $data->set('commentForm', $this->normalize($commentContext->getForm(), null, ['groups' => ['endpoint']]));
         }
 
         $context->set('resource', $resource);
         $data->set('resource', $this->normalize($resource, null, ['groups' => ['endpoint']]));
-        $data->set('commentForm', $this->normalize($commentContext->getForm(), null, ['groups' => ['endpoint']]));
         $data->set('structuredData', $this->structuredDataManager->getData($resource, $options['structured_data_groups']));
     }
 

--- a/src/Enhavo/Bundle/CommentBundle/Comment/CommentManager.php
+++ b/src/Enhavo/Bundle/CommentBundle/Comment/CommentManager.php
@@ -75,7 +75,9 @@ class CommentManager
      */
     public function handleSubmitForm(Request $request, CommentSubjectInterface $subject): SubmitContext
     {
-        $this->checkThread($subject);
+        if ($this->hasThread($subject)) {
+            throw CommentSubjectException::createNoThreadException($subject);
+        }
         $form = $this->createSubmitForm();
         $form->handleRequest($request);
         $insert = false;
@@ -91,12 +93,10 @@ class CommentManager
         return new SubmitContext($form, $insert);
     }
 
-    private function checkThread(CommentSubjectInterface $subject)
+    public function hasThread(CommentSubjectInterface $subject): bool
     {
         $thread = $subject->getThread();
-        if (null === $thread) {
-            throw CommentSubjectException::createNoThreadException($subject);
-        }
+        return null !== $thread;
     }
 
     public function publishComment(CommentInterface $comment)


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| Backport     | 0.15
| License      | MIT

fix: Add hasThread method to comment manager and check in article endpoint
