### PR TITLE
fix: di get service queue

### DIFF
--- a/packages/dependency-injection/container/Container.js
+++ b/packages/dependency-injection/container/Container.js
@@ -11,18 +11,20 @@ export class Container
         /** @type {Array<Service>} */
         this._resolveStack = [];
         this._resolveCallStack = [];
-        this._pending = {};
+        this._queue = Promise.resolve();
     }
 
     async get(name) {
-        // sync concurrency calls on the same name to avoid returning unfinished services
-        if (this._pending[name]) {
-            return await this._pending[name];
+        // serialize all get calls so one fully completes before the next starts
+        let resolve;
+        const previous = this._queue;
+        this._queue = new Promise(r => resolve = r);
+        await previous;
+        try {
+            return await this._get(name);
+        } finally {
+            resolve();
         }
-        this._pending[name] = this._get(name).finally(() => {
-            delete this._pending[name];
-        });
-        return await this._pending[name];
     }
 
     async _get(name) {

--- a/packages/dependency-injection/container/Container.js
+++ b/packages/dependency-injection/container/Container.js
@@ -15,7 +15,7 @@ export class Container
     }
 
     async get(name) {
-        // serialize all get calls so one fully completes before the next starts
+        // sync concurrency get calls to avoid returning unfinished services
         let resolve;
         const previous = this._queue;
         this._queue = new Promise(r => resolve = r);


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Sync all concurrency get calls on di container and not only on the same name to avoid returning unfinished services. If service A and B have a dependency C and A and B is calling at the same time, then C might be unfinished because it was created but never initialized.