### PR TITLE
[TranslationBundle] fix: do not lock options resolver to specific version

### DIFF
--- a/src/Enhavo/Bundle/TranslationBundle/composer.json
+++ b/src/Enhavo/Bundle/TranslationBundle/composer.json
@@ -19,8 +19,7 @@
     "enhavo/media-bundle": "^0.16",
     "enhavo/metadata": "^0.16",
     "enhavo/routing-bundle": "^0.16",
-    "league/uri-components": "^2.4",
-    "symfony/options-resolver": "^7.4"
+    "league/uri-components": "^2.4"
   },
   "autoload": {
     "psr-4": { "Enhavo\\Bundle\\TranslationBundle\\": "" }


### PR DESCRIPTION
| Q            | A
|--------------| ---
| Bug fix?     | yes
| New feature? | no
| BC-Break?    | no
| Backport     | 0.15
| Tickets      | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License      | MIT

Not able to install newest translation bundle in a local project without having to set a specific options resolver in local composer.json. 
Change the requirement according to the other packages:  do not demand specific version
