### PR TITLE
[CommentBundle] Fix error in CommentBundle CommentManager when testing if the su…

### DIFF
--- a/src/Enhavo/Bundle/CommentBundle/Comment/CommentManager.php
+++ b/src/Enhavo/Bundle/CommentBundle/Comment/CommentManager.php
@@ -75,7 +75,7 @@ class CommentManager
      */
     public function handleSubmitForm(Request $request, CommentSubjectInterface $subject): SubmitContext
     {
-        if ($this->hasThread($subject)) {
+        if (!$this->hasThread($subject)) {
             throw CommentSubjectException::createNoThreadException($subject);
         }
         $form = $this->createSubmitForm();


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

Fix error in CommentBundle CommentManager when testing if the subject has a thread
