### PR TITLE
feat: jquery global plugin

### DIFF
--- a/packages/app/vite/jquery-global-plugin.js
+++ b/packages/app/vite/jquery-global-plugin.js
@@ -1,0 +1,12 @@
+export function jqueryGlobalPlugin(libs) {
+    return {
+        name: 'global-jquery',
+        transform(code, id) {
+            for (const lib of libs) {
+                if (id.includes(lib)) {
+                    return `import ___jq from 'jquery'; if(typeof window !== 'undefined') { window.jQuery = window.jQuery || ___jq; }\n${code}`;
+                }
+            }
+        }
+    }
+}

--- a/packages/form/services/admin/components.yaml
+++ b/packages/form/services/admin/components.yaml
@@ -1,0 +1,12 @@
+services:
+    '@enhavo/form/components/FormICheckCheckbox.vue':
+        static: true
+        chunk: 'form'
+        tags:
+            - { name: vue.component, component: 'form-icheck-checkbox' }
+
+    '@enhavo/form/components/FormICheckRadio.vue':
+        static: true
+        chunk: 'form'
+        tags:
+            - { name: vue.component, component: 'form-icheck-radio' }

--- a/packages/form/services/components.yaml
+++ b/packages/form/services/components.yaml
@@ -143,18 +143,6 @@ services:
         tags:
             - { name: vue.component, component: 'form-choice-tree-row' }
 
-    '@enhavo/form/components/FormICheckCheckbox.vue':
-        static: true
-        chunk: 'form'
-        tags:
-            - { name: vue.component, component: 'form-icheck-checkbox' }
-
-    '@enhavo/form/components/FormICheckRadio.vue':
-        static: true
-        chunk: 'form'
-        tags:
-            - { name: vue.component, component: 'form-icheck-radio' }
-
     '@enhavo/form/components/FormAutoComplete.vue':
         static: true
         chunk: 'form'

--- a/playground/app/assets/theme/vite.config.js
+++ b/playground/app/assets/theme/vite.config.js
@@ -4,6 +4,7 @@ import liveReload from 'vite-plugin-live-reload'
 import path from 'node:path'
 import 'dotenv/config'
 import containerDIPlugin from '@enhavo/app/vite/rollup-plugin-container-di'
+import {jqueryGlobalPlugin} from '@enhavo/app/vite/jquery-global-plugin.js'
 
 export default defineConfig({
     optimizeDeps: {
@@ -13,9 +14,11 @@ export default defineConfig({
             'jquery',
             'select2',
             'axios',
+            'icheck',
         ],
     },
     plugins: [
+        jqueryGlobalPlugin(['icheck', 'select2']),
         vue(),
         liveReload([
             __dirname + '/../../src/**/*.php',


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

* feat: add jquery-global-plugin for vite, to make sure, jquery was loaded from global var
* fix: icheck forms not loaded in theme by default
