### PR TITLE
feat: parameter loader compiler pass

### DIFF
--- a/packages/app/compiler-pass/parameter-loader.js
+++ b/packages/app/compiler-pass/parameter-loader.js
@@ -1,0 +1,42 @@
+import fs from "fs"
+import path from "path"
+import YAML from "yaml"
+
+/**
+ * @param {ContainerBuilder} builder
+ * @param {object} options
+ * @param {string} options.file - Path to the parameter file. Supports .yaml, .yml and .json
+ * @param {string} [options.parameter] - Parameter name. If not set, the entire file content is stored as parameters.
+ * @param {string} context
+ */
+export default function(builder, options, context)
+{
+    let file = options.file;
+    if (!file) {
+        throw 'Option "file" is required for parameter-loader compiler pass';
+    }
+
+    let filepath = file.startsWith('/') ? file : path.resolve(context, file);
+
+    if (!fs.existsSync(filepath)) {
+        throw 'Parameter file "' + filepath + '" does not exist';
+    }
+
+    let content = fs.readFileSync(filepath, 'utf8');
+    let extension = path.extname(filepath);
+    let data;
+
+    if (extension === '.yaml' || extension === '.yml') {
+        data = YAML.parse(content);
+    } else if (extension === '.json') {
+        data = JSON.parse(content);
+    } else {
+        throw 'Unsupported file format "' + extension + '" for parameter-loader. Use .yaml, .yml or .json';
+    }
+
+    if (typeof options.parameter === 'string') {
+        builder.setParameter(options.parameter, data);
+    } else if (data && typeof data === 'object') {
+        builder.addParameters(data);
+    }
+};

--- a/packages/app/view/DataLoader.ts
+++ b/packages/app/view/DataLoader.ts
@@ -5,7 +5,7 @@ export default class DataLoader
     private readonly id: string;
     private readonly parameter: string;
     private loaded: boolean = false;
-    private container: Container = false;
+    private container: Container = null;
 
     constructor(id: string, parameter: string, container: Container)
     {

--- a/packages/app/vite/rollup-plugin-container-di.js
+++ b/packages/app/vite/rollup-plugin-container-di.js
@@ -8,6 +8,7 @@ const defaults = {
     transform: null,
     extensions: ['.di.yaml'],
     enableChunks: true,
+    parameters: {},
     manualChunks: function (id, { getModuleInfo }) {
         return null
     }
@@ -29,6 +30,7 @@ export default async function (opts = {}) {
 
             // load and compile container
             if (!builder.isPrepared()) {
+                builder.addParameters(options.parameters);
                 let loader = new Loader();
                 loader.loadFile(id, builder)
 

--- a/packages/dependency-injection/compiler/Compiler.js
+++ b/packages/dependency-injection/compiler/Compiler.js
@@ -17,6 +17,7 @@ export default class Compiler
         content += this._generateServiceFunctions(builder) + `\n`;
         content += `}\n\n`;
         content += `let container = new CompiledContainer;\n`;
+        content += this._generateSetParameters(builder) + `\n`;
         content += `export default container;\n\n`;
 
         return content;
@@ -198,6 +199,19 @@ export default class Compiler
         }
 
         content += `}\n`;
+        return content;
+    }
+
+    /**
+     * @param {ContainerBuilder} builder
+     * @returns {string}
+     * @private
+     */
+    _generateSetParameters(builder) {
+        let content = '';
+        for (let parameterName of builder.getParameterKeys()) {
+            content += `container.setParameter("`+parameterName+`", JSON.parse('`+JSON.stringify(builder.getParameter(parameterName))+`'));\n`
+        }
         return content;
     }
 }

--- a/packages/dependency-injection/container/Container.js
+++ b/packages/dependency-injection/container/Container.js
@@ -184,6 +184,10 @@ export class Container
     getParameter(key) {
         return this._parameters.get(key);
     }
+
+    hasParameter(key) {
+        return this._parameters.has(key);
+    }
 }
 
 class Service

--- a/packages/dependency-injection/container/ContainerBuilder.js
+++ b/packages/dependency-injection/container/ContainerBuilder.js
@@ -12,6 +12,8 @@ export default class ContainerBuilder
         this.definitions = new Map();
         /** @type {Map<CompilerPass>} */
         this.compilerPasses = new Map();
+        /** @type {Map<Object|String|Number>} */
+        this.parameters = new Map();
 
         this.files = [];
     }
@@ -126,10 +128,39 @@ export default class ContainerBuilder
         this._prepared = true;
     }
 
+    addParameters(parameters) {
+        if (this._prepared) {
+            throw 'Can\'t add parameter to prepared builder';
+        }
+        for (let key in parameters) {
+            this.setParameter(key, parameters[key]);
+        }
+    }
+
+    setParameter(key, value) {
+        if (this._prepared) {
+            throw 'Can\'t add parameter to prepared builder';
+        }
+        this.parameters.add(key, value);
+    }
+
+    getParameterKeys() {
+        return this.parameters.getKeys();
+    }
+
+    getParameter(key) {
+        return this.parameters.get(key);
+    }
+
+    hasParameter(key) {
+        return this.parameters.has(key);
+    }
+
     reset() {
         this._prepared = false;
         this.definitions = new Map();
         this.compilerPasses = new Map();
+        this.parameters = new Map();
         this.files = [];
     }
 

--- a/packages/dependency-injection/container/ParameterBag.js
+++ b/packages/dependency-injection/container/ParameterBag.js
@@ -38,4 +38,21 @@ export default class ParameterBag
         }
         return temp;
     }
+
+    has(key)
+    {
+        if (typeof key !== "string") {
+            throw "Key should be a string"
+        }
+
+        let parts = key.split(".");
+        let temp = this._data;
+        for (let part of parts) {
+            if (!temp[part]) {
+                return false;
+            }
+            temp = temp[part];
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | no
| New feature? | yes
| BC-Break?    | no
| Backport     | 0.15
| License      | MIT

* Add parameters loader compiler pass to load parameter from json and yaml file
* Add parameters option in containerDI vite plugin, to pass parameters directly into container
* Add setters and getters to DI Builder and update the compiler to pass the parameters into the container
